### PR TITLE
chore(contracts): sync partial repayment support from invofi-contracts

### DIFF
--- a/invofi/apps/contracts/lib.rs
+++ b/invofi/apps/contracts/lib.rs
@@ -69,6 +69,8 @@ pub struct FinancingOffer {
     pub status: OfferStatus,
     /// Unix timestamp when the offer was accepted; 0 if not yet accepted
     pub funded_at: u64,
+    /// Running total of repayments made against the financing obligation
+    pub amount_repaid: i128,
 }
 
 #[contracttype]
@@ -78,8 +80,9 @@ pub enum OfferStatus {
     Pending   = 0,
     Accepted  = 1,
     Rejected  = 2,
-    Repaid    = 3,
-    Defaulted = 4,
+    Financed  = 3,
+    Repaid    = 4,
+    Defaulted = 5,
 }
 
 // ─── Storage helpers ─────────────────────────────────────────────────────────
@@ -293,6 +296,7 @@ impl InvoiceRegistryContract {
             duration,
             status: OfferStatus::Pending,
             funded_at: 0,
+            amount_repaid: 0,
         };
         offers.set(offer_id, offer.clone());
         save_offers(&env, &offers);
@@ -392,13 +396,15 @@ impl InvoiceRegistryContract {
         offer
     }
 
-    /// Mark an invoice as repaid. Only the invoice originator (debtor) can call this.
-    /// Sets the invoice to Repaid and the linked offer to Repaid.
+    /// Mark part or all of an invoice as repaid. Only the invoice originator
+    /// (debtor) can call this. Partial payments keep the invoice/offer in
+    /// Financed status until the outstanding balance is fully cleared.
     pub fn repay_invoice(
         env: Env,
         invoice_id: Symbol,
         offer_id: Symbol,
         repayer: Address,
+        amount: i128,
     ) -> Invoice {
         repayer.require_auth();
 
@@ -422,9 +428,10 @@ impl InvoiceRegistryContract {
         if offer.invoice_id != invoice_id {
             panic!("Offer does not belong to this invoice");
         }
-        if offer.status != OfferStatus::Accepted {
-            panic!("Offer must be Accepted before repayment");
+        if offer.status != OfferStatus::Accepted && offer.status != OfferStatus::Financed {
+            panic!("Offer must be Accepted or Financed before repayment");
         }
+        assert!(amount > 0, "repayment amount must be greater than zero");
 
         // Repay principal + yield directly to the lender. `repayer` already
         // authorized this call above, so a direct transfer (not
@@ -436,14 +443,26 @@ impl InvoiceRegistryContract {
             .unwrap_or_else(|| panic!("Not initialized"));
         let token_client = token::TokenClient::new(&env, &token_id);
         let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
-        let repay_amount = offer.amount + yield_amount;
-        token_client.transfer(&repayer, &offer.lender, &repay_amount);
+        let total_due = offer.amount + yield_amount;
+        let remaining_balance = total_due - offer.amount_repaid;
+        assert!(
+            amount <= remaining_balance,
+            "Repayment amount exceeds remaining balance"
+        );
+        token_client.transfer(&repayer, &offer.lender, &amount);
 
-        invoice.status = InvoiceStatus::Repaid;
+        offer.amount_repaid += amount;
+        if offer.amount_repaid >= total_due {
+            invoice.status = InvoiceStatus::Repaid;
+            offer.status = OfferStatus::Repaid;
+        } else {
+            invoice.status = InvoiceStatus::Financed;
+            offer.status = OfferStatus::Financed;
+        }
+
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
 
-        offer.status = OfferStatus::Repaid;
         offers.set(offer_id, offer);
         save_offers(&env, &offers);
 
@@ -482,8 +501,8 @@ impl InvoiceRegistryContract {
         if offer.lender != lender {
             panic!("Only the financing lender can reclaim");
         }
-        if offer.status != OfferStatus::Accepted {
-            panic!("Offer must be Accepted before reclaim");
+        if offer.status != OfferStatus::Accepted && offer.status != OfferStatus::Financed {
+            panic!("Offer must be Accepted or Financed before reclaim");
         }
 
         offer.status = OfferStatus::Defaulted;

--- a/invofi/apps/contracts/test.rs
+++ b/invofi/apps/contracts/test.rs
@@ -250,7 +250,7 @@ fn test_reject_offer() {
 }
 
 #[test]
-fn test_repay_invoice() {
+fn test_repay_invoice_partial_then_full() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(InvoiceRegistryContract, ());
@@ -263,6 +263,8 @@ fn test_repay_invoice() {
     let offer_id = symbol_short!("off004");
     let amount: i128 = 1_000_000_000;
     let interest_rate: u32 = 500; // 5.00%
+    let yield_amount = amount * (interest_rate as i128) / 10_000;
+    let total_due = amount + yield_amount;
 
     let token_id = setup_token(&env, &contract_id, &lender, amount);
     client.initialize(&admin, &token_id);
@@ -285,21 +287,75 @@ fn test_repay_invoice() {
     );
     client.accept_offer(&offer_id, &originator);
 
-    // Business needs principal + yield on hand to repay — mint them the
-    // yield portion (they already hold the principal from acceptance).
-    let yield_amount = amount * (interest_rate as i128) / 10_000;
     let asset_client = token::StellarAssetClient::new(&env, &token_id);
-    asset_client.mint(&originator, &yield_amount);
+    asset_client.mint(&originator, &total_due);
 
-    let repaid = client.repay_invoice(&invoice_id, &offer_id, &originator);
-    assert_eq!(repaid.status, InvoiceStatus::Repaid);
+    let partial_amount = amount / 2;
+    let repaid = client.repay_invoice(&invoice_id, &offer_id, &originator, &partial_amount);
+    assert_eq!(repaid.status, InvoiceStatus::Financed);
 
     let offer = client.get_offer(&offer_id);
-    assert_eq!(offer.status, OfferStatus::Repaid);
+    assert_eq!(offer.status, OfferStatus::Financed);
+    assert_eq!(offer.amount_repaid, partial_amount);
 
     let token_client = token::TokenClient::new(&env, &token_id);
-    assert_eq!(token_client.balance(&lender), amount + yield_amount);
-    assert_eq!(token_client.balance(&originator), 0);
+    assert_eq!(token_client.balance(&lender), partial_amount);
+    assert_eq!(token_client.balance(&originator), amount + total_due - partial_amount);
+
+    let final_amount = total_due - partial_amount;
+    let repaid_final = client.repay_invoice(&invoice_id, &offer_id, &originator, &final_amount);
+    assert_eq!(repaid_final.status, InvoiceStatus::Repaid);
+
+    let settled_offer = client.get_offer(&offer_id);
+    assert_eq!(settled_offer.status, OfferStatus::Repaid);
+    assert_eq!(settled_offer.amount_repaid, total_due);
+    assert_eq!(token_client.balance(&lender), total_due);
+    assert_eq!(token_client.balance(&originator), amount);
+}
+
+#[test]
+#[should_panic(expected = "Repayment amount exceeds remaining balance")]
+fn test_repay_invoice_overpayment_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv010");
+    let offer_id = symbol_short!("off008");
+    let amount: i128 = 1_000_000_000;
+    let interest_rate: u32 = 500;
+    let yield_amount = amount * (interest_rate as i128) / 10_000;
+    let total_due = amount + yield_amount;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &interest_rate,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    let asset_client = token::StellarAssetClient::new(&env, &token_id);
+    asset_client.mint(&originator, &total_due);
+
+    client.repay_invoice(&invoice_id, &offer_id, &originator, &(total_due + 1));
 }
 
 #[test]
@@ -407,7 +463,7 @@ fn test_repay_unfinanced_invoice_panics() {
         &(2_592_000u64),
     );
     // Note: offer NOT accepted — invoice stays Pending
-    client.repay_invoice(&invoice_id, &offer_id, &originator);
+    client.repay_invoice(&invoice_id, &offer_id, &originator, &1);
 }
 
 #[test]


### PR DESCRIPTION
Syncs contracts/lib.rs and contracts/test.rs from the invofi-contracts split repo master (PR #20 — feat/partial-repayment-support by hexlaapp).

**What changed:**
-  gains  field
-  now supports partial payments — offer stays  until balance fully cleared
- Validation: repayment amount > 0 and <= remaining balance
- Additional test cases covering partial and full repayment paths