### PR TITLE
feat(frontend): Freighter wallet — install detection, network mismatch warning, click-to-copy, dark mode polish

### DIFF
--- a/invofi/apps/frontend/src/components/auth/WalletButton.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Loader2, Wallet, LogOut } from 'lucide-react';
+import { useState } from 'react';
+import { Loader2, Wallet, LogOut, Copy, Check, AlertTriangle, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useWallet } from './WalletProvider';
 import { formatAddress } from '@/lib/utils';
@@ -11,10 +12,20 @@ interface WalletButtonProps {
 }
 
 export function WalletButton({ onConnected }: WalletButtonProps) {
-  const { publicKey, isConnected, isConnecting, connect, disconnect } = useWallet();
+  const {
+    publicKey, isConnected, isConnecting,
+    isInstalled, networkMismatch,
+    isCheckingWallet,
+    connect, disconnect,
+  } = useWallet();
   const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
 
   const handleConnect = async () => {
+    if (!isInstalled) {
+      window.open('https://freighter.app', '_blank', 'noreferrer noopener');
+      return;
+    }
     try {
       await connect();
       if (onConnected && publicKey) onConnected(publicKey);
@@ -22,34 +33,88 @@ export function WalletButton({ onConnected }: WalletButtonProps) {
       toast({
         title: 'Wallet connection failed',
         description:
-          err instanceof Error
-            ? err.message
-            : 'Make sure the Freighter extension is installed.',
+          err instanceof Error ? err.message : 'Make sure the Freighter extension is installed.',
         variant: 'destructive',
       });
     }
   };
 
+  const handleCopy = async () => {
+    if (!publicKey) return;
+    try {
+      await navigator.clipboard.writeText(publicKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard not available (e.g. HTTP context)
+    }
+  };
+
+  // Connected state
   if (isConnected && publicKey) {
     return (
-      <div className="flex items-center gap-2">
-        <div className="flex items-center gap-2 bg-green-50 border border-green-200 rounded-lg px-3 py-1.5 text-sm">
-          <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-          <span className="font-mono text-green-800">{formatAddress(publicKey)}</span>
+      <div className="flex flex-col items-end gap-1">
+        {networkMismatch && (
+          <div className="flex items-center gap-1.5 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md px-2.5 py-1">
+            <AlertTriangle className="h-3 w-3 shrink-0" />
+            Switch Freighter to {process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet'}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleCopy}
+            title={copied ? 'Copied!' : 'Click to copy full address'}
+            className="flex items-center gap-2 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg px-3 py-1.5 text-sm transition-colors hover:bg-green-100 dark:hover:bg-green-900"
+          >
+            <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+            <span className="font-mono text-green-800 dark:text-green-200">
+              {formatAddress(publicKey)}
+            </span>
+            {copied
+              ? <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+              : <Copy className="h-3.5 w-3.5 text-green-500 dark:text-green-500 opacity-60" />
+            }
+          </button>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={disconnect}
+            title="Disconnect wallet"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <LogOut className="h-4 w-4" />
+          </Button>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={disconnect}
-          className="text-gray-400 hover:text-gray-600"
-          title="Disconnect wallet"
-        >
-          <LogOut className="h-4 w-4" />
-        </Button>
       </div>
     );
   }
 
+  // Still detecting whether Freighter is installed
+  if (isCheckingWallet) {
+    return (
+      <Button variant="outline" disabled className="gap-2 opacity-60">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Wallet
+      </Button>
+    );
+  }
+
+  // Freighter not installed
+  if (!isInstalled) {
+    return (
+      <Button
+        onClick={handleConnect}
+        variant="outline"
+        className="gap-2 border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
+      >
+        <ExternalLink className="h-4 w-4" />
+        Get Freighter
+      </Button>
+    );
+  }
+
+  // Freighter installed, not yet connected
   return (
     <Button onClick={handleConnect} disabled={isConnecting} variant="outline" className="gap-2">
       {isConnecting ? (
@@ -57,7 +122,7 @@ export function WalletButton({ onConnected }: WalletButtonProps) {
       ) : (
         <Wallet className="h-4 w-4" />
       )}
-      {isConnecting ? 'Connecting…' : 'Connect Freighter'}
+      {isConnecting ? 'Connecting...' : 'Connect Freighter'}
     </Button>
   );
 }

--- a/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState, useCallback } from 'rea
 import {
   isFreighterInstalled,
   getFreighterPublicKey,
+  getFreighterNetwork,
   connectFreighter,
 } from '@/lib/freighter';
 import type { WalletState } from '@/types';
@@ -11,39 +12,75 @@ import type { WalletState } from '@/types';
 interface WalletContextValue extends WalletState {
   connect: () => Promise<void>;
   disconnect: () => void;
+  isCheckingWallet: boolean;
 }
 
 const WalletContext = createContext<WalletContextValue>({
   publicKey: null,
   isConnected: false,
   isConnecting: false,
+  isInstalled: false,
+  networkMismatch: false,
+  isCheckingWallet: true,
   connect: async () => {},
   disconnect: () => {},
 });
 
+const EXPECTED_NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet').toLowerCase();
+
+function networkMismatchFor(freighterNet: string | null): boolean {
+  if (!freighterNet) return false;
+  const normalized = freighterNet.toLowerCase() === 'public' ? 'mainnet' : freighterNet.toLowerCase();
+  return normalized !== EXPECTED_NETWORK;
+}
+
 export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [isCheckingWallet, setIsCheckingWallet] = useState(true);
   const [state, setState] = useState<WalletState>({
     publicKey: null,
     isConnected: false,
     isConnecting: false,
+    isInstalled: false,
+    networkMismatch: false,
   });
 
-  // Restore session on mount
   useEffect(() => {
-    isFreighterInstalled().then(async installed => {
-      if (!installed) return;
+    (async () => {
+      const installed = await isFreighterInstalled();
+      if (!installed) {
+        setState(s => ({ ...s, isInstalled: false }));
+        setIsCheckingWallet(false);
+        return;
+      }
       const key = await getFreighterPublicKey();
       if (key) {
-        setState({ publicKey: key, isConnected: true, isConnecting: false });
+        const net = await getFreighterNetwork();
+        setState({
+          publicKey: key,
+          isConnected: true,
+          isConnecting: false,
+          isInstalled: true,
+          networkMismatch: networkMismatchFor(net),
+        });
+      } else {
+        setState(s => ({ ...s, isInstalled: true }));
       }
-    });
+      setIsCheckingWallet(false);
+    })();
   }, []);
 
   const connect = useCallback(async () => {
     setState(s => ({ ...s, isConnecting: true }));
     try {
       const key = await connectFreighter();
-      setState({ publicKey: key, isConnected: true, isConnecting: false });
+      const net = await getFreighterNetwork();
+      setState({
+        publicKey: key,
+        isConnected: true,
+        isConnecting: false,
+        isInstalled: true,
+        networkMismatch: networkMismatchFor(net),
+      });
     } catch {
       setState(s => ({ ...s, isConnecting: false }));
       throw new Error('Failed to connect wallet. Make sure Freighter is installed.');
@@ -51,11 +88,17 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const disconnect = useCallback(() => {
-    setState({ publicKey: null, isConnected: false, isConnecting: false });
+    setState(s => ({
+      ...s,
+      publicKey: null,
+      isConnected: false,
+      isConnecting: false,
+      networkMismatch: false,
+    }));
   }, []);
 
   return (
-    <WalletContext.Provider value={{ ...state, connect, disconnect }}>
+    <WalletContext.Provider value={{ ...state, connect, disconnect, isCheckingWallet }}>
       {children}
     </WalletContext.Provider>
   );

--- a/invofi/apps/frontend/src/lib/freighter.ts
+++ b/invofi/apps/frontend/src/lib/freighter.ts
@@ -2,6 +2,7 @@ import {
   isConnected,
   isAllowed,
   getAddress,
+  getNetwork,
   signTransaction,
   requestAccess,
 } from '@stellar/freighter-api';
@@ -40,6 +41,16 @@ export async function getFreighterPublicKey(): Promise<string | null> {
     const result = await getAddress();
     if (result.error) return null;
     return result.address;
+  } catch {
+    return null;
+  }
+}
+
+export async function getFreighterNetwork(): Promise<string | null> {
+  try {
+    const result = await getNetwork();
+    if ('error' in result && result.error) return null;
+    return (result as { network: string }).network ?? null;
   } catch {
     return null;
   }

--- a/invofi/apps/frontend/src/types/index.ts
+++ b/invofi/apps/frontend/src/types/index.ts
@@ -37,4 +37,6 @@ export interface WalletState {
   publicKey: string | null;
   isConnected: boolean;
   isConnecting: boolean;
+  isInstalled: boolean;
+  networkMismatch: boolean;
 }


### PR DESCRIPTION
Improves the Freighter wallet integration across three dimensions:

**W-01 Install detection**
- `WalletProvider` checks `isFreighterInstalled()` on mount before anything else
- Exposes `isInstalled` and `isCheckingWallet` via context
- `WalletButton` shows a spinner while checking, then renders "Get Freighter" (amber, opens freighter.app) when not installed

**W-02 Network mismatch warning**
- `freighter.ts` gains `getFreighterNetwork()` wrapping the v6 `getNetwork()` call
- After connect/restore, compares Freighter's active network to `NEXT_PUBLIC_STELLAR_NETWORK`
- `WalletButton` renders a compact amber warning stripe when networks differ

**W-03 WalletButton polish**
- Connected address pill is now clickable — copies full public key to clipboard, shows a checkmark for 2 s
- Dark mode: address pill now uses `dark:bg-green-950 dark:border-green-800 dark:text-green-200`
- Disconnect icon uses `text-muted-foreground` for theme-aware contrast
- `WalletState` type gains `isInstalled` and `networkMismatch` fields