### PR TITLE
feat(frontend): SEO — per-page metadata via segment layouts, robots.ts, sitemap.ts

### DIFF
--- a/invofi/apps/frontend/src/app/auth/login/layout.tsx
+++ b/invofi/apps/frontend/src/app/auth/login/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Log In',
+  description: 'Sign in to InvoFi with your email or Stellar wallet.',
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/auth/register/layout.tsx
+++ b/invofi/apps/frontend/src/app/auth/register/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Create Account',
+  description: 'Join InvoFi — the decentralized invoice financing marketplace on Stellar. Choose your role as a business or lender.',
+};
+
+export default function RegisterLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/dashboard/layout.tsx
+++ b/invofi/apps/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Dashboard',
+  description: 'Manage your registered invoices, track financing offers, and monitor repayment status.',
+};
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/invoices/[id]/layout.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+type Props = { params: { id: string } };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  return {
+    title: `Invoice ${params.id}`,
+    description: `View details, financing offers, and repayment history for invoice ${params.id} on InvoFi.`,
+  };
+}
+
+export default function InvoiceDetailLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/invoices/new/layout.tsx
+++ b/invofi/apps/frontend/src/app/invoices/new/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Register Invoice',
+  description: 'Tokenize a new invoice as a Soroban on-chain asset and list it for financing on the InvoFi marketplace.',
+};
+
+export default function NewInvoiceLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/layout.tsx
+++ b/invofi/apps/frontend/src/app/layout.tsx
@@ -10,7 +10,10 @@ const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://invofi-five.vercel.app'),
-  title: 'InvoFi — Decentralized Invoice Financing on Stellar',
+  title: {
+    template: '%s — InvoFi',
+    default: 'InvoFi — Decentralized Invoice Financing on Stellar',
+  },
   description:
     'Tokenize invoices as on-chain assets and get immediate financing from investors — powered by Stellar Soroban.',
   keywords: ['invoice financing', 'DeFi', 'Stellar', 'Soroban', 'blockchain'],

--- a/invofi/apps/frontend/src/app/marketplace/layout.tsx
+++ b/invofi/apps/frontend/src/app/marketplace/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Marketplace',
+  description: 'Browse open invoices and submit financing offers. Earn yield by funding real-world receivables on Stellar.',
+  openGraph: {
+    title: 'InvoFi Marketplace — Finance Real Invoices on Stellar',
+    description: 'Browse open invoices and submit financing offers. Earn yield by funding real-world receivables on Stellar.',
+  },
+};
+
+export default function MarketplaceLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/portfolio/layout.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Portfolio',
+  description: 'Track your active investments, earned yield, and repayment history across all financed invoices.',
+};
+
+export default function PortfolioLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/profile/layout.tsx
+++ b/invofi/apps/frontend/src/app/profile/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Profile',
+  description: 'Manage your display name, view your linked Stellar wallet address, and update your InvoFi profile.',
+};
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/robots.ts
+++ b/invofi/apps/frontend/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/marketplace'],
+      disallow: ['/dashboard/', '/invoices/', '/portfolio/', '/profile/', '/settings/', '/auth/'],
+    },
+    sitemap: 'https://invofi-five.vercel.app/sitemap.xml',
+  };
+}

--- a/invofi/apps/frontend/src/app/settings/layout.tsx
+++ b/invofi/apps/frontend/src/app/settings/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Settings',
+  description: 'Manage your InvoFi account settings, email preferences, and security options.',
+};
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/invofi/apps/frontend/src/app/sitemap.ts
+++ b/invofi/apps/frontend/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+const BASE = 'https://invofi-five.vercel.app';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    { url: BASE,                      lastModified: now, changeFrequency: 'weekly',  priority: 1.0 },
+    { url: `${BASE}/marketplace`,     lastModified: now, changeFrequency: 'hourly',  priority: 0.9 },
+    { url: `${BASE}/auth/register`,   lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE}/auth/login`,      lastModified: now, changeFrequency: 'monthly', priority: 0.5 },
+  ];
+}


### PR DESCRIPTION
Adds comprehensive SEO infrastructure using Next.js 14 App Router conventions:

**S-01 Per-page metadata**
- Root `layout.tsx` gains `title.template: '%s — InvoFi'` so child pages only need to set a short title
- 9 new `layout.tsx` files (one per route segment) export `metadata` as Server Components, keeping all existing client page files unchanged
- Dynamic `/invoices/[id]` segment uses `generateMetadata({ params })` to set `Invoice <id>` as the browser title
- Marketplace layout adds explicit `openGraph` override for better social sharing

**S-02 robots.ts + sitemap.ts**
- `robots.ts`: allows crawlers on `/` and `/marketplace`; disallows all auth and app routes
- `sitemap.ts`: includes `/`, `/marketplace` (hourly), `/auth/register` and `/auth/login` (monthly) with proper priorities; authenticated routes are excluded