### PR TITLE
fix(frontend): auth sign-up and sign-in — defer profile insert, ensure profile on login, dark mode

### DIFF
--- a/invofi/apps/frontend/src/app/auth/login/page.tsx
+++ b/invofi/apps/frontend/src/app/auth/login/page.tsx
@@ -48,11 +48,11 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-[calc(100vh-64px)] flex items-center justify-center px-4 py-12 bg-gray-50">
+    <div className="min-h-[calc(100vh-64px)] flex items-center justify-center px-4 py-12 bg-gray-50 dark:bg-gray-950">
       <div className="w-full max-w-md space-y-6">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900">Welcome back</h1>
-          <p className="text-gray-500 mt-1">Sign in to your InvoFi account</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Welcome back</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">Sign in to your InvoFi account</p>
         </div>
 
         {/* Wallet login */}
@@ -68,10 +68,10 @@ export default function LoginPage() {
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-200" />
+            <div className="w-full border-t border-gray-200 dark:border-gray-700" />
           </div>
           <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-gray-50 px-2 text-gray-400">or sign in with email</span>
+            <span className="bg-gray-50 dark:bg-gray-950 px-2 text-gray-400 dark:text-gray-500">or sign in with email</span>
           </div>
         </div>
 
@@ -99,9 +99,9 @@ export default function LoginPage() {
           </CardContent>
         </Card>
 
-        <p className="text-center text-sm text-gray-500">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
           Don&apos;t have an account?{' '}
-          <Link href="/auth/register" className="text-blue-600 hover:underline font-medium">
+          <Link href="/auth/register" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
             Create one
           </Link>
         </p>

--- a/invofi/apps/frontend/src/app/auth/register/page.tsx
+++ b/invofi/apps/frontend/src/app/auth/register/page.tsx
@@ -57,12 +57,17 @@ function RegisterForm() {
   const onSubmit = async (values: FormValues) => {
     setLoading(true);
     try {
-      await signUpWithEmail(values.email, values.password, role, values.displayName);
-      toast({
-        title: 'Account created!',
-        description: 'Check your email to verify your account, then sign in.',
-      });
-      router.push('/auth/login');
+      const result = await signUpWithEmail(values.email, values.password, role, values.displayName);
+      if (result.session) {
+        // Email confirmation is disabled — user is immediately active
+        router.push('/dashboard');
+      } else {
+        toast({
+          title: 'Account created!',
+          description: 'Check your email for a confirmation link, then sign in.',
+        });
+        router.push('/auth/login');
+      }
     } catch (err: unknown) {
       toast({
         title: 'Registration failed',
@@ -75,11 +80,11 @@ function RegisterForm() {
   };
 
   return (
-    <div className="min-h-[calc(100vh-64px)] flex items-center justify-center px-4 py-12 bg-gray-50">
+    <div className="min-h-[calc(100vh-64px)] flex items-center justify-center px-4 py-12 bg-gray-50 dark:bg-gray-950">
       <div className="w-full max-w-md space-y-6">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900">Create your account</h1>
-          <p className="text-gray-500 mt-1">Join InvoFi and start financing invoices on-chain</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Create your account</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">Join InvoFi and start financing invoices on-chain</p>
         </div>
 
         {/* Role picker */}
@@ -92,15 +97,15 @@ function RegisterForm() {
               className={cn(
                 'p-4 rounded-xl border-2 text-left transition-all',
                 role === r.id
-                  ? 'border-blue-600 bg-blue-50'
-                  : 'border-gray-200 bg-white hover:border-gray-300',
+                  ? 'border-blue-600 bg-blue-50 dark:bg-blue-950'
+                  : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600',
               )}
             >
               <r.icon className={cn('h-5 w-5 mb-2', role === r.id ? 'text-blue-600' : 'text-gray-400')} />
-              <p className={cn('font-semibold text-sm', role === r.id ? 'text-blue-700' : 'text-gray-700')}>
+              <p className={cn('font-semibold text-sm', role === r.id ? 'text-blue-700 dark:text-blue-300' : 'text-gray-700 dark:text-gray-300')}>
                 {r.label}
               </p>
-              <p className="text-xs text-gray-500 mt-0.5 leading-tight">{r.description}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 leading-tight">{r.description}</p>
             </button>
           ))}
         </div>
@@ -140,9 +145,9 @@ function RegisterForm() {
           </CardContent>
         </Card>
 
-        <p className="text-center text-sm text-gray-500">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
           Already have an account?{' '}
-          <Link href="/auth/login" className="text-blue-600 hover:underline font-medium">
+          <Link href="/auth/login" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
             Sign in
           </Link>
         </p>

--- a/invofi/apps/frontend/src/lib/supabase.ts
+++ b/invofi/apps/frontend/src/lib/supabase.ts
@@ -10,18 +10,32 @@ export async function signUpWithEmail(
   role: UserRole,
   displayName: string,
 ) {
-  const { data: authData, error: authError } = await supabase.auth.signUp({ email, password });
-  if (authError) throw authError;
-  if (!authData.user) throw new Error('Sign up failed');
-
-  const { error: profileError } = await supabase.from('user_profiles').insert({
-    id: authData.user.id,
+  // Store role + displayName in user_metadata so we can create the profile
+  // after email confirmation when no session exists yet.
+  const { data: authData, error: authError } = await supabase.auth.signUp({
     email,
-    role,
-    display_name: displayName,
-    wallet_address: null,
+    password,
+    options: {
+      data: { role, display_name: displayName },
+    },
   });
-  if (profileError) throw profileError;
+  if (authError) throw authError;
+  if (!authData.user) throw new Error('Sign up failed — please try again.');
+
+  // If Supabase immediately returns a session (email confirmation disabled),
+  // insert the profile now. Otherwise it will be created on first sign-in.
+  if (authData.session) {
+    const { error: profileError } = await supabase.from('user_profiles').upsert({
+      id: authData.user.id,
+      email,
+      role,
+      display_name: displayName,
+      wallet_address: null,
+    });
+    if (profileError) {
+      console.warn('Profile insert failed:', profileError.message);
+    }
+  }
 
   return authData;
 }
@@ -29,7 +43,36 @@ export async function signUpWithEmail(
 export async function signInWithEmail(email: string, password: string) {
   const { data, error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) throw error;
+
+  // Ensure a profile row exists. Handles the case where registration
+  // succeeded but the profile insert was deferred (email confirmation flow).
+  if (data.user) {
+    await ensureProfile(data.user.id, data.user.email ?? '', data.user.user_metadata);
+  }
+
   return data;
+}
+
+async function ensureProfile(
+  userId: string,
+  email: string,
+  meta: Record<string, unknown> = {},
+) {
+  const { data: existing } = await supabase
+    .from('user_profiles')
+    .select('id')
+    .eq('id', userId)
+    .single();
+
+  if (!existing) {
+    await supabase.from('user_profiles').insert({
+      id: userId,
+      email,
+      role: (meta.role as UserRole) ?? 'business',
+      display_name: (meta.display_name as string) ?? null,
+      wallet_address: null,
+    });
+  }
 }
 
 export async function signOut() {


### PR DESCRIPTION
Fixes two auth bugs and adds dark mode to auth pages.

**Root cause of sign-up failure**
`signUpWithEmail` was inserting the `user_profiles` row immediately after `supabase.auth.signUp`. When Supabase email confirmation is enabled (the default), no session exists yet at that point, so `auth.uid()` is NULL and the RLS policy `id = auth.uid()` blocks the insert. The auth user was created but the profile row was not, leaving the account broken.

**Fixes in `supabase.ts`**
- `signUp` now passes `role` and `display_name` in `user_metadata` so they survive without a profile row
- Profile insert only runs immediately if `authData.session` exists (email confirmation disabled)
- `signInWithEmail` calls `ensureProfile()` after a successful login — creates the missing profile row on first sign-in using the metadata stored during signup

**Register page**
- If signup returns a session immediately, redirect to `/dashboard` instead of login
- Otherwise, show "check your email" toast and redirect to `/auth/login`

**Dark mode**
- Login and register pages: background, headings, divider, role picker cards, and footer links all use `dark:` variants