### PR TITLE
fix(frontend): accept NEXT_PUBLIC_SUPABASE_ANON_KEY alongside PUBLISHABLE_KEY — fixes Failed to fetch on auth

### DIFF
--- a/invofi/apps/frontend/.env.local.example
+++ b/invofi/apps/frontend/.env.local.example
@@ -1,11 +1,14 @@
 # ── Supabase ─────────────────────────────────────────────────────────────────
 # Project dashboard: https://supabase.com/dashboard/project/ukhxnrlcqmyncjoericr
 NEXT_PUBLIC_SUPABASE_URL=https://ukhxnrlcqmyncjoericr.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<your-publishable-key-from-supabase-dashboard>
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key-from-supabase-dashboard>
+
+# Your Supabase API key — use whichever name your dashboard shows.
+# Older dashboard: Settings → API → "anon / public" key
+# Newer dashboard: Settings → API → "Publishable" key
+# Both are the same key; the app accepts either variable name.
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-or-publishable-key>
 
 # ── Stellar / Soroban ─────────────────────────────────────────────────────────
-# Fill in after: stellar contract deploy ...
 NEXT_PUBLIC_CONTRACT_ID=<output-from-stellar-contract-deploy>
 
 NEXT_PUBLIC_STELLAR_NETWORK=testnet

--- a/invofi/apps/frontend/src/utils/supabase/client.ts
+++ b/invofi/apps/frontend/src/utils/supabase/client.ts
@@ -1,8 +1,11 @@
 import { createBrowserClient } from '@supabase/ssr';
 
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-  );
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  // Supabase renamed "anon key" to "publishable key" in late 2024.
+  // Accept either env var name so both old and new deployments work.
+  const key =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!;
+  return createBrowserClient(url, key);
 }

--- a/invofi/apps/frontend/src/utils/supabase/middleware.ts
+++ b/invofi/apps/frontend/src/utils/supabase/middleware.ts
@@ -8,7 +8,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)!,
     {
       cookies: {
         getAll() {

--- a/invofi/apps/frontend/src/utils/supabase/server.ts
+++ b/invofi/apps/frontend/src/utils/supabase/server.ts
@@ -8,7 +8,7 @@ export async function createClient() {
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)!,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Root cause

All three Supabase utility files (`client.ts`, `server.ts`, `middleware.ts`) read `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` for the API key. Supabase renamed the "anon key" to "publishable key" in late 2024, but most existing deployments (and the Vercel config set up following the README) only have `NEXT_PUBLIC_SUPABASE_ANON_KEY` set.

When the key env var is missing, `createBrowserClient` initialises with `undefined` as the key. The Authorization header then reads `Bearer undefined`. Supabase rejects this before returning CORS headers, so the browser reports it as **`TypeError: Failed to fetch`** rather than a 401 — which is why the error looked like a network problem.

## Fix

All three utility files now resolve the key as:
```ts
process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
```
Whichever variable is set in the deployment will be used. Both are the same key — just different names.

`.env.local.example` is also updated to explain the naming difference and consolidate to `NEXT_PUBLIC_SUPABASE_ANON_KEY`.