### PR TITLE
fixes: #136 added 403 page

### DIFF
--- a/docs/04-frontend.md
+++ b/docs/04-frontend.md
@@ -97,6 +97,10 @@ Lender's investment tracker.
   and added with a one-click "Add POS trustline" button (changeTrust signed by
   the connected wallet)
 
+### Forbidden — `/403`
+
+Branded 403 Forbidden error page styled identically to the custom 404 page. Rendered or redirected to whenever a user attempts to access an unauthorized resource or another user's invoice.
+
 ---
 
 ## Component Reference
@@ -121,7 +125,7 @@ Renders a "Connect Freighter" button when disconnected, or an address chip + dis
 
 ### `components/auth/AuthGuard.tsx`
 
-Wraps authenticated pages. Checks Supabase session on mount and redirects to `/auth/login` if no session exists.
+Wraps authenticated pages. Checks Supabase session/wallet on mount and redirects to `/auth/login` if no session exists. Supports resource-level protection via `isUnauthorized` prop, redirecting to `/403` when unauthorized access is detected.
 
 ### `components/invoices/InvoiceCard.tsx`
 

--- a/docs/05-authentication.md
+++ b/docs/05-authentication.md
@@ -98,7 +98,7 @@ export default function DashboardPage() {
 }
 ```
 
-`AuthGuard` checks `supabase.auth.getUser()` on mount. If no session exists, it redirects to `/auth/login`. While checking, it renders a centered loading spinner.
+`AuthGuard` checks `supabase.auth.getUser()` and wallet connection state on mount. If no session or wallet exists, it redirects to `/auth/login`. While checking, it renders a centered loading spinner. It also accepts an optional `isUnauthorized` prop for resource-level guards to redirect unauthorized access attempts to `/403`.
 
 ---
 

--- a/invofi/apps/frontend/src/app/403/page.tsx
+++ b/invofi/apps/frontend/src/app/403/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function Forbidden() {
+  return (
+    <div className="min-h-[calc(100vh-64px)] flex flex-col items-center justify-center text-center px-4">
+      <p className="text-6xl font-bold text-blue-600 mb-4">403</p>
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Access forbidden</h1>
+      <p className="text-gray-500 mb-8 max-w-sm">
+        You don&rsquo;t have permission to access this resource.
+      </p>
+      <Button asChild>
+        <Link href="/">Back to home</Link>
+      </Button>
+    </div>
+  );
+}

--- a/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
@@ -26,6 +26,7 @@ export default function InvoiceDetailPage() {
   const [cancelling, setCancelling] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isUnauthorized, setIsUnauthorized] = useState(false);
 
   const handleCancel = async () => {
     if (!invoice || !publicKey) return;
@@ -51,12 +52,19 @@ export default function InvoiceDetailPage() {
     setLoading(true);
     getInvoice(id)
       .then(setInvoice)
-      .catch(e => setError(e instanceof Error ? e.message : 'Invoice not found'))
+      .catch(e => {
+        const errMsg = e instanceof Error ? e.message : String(e);
+        if (/403|unauthorized|forbidden|not authorized|access denied/i.test(errMsg)) {
+          setIsUnauthorized(true);
+        } else {
+          setError(errMsg || 'Invoice not found');
+        }
+      })
       .finally(() => setLoading(false));
   }, [id]);
 
   return (
-    <AuthGuard>
+    <AuthGuard isUnauthorized={isUnauthorized}>
       <div className="max-w-3xl mx-auto px-4 py-8">
         <Link
           href="/dashboard"

--- a/invofi/apps/frontend/src/components/auth/AuthGuard.tsx
+++ b/invofi/apps/frontend/src/components/auth/AuthGuard.tsx
@@ -6,7 +6,12 @@ import { Loader2 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { useWallet } from '@/components/auth/WalletProvider';
 
-export function AuthGuard({ children }: { children: React.ReactNode }) {
+interface AuthGuardProps {
+  children: React.ReactNode;
+  isUnauthorized?: boolean;
+}
+
+export function AuthGuard({ children, isUnauthorized }: AuthGuardProps) {
   const router = useRouter();
   const { isConnected, isCheckingWallet } = useWallet();
   const [sessionReady, setSessionReady] = useState(false);
@@ -19,6 +24,12 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     });
   }, [router]);
 
+  useEffect(() => {
+    if (sessionReady && !isCheckingWallet && isUnauthorized) {
+      router.push('/403');
+    }
+  }, [sessionReady, isCheckingWallet, isUnauthorized, router]);
+
   // Wait for both the Supabase check AND the wallet init to finish.
   if (!sessionReady || isCheckingWallet) {
     return (
@@ -26,6 +37,10 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
       </div>
     );
+  }
+
+  if (isUnauthorized) {
+    return null;
   }
 
   // Accept either a Supabase session OR a connected wallet as valid auth.


### PR DESCRIPTION
# Pull Request

## Summary

<!-- One or two sentences describing what this PR does and why. -->
- I added a 403 page, it will be shown when the AuthGuard knows if the user is unauthorized 
- Now we have a clean screen which shows 
- Then updated the documentation listing the new changes. 

## Related issue

Closes #136 

## Type of change

- [ ] Bug fix
- [ x ] New feature
- [ ] Refactor (no functional changes)
- [ X ] Documentation update
- [ ] Test addition
- [ ] Dependency update

## Changes made

<!-- Bullet list of specific changes. Be precise. -->

-Created custom branded 403 Forbidden page at `src/app/403/page.tsx` matching the existing 404 (`not-found.tsx`) page layout and styling.
-Updated `AuthGuard` component (`src/components/auth/AuthGuard.tsx`) to accept an `isUnauthorized` prop and automatically redirect users to `/403` when resource access is denied.
- Updated invoice detail page (`src/app/invoices/[id]/page.tsx`) to catch `403`/unauthorized errors from data fetches and trigger the `AuthGuard` 403 view instead of falling back to a generic error screen.

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes (if contracts changed)
- [ X ] `npm run type-check` passes (if frontend changed)
- [ X ] `npm run lint` passes (if frontend changed)
- [ ] Manually tested on Stellar testnet (for contract changes)
- [ ] Manually tested in browser with Freighter wallet (for frontend changes)

## Screenshots (if UI changed)

<!-- Paste before/after screenshots here, or delete this section. -->
Before:
<img width="1909" height="939" alt="image" src="https://github.com/user-attachments/assets/9555fcdb-4e46-4d50-bc74-58a3c7f7abd4" />

After:
<img width="1783" height="939" alt="image" src="https://github.com/user-attachments/assets/6fcbcd20-8b1f-40de-bd29-812fbdc4d565" />


## Checklist

- [ X ] My branch is up to date with `main`
- [ X ] I followed the commit message format in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ X ] I added tests for new behavior
- [ X ] I updated the relevant documentation
- [ X ] I have not introduced any hardcoded secrets or keys
