### PR TITLE
test(e2e): Playwright smoke suite for the core user lifecycle

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,87 @@
+name: e2e
+
+# InvoFi end-to-end suite (issue #171).
+#
+# Two jobs, both opt-in — this workflow is NOT wired into every PR:
+#   smoke    — Playwright smoke suite for the core user lifecycle (frontend).
+#              Runs against the live testnet contracts; stubs Supabase and the
+#              on-chain invoice read with fixtures, so it needs no secrets.
+#   onchain  — scripted register → offer → accept flow against testnet using
+#              two seeded identities (invofi/scripts/e2e-onchain.ts).
+#
+# Required repo configuration (for the onchain job only):
+#   Secrets: E2E_ORIGINATOR_SECRET_KEY, E2E_LENDER_SECRET_KEY
+#            (two funded Stellar testnet secret keys — see CONTRIBUTING.md#testing).
+#   Variables: REGISTRY_CONTRACT_ID, FINANCING_CONTRACT_ID,
+#              REPAYMENT_CONTRACT_ID (defaults point at the live testnet
+#              deployment below).
+
+on:
+  schedule:
+    # Weekly on Sunday at 00:30 UTC (offset from the keeper/indexer sweeps).
+    - cron: '30 0 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: E2E / Playwright smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: invofi/apps/frontend
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: invofi/apps/frontend/package-lock.json
+      - run: npm ci
+      - name: Install Playwright Chromium + system deps
+        run: npx playwright install --with-deps chromium
+      - name: Run smoke tests
+        run: npm run test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: invofi/apps/frontend/playwright-report
+          retention-days: 14
+
+  onchain:
+    name: E2E / On-chain flow
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: invofi/scripts
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          # Node 22+ required: @stellar/stellar-sdk@16.2+ declares engines
+          # node >=22.
+          node-version: 22
+          cache: npm
+          cache-dependency-path: invofi/scripts/package-lock.json
+      - run: npm ci
+      # e2e-onchain.ts imports the SDK source (../apps/sdk/src), whose runtime
+      # dependency (@stellar/stellar-sdk) resolves from the SDK's own
+      # node_modules — install it explicitly.
+      - name: Install SDK deps
+        working-directory: invofi/apps/sdk
+        run: npm ci
+      - run: npm run type-check
+      - name: Run on-chain flow
+        env:
+          RPC_URL: https://soroban-testnet.stellar.org
+          NETWORK_PASSPHRASE: Test SDF Network ; September 2015
+          REGISTRY_CONTRACT_ID: ${{ vars.REGISTRY_CONTRACT_ID || 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7' }}
+          FINANCING_CONTRACT_ID: ${{ vars.FINANCING_CONTRACT_ID || 'CBGRA3457ZFXYZNEQLO4YGUQ3OBEWOE6US6ZREHK6NF2DLZYBO73IFVW' }}
+          REPAYMENT_CONTRACT_ID: ${{ vars.REPAYMENT_CONTRACT_ID || 'CCDATW5GMVDOPK55Q4MLXV5SGA3VLXPD67ABLBNMHWFF6BLL2IZBUVEP' }}
+          E2E_ORIGINATOR_SECRET_KEY: ${{ secrets.E2E_ORIGINATOR_SECRET_KEY }}
+          E2E_LENDER_SECRET_KEY: ${{ secrets.E2E_LENDER_SECRET_KEY }}
+        run: npm run e2e:onchain

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ build/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# ── Playwright ──────────────────────────────────────────────────────────────
+test-results/
+playwright-report/
+blob-report/
+.playwright/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,47 @@ cd invofi/apps/frontend
 npm run type-check
 ```
 
-There is no frontend unit test suite yet. If you add one, use Vitest.
+### Frontend end-to-end (Playwright)
+
+The frontend has a Playwright smoke suite for the core user lifecycle (landing
+→ login/register, wallet-connect dialog, marketplace, invoice detail, print
+view):
+
+```bash
+cd invofi/apps/frontend
+npm run test:e2e
+```
+
+It runs against the live Stellar testnet contracts and stubs Supabase + the
+on-chain invoice read with fixtures, so no Supabase credentials are needed.
+There is no unit test suite yet — if you add one, use Vitest.
+
+### Scripted on-chain flow
+
+A scripted `register → offer → accept` flow runs against testnet with two
+seeded identities:
+
+```bash
+cd invofi/scripts
+E2E_ORIGINATOR_SECRET_KEY=… E2E_LENDER_SECRET_KEY=… npm run e2e:onchain
+```
+
+| Variable | Role |
+| --- | --- |
+| `E2E_ORIGINATOR_SECRET_KEY` | Business — registers the invoice and accepts the offer |
+| `E2E_LENDER_SECRET_KEY` | Lender — creates the offer, approves XLM, holds the position token |
+
+Both identities are auto-funded via Friendbot on testnet if missing, and the
+script asserts the invoice reaches `Financed` and the offer reaches `Accepted`.
+To create a fresh identity (a funded Stellar testnet secret key):
+
+```bash
+cd invofi/scripts
+node -e "console.log(require('@stellar/stellar-sdk').Keypair.random().secret())"
+```
+
+Never commit these secret keys — pass them as environment variables or GitHub
+Actions secrets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,39 @@ create policy "Own profile" on user_profiles for all using (id = auth.uid());
 
 ---
 
+## Testing
+
+### Frontend end-to-end (Playwright)
+
+The frontend ships a Playwright smoke suite that exercises the core user
+lifecycle — landing → login/register, the wallet-connect dialog, the
+marketplace, and the invoice detail + print views — against the live Stellar
+testnet contracts (issue #171):
+
+```bash
+cd invofi/apps/frontend
+npm run test:e2e
+```
+
+Supabase and the on-chain invoice read are stubbed with fixtures, so the suite
+needs no Supabase credentials. It also runs in CI on demand — see
+`.github/workflows/e2e.yml`.
+
+### Scripted on-chain flow
+
+A scripted `register → offer → accept` flow exercises the contract wiring
+against testnet with two seeded identities:
+
+```bash
+cd invofi/scripts
+E2E_ORIGINATOR_SECRET_KEY=… E2E_LENDER_SECRET_KEY=… npm run e2e:onchain
+```
+
+Both identities are auto-funded via Friendbot on testnet. See
+[CONTRIBUTING.md](./CONTRIBUTING.md#testing) for how to create them.
+
+---
+
 ## Roadmap
 
 - [x] Core invoice registry contract (register, offer, accept, reject, repay, overdue, reclaim)

--- a/invofi/apps/frontend/e2e/auth.spec.ts
+++ b/invofi/apps/frontend/e2e/auth.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('authentication pages', () => {
+  test('login renders wallet and email sign-in', async ({ page }) => {
+    await page.goto('/auth/login');
+
+    await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Connect Wallet' })).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+  });
+
+  test('register renders the role picker and form', async ({ page }) => {
+    await page.goto('/auth/register');
+
+    await expect(
+      page.getByRole('heading', { name: 'Create your account' }),
+    ).toBeVisible();
+    await expect(page.getByText('Business', { exact: true })).toBeVisible();
+    await expect(page.getByText('Lender / Investor', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Full name / Company name')).toBeVisible();
+    await expect(page.getByLabel('Confirm password')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Create Account as Business' }),
+    ).toBeVisible();
+  });
+
+  test('register preselects the lender role from the query param', async ({ page }) => {
+    await page.goto('/auth/register?role=lender');
+
+    await expect(
+      page.getByRole('button', { name: 'Create Account as Lender' }),
+    ).toBeVisible();
+  });
+});

--- a/invofi/apps/frontend/e2e/fixtures.ts
+++ b/invofi/apps/frontend/e2e/fixtures.ts
@@ -1,0 +1,236 @@
+import { type Page } from '@playwright/test';
+import { nativeToScVal, SorobanDataBuilder } from '@stellar/stellar-sdk';
+
+/**
+ * Shared fixtures for the InvoFi e2e smoke suite.
+ *
+ * The app has two external dependencies — Supabase (auth + the invoice/offer
+ * mirror) and the Soroban RPC (on-chain reads). The smoke tests stub both at
+ * the HTTP boundary so the suite is deterministic and needs no real Supabase
+ * credentials, while still running against the live testnet contracts for the
+ * account lookup the SDK performs before a simulated read.
+ */
+
+export const SUPABASE_URL = 'https://e2e.supabase.co';
+export const RPC_URL = 'https://soroban-testnet.stellar.org';
+
+/**
+ * The auth storage key @supabase/ssr derives for `SUPABASE_URL`:
+ * `sb-<first-hostname-label>-auth-token` → `sb-e2e-auth-token`.
+ */
+const AUTH_STORAGE_KEY = 'sb-e2e-auth-token';
+
+/** A real, funded Stellar testnet account used as the fixture originator. */
+export const ORIGINATOR = 'GCHVSUK5XKL44CSZ3WGI2W2OZCC7SXZMM5B34TCOQ2YNEGPNP3BLOVMT';
+
+/**
+ * Invoice status as the live Soroban contract actually serializes it — the
+ * u32 discriminant, NOT the string the Supabase mirror stores. Verified
+ * against testnet: `status` decodes to 0..4.
+ */
+export const InvoiceStatus = {
+  Pending: 0,
+  Financed: 1,
+  Repaid: 2,
+  Overdue: 3,
+  Cancelled: 4,
+} as const;
+
+/** Shape of an invoice as returned by the on-chain `get_invoice` read. */
+export interface OnChainInvoice {
+  id: string;
+  originator: string;
+  /** i128 stroops */
+  amount: bigint;
+  currency: 'XLM' | 'USDC';
+  /** u64 unix seconds */
+  due_date: bigint;
+  status: number;
+}
+
+/** Shape of an invoice as stored in the Supabase mirror. */
+export interface MirrorInvoice {
+  id: string;
+  originator: string;
+  /** Human-unit decimal string, e.g. "10000.00" (mirror convention). */
+  amount: string;
+  currency: 'XLM' | 'USDC';
+  /** ISO timestamp string (mirror convention). */
+  due_date: string;
+  status: 'Pending' | 'Financed' | 'Overdue' | 'Repaid' | 'Cancelled' | 'Defaulted';
+  created_at: string;
+}
+
+export const SMOKE_INVOICE: OnChainInvoice = {
+  id: 'inv_smoke_demo',
+  originator: ORIGINATOR,
+  amount: 20_000_000n, // 2 XLM
+  currency: 'XLM',
+  due_date: 2_000_000_000n,
+  status: InvoiceStatus.Pending,
+};
+
+export const SMOKE_INVOICES: MirrorInvoice[] = [
+  {
+    id: 'inv_smoke_market_1',
+    originator: ORIGINATOR,
+    amount: '10000.00',
+    currency: 'XLM',
+    due_date: '2027-01-01T00:00:00.000Z',
+    status: 'Pending',
+    created_at: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    id: 'inv_smoke_market_2',
+    originator: ORIGINATOR,
+    amount: '2500000.00',
+    currency: 'USDC',
+    due_date: '2027-02-01T00:00:00.000Z',
+    status: 'Financed',
+    created_at: '2026-08-02T00:00:00.000Z',
+  },
+];
+
+/** A Supabase user the app sees for the authenticated smoke flows. */
+export const SMOKE_USER = {
+  id: '00000000-0000-4000-8000-0000000000e2',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'lender@e2e.test',
+  email_confirmed_at: '2026-08-01T00:00:00.000Z',
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: { role: 'lender', display_name: 'E2E Lender' },
+  created_at: '2026-08-01T00:00:00.000Z',
+  updated_at: '2026-08-01T00:00:00.000Z',
+};
+
+// ── Session seeding ─────────────────────────────────────────────────────────
+
+/**
+ * Encodes a Supabase session the way @supabase/ssr persists it: a cookie named
+ * `<storage-key>` whose value is `base64-` + base64url(JSON.stringify(session)).
+ */
+function encodeSessionCookie(session: object): string {
+  return `base64-${Buffer.from(JSON.stringify(session)).toString('base64url')}`;
+}
+
+/**
+ * Seeds a signed-in Supabase session and stubs the `/auth/v1/user` endpoint
+ * `getUser()` calls, so `AuthGuard` sees a valid session without any real
+ * Supabase project.
+ */
+export async function mockSupabaseAuth(page: Page): Promise<void> {
+  const session = {
+    access_token: 'e2e-dummy-access-token',
+    refresh_token: 'e2e-dummy-refresh-token',
+    token_type: 'bearer',
+    // Far enough in the future that auth-js never attempts a refresh mid-test.
+    expires_at: Math.floor(Date.now() / 1000) + 60 * 60,
+    expires_in: 3600,
+    user: SMOKE_USER,
+  };
+
+  await page.context().addCookies([
+    {
+      name: AUTH_STORAGE_KEY,
+      value: encodeSessionCookie(session),
+      url: 'http://localhost:3000',
+    },
+  ]);
+
+  await page.route('**/auth/v1/user', (route) =>
+    route.fulfill({ json: SMOKE_USER }),
+  );
+}
+
+// ── Supabase REST mirror mocks ───────────────────────────────────────────────
+
+/** Stubs the invoice / offer mirror reads the marketplace and detail pages use. */
+export async function mockSupabaseMirror(
+  page: Page,
+  data: { invoices?: MirrorInvoice[]; offers?: object[] } = {},
+): Promise<void> {
+  await page.route('**/rest/v1/invoices**', (route) =>
+    route.fulfill({ json: data.invoices ?? SMOKE_INVOICES }),
+  );
+  await page.route('**/rest/v1/financing_offers**', (route) =>
+    route.fulfill({ json: data.offers ?? [] }),
+  );
+}
+
+// ── Soroban RPC mock (on-chain invoice read) ────────────────────────────────
+
+/**
+ * Builds the ScVal for an invoice exactly as the live contract returns it
+ * (verified against testnet): a map of symbol-keyed fields with amount=i128,
+ * due_date=u64, status=u32.
+ */
+function invoiceScVal(invoice: OnChainInvoice) {
+  return nativeToScVal(
+    {
+      id: invoice.id,
+      originator: invoice.originator,
+      amount: invoice.amount,
+      currency: invoice.currency,
+      due_date: invoice.due_date,
+      status: invoice.status,
+    },
+    {
+      type: {
+        id: ['symbol', 'symbol'],
+        originator: ['symbol', 'address'],
+        amount: ['symbol', 'i128'],
+        currency: ['symbol', 'symbol'],
+        due_date: ['symbol', 'u64'],
+        status: ['symbol', 'u32'],
+      },
+    },
+  );
+}
+
+/**
+ * Stubs `simulateTransaction` responses for the Soroban RPC so `get_invoice`
+ * returns `invoice` deterministically. Other RPC calls (the account lookup the
+ * SDK does before a simulated read) fall through to real testnet.
+ */
+export async function mockInvoiceRead(page: Page, invoice: OnChainInvoice): Promise<void> {
+  await page.route(`**${RPC_URL}/**`, async (route) => {
+    let method: unknown;
+    try {
+      method = (route.request().postDataJSON() as { method?: unknown } | null)?.method;
+    } catch {
+      // Non-JSON RPC request — let it through to testnet.
+      return route.fallback();
+    }
+    if (method !== 'simulateTransaction') {
+      return route.fallback();
+    }
+
+    const result = {
+      transactionData: new SorobanDataBuilder().build().toXDR('base64'),
+      minResourceFee: '100',
+      results: [{ auth: [], xdr: invoiceScVal(invoice).toXDR('base64') }],
+      events: [],
+      latestLedger: 5_000_000,
+    };
+
+    return route.fulfill({
+      json: { jsonrpc: '2.0', id: 1, result },
+    });
+  });
+}
+
+/**
+ * One-call setup for the authenticated smoke flows: a signed-in Supabase
+ * session plus the mirror and (optionally) on-chain mocks.
+ */
+export async function authenticate(
+  page: Page,
+  options: { invoice?: OnChainInvoice; invoices?: MirrorInvoice[]; offers?: object[] } = {},
+): Promise<void> {
+  await mockSupabaseAuth(page);
+  await mockSupabaseMirror(page, options);
+  if (options.invoice) {
+    await mockInvoiceRead(page, options.invoice);
+  }
+}

--- a/invofi/apps/frontend/e2e/invoice-detail.spec.ts
+++ b/invofi/apps/frontend/e2e/invoice-detail.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { authenticate, SMOKE_INVOICE } from './fixtures';
+
+test.describe('invoice detail', () => {
+  test('renders the on-chain invoice fields and print CTA', async ({ page }) => {
+    await authenticate(page, { invoice: SMOKE_INVOICE });
+
+    await page.goto(`/invoices/${SMOKE_INVOICE.id}`);
+
+    await expect(page.getByText(SMOKE_INVOICE.id)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Invoice' })).toBeVisible();
+
+    // Field values: amount is i128 stroops formatted to "2 XLM". The
+    // originator is rendered truncated (e.g. "GCHV…OVMT").
+    await expect(page.getByText('2 XLM')).toBeVisible();
+    await expect(page.getByText('XLM', { exact: true }).first()).toBeVisible();
+    const truncated = `${SMOKE_INVOICE.originator.slice(0, 4)}…${SMOKE_INVOICE.originator.slice(-4)}`;
+    await expect(page.getByText(truncated)).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: /Print \/ Export PDF/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Financing Offers/ }),
+    ).toBeVisible();
+  });
+});

--- a/invofi/apps/frontend/e2e/landing.spec.ts
+++ b/invofi/apps/frontend/e2e/landing.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('landing page', () => {
+  test('renders the hero and links to register / marketplace', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(
+      page.getByRole('heading', { name: /Invoice Financing/ }),
+    ).toBeVisible();
+    await expect(page.getByText('On-Chain.', { exact: true })).toBeVisible();
+
+    await expect(
+      page.getByRole('link', { name: /Get Started/ }),
+    ).toHaveAttribute('href', '/auth/register');
+    await expect(
+      page.getByRole('link', { name: /Browse Marketplace/ }).first(),
+    ).toHaveAttribute('href', '/marketplace');
+  });
+});

--- a/invofi/apps/frontend/e2e/marketplace.spec.ts
+++ b/invofi/apps/frontend/e2e/marketplace.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { authenticate, SMOKE_INVOICES } from './fixtures';
+
+test.describe('marketplace', () => {
+  test('loads invoices for an authenticated lender', async ({ page }) => {
+    await authenticate(page, { invoices: SMOKE_INVOICES });
+
+    await page.goto('/marketplace');
+
+    await expect(
+      page.getByRole('heading', { name: 'Invoice Marketplace' }),
+    ).toBeVisible();
+
+    // Each mirrored invoice renders a card with its amount and a Make Offer CTA.
+    await expect(page.getByText(SMOKE_INVOICES[0].id)).toBeVisible();
+    await expect(page.getByText('10000 XLM')).toBeVisible();
+    await expect(page.getByText('2500000 USDC')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Make Offer/ })).toHaveCount(
+      SMOKE_INVOICES.length,
+    );
+  });
+});

--- a/invofi/apps/frontend/e2e/print-view.spec.ts
+++ b/invofi/apps/frontend/e2e/print-view.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { authenticate, SMOKE_INVOICE } from './fixtures';
+
+test.describe('print view', () => {
+  test('opens the printable invoice document', async ({ page }) => {
+    // The print view calls window.print() once data loads — stub it so the
+    // headless browser never attempts a real print dialog.
+    await page.addInitScript(() => {
+      window.print = () => undefined;
+    });
+
+    await authenticate(page, { invoice: SMOKE_INVOICE });
+
+    await page.goto(`/invoices/${SMOKE_INVOICE.id}/print`);
+
+    await expect(page.getByText('INVOICE', { exact: true }).first()).toBeVisible();
+    // The id appears in both the metadata grid and the footer.
+    await expect(page.getByText(SMOKE_INVOICE.id, { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('2 XLM', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText(SMOKE_INVOICE.originator).first()).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /Print \/ Save as PDF/ }),
+    ).toBeVisible();
+  });
+});

--- a/invofi/apps/frontend/e2e/wallet-dialog.spec.ts
+++ b/invofi/apps/frontend/e2e/wallet-dialog.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('wallet connect dialog', () => {
+  test('lists the approved Freighter and LOBSTR wallets', async ({ page }) => {
+    await page.goto('/auth/login');
+
+    // The navbar also renders a "Connect Wallet" button — target the login
+    // card's copy inside <main>.
+    await page
+      .getByRole('main')
+      .getByRole('button', { name: 'Connect Wallet' })
+      .click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('heading', { name: 'Connect Wallet' })).toBeVisible();
+    await expect(dialog.getByText('Freighter', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('LOBSTR', { exact: true })).toBeVisible();
+  });
+});

--- a/invofi/apps/frontend/package-lock.json
+++ b/invofi/apps/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.49.1",
         "@types/node": "^22.5.4",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
@@ -1324,6 +1325,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@preact/signals": {
@@ -14719,6 +14736,52 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/invofi/apps/frontend/package.json
+++ b/invofi/apps/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "14.2.35",
@@ -49,6 +50,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.26",
     "eslint": "^8.57.1",
-    "eslint-config-next": "14.2.35"
+    "eslint-config-next": "14.2.35",
+    "@playwright/test": "^1.49.1"
   }
 }

--- a/invofi/apps/frontend/playwright.config.ts
+++ b/invofi/apps/frontend/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E smoke suite for the InvoFi frontend (issue #171).
+ *
+ * The webServer boots `next dev` against the live Stellar testnet contracts and
+ * a placeholder Supabase URL. The placeholder Supabase base URL is intercepted
+ * by the tests (see e2e/fixtures.ts) so the suite is deterministic without any
+ * real Supabase credentials. On-chain reads for the invoice detail / print
+ * views are likewise stubbed at the Soroban RPC boundary with fixture data;
+ * the account lookup still hits real testnet.
+ *
+ * Local run:   npm run test:e2e
+ * CI run:      .github/workflows/e2e.yml (manual + scheduled)
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  // `next dev` compiles each route on first request, which can exceed the
+  // defaults on a cold start. Give tests and assertions room to wait for it.
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      // Placeholder Supabase base URL — all requests to it are intercepted in
+      // tests, so no real project or credentials are required. The subdomain
+      // ("e2e") determines the auth storage key (`sb-e2e-auth-token`) used by
+      // the session-seeding helper.
+      NEXT_PUBLIC_SUPABASE_URL: 'https://e2e.supabase.co',
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'placeholder-publishable-key',
+      // Live v0.3 contract set on Stellar testnet (matches README's Live Demo).
+      NEXT_PUBLIC_REGISTRY_CONTRACT_ID: 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7',
+      NEXT_PUBLIC_FINANCING_CONTRACT_ID: 'CBGRA3457ZFXYZNEQLO4YGUQ3OBEWOE6US6ZREHK6NF2DLZYBO73IFVW',
+      NEXT_PUBLIC_REPAYMENT_CONTRACT_ID: 'CCDATW5GMVDOPK55Q4MLXV5SGA3VLXPD67ABLBNMHWFF6BLL2IZBUVEP',
+      NEXT_PUBLIC_STELLAR_NETWORK: 'testnet',
+      NEXT_PUBLIC_RPC_URL: 'https://soroban-testnet.stellar.org',
+      NEXT_PUBLIC_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+    },
+  },
+});

--- a/invofi/scripts/e2e-onchain.ts
+++ b/invofi/scripts/e2e-onchain.ts
@@ -1,0 +1,384 @@
+#!/usr/bin/env tsx
+/**
+ * InvoFi on-chain e2e flow (issue #171)
+ * ====================================
+ * Exercises the core lifecycle — register_invoice → create_offer →
+ * accept_offer — against the live Stellar testnet contracts using two seeded
+ * identities. This is the single "scripted on-chain flow" from the issue: it
+ * catches contract-wiring regressions that pass unit checks but would still
+ * break the app.
+ *
+ * Why two identities: the financing contract rejects a lender that is the same
+ * account as the originator, so the business (originator) and the lender must
+ * be distinct funded keys.
+ *
+ * Why this script also does an XLM `approve` and a position-token trustline:
+ * `accept_offer` pulls the lender's principal via `transfer_from` (needs an
+ * allowance on the settlement token) and mints the lender's position token
+ * (needs a trustline to that token's underlying asset). The position-token
+ * asset is derived from the token contract's `name()` (`"CODE:ISSUER"`) so the
+ * script follows whatever the deployed financing contract actually points at,
+ * rather than trusting a hardcoded asset.
+ *
+ * Env vars:
+ *   E2E_ORIGINATOR_SECRET_KEY   secret key of the business identity (required)
+ *   E2E_LENDER_SECRET_KEY       secret key of the lender identity (required)
+ *   REGISTRY_CONTRACT_ID        registry contract (default: testnet v0.3)
+ *   FINANCING_CONTRACT_ID       financing contract (default: testnet v0.3)
+ *   REPAYMENT_CONTRACT_ID       repayment contract (default: testnet v0.3)
+ *   RPC_URL                     Soroban RPC (default: soroban-testnet)
+ *   HORIZON_URL                 Horizon (default: horizon-testnet)
+ *   NETWORK_PASSPHRASE          network passphrase (default: testnet)
+ *   E2E_AMOUNT_STROOPS          amount in stroops (default: 1 XLM)
+ *
+ * On testnet the two identities are auto-funded via Friendbot if missing.
+ */
+
+import {
+  Asset,
+  Contract,
+  Keypair,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+  rpc as SorobanRpc,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { createInvofiClient } from '../apps/sdk/src/index';
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+const RPC_URL = process.env.RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const HORIZON_URL = process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+const NETWORK_PASSPHRASE = process.env.NETWORK_PASSPHRASE ?? Networks.TESTNET;
+const REGISTRY_ID =
+  process.env.REGISTRY_CONTRACT_ID ??
+  'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7';
+const FINANCING_ID =
+  process.env.FINANCING_CONTRACT_ID ??
+  'CBGRA3457ZFXYZNEQLO4YGUQ3OBEWOE6US6ZREHK6NF2DLZYBO73IFVW';
+const REPAYMENT_ID =
+  process.env.REPAYMENT_CONTRACT_ID ??
+  'CCDATW5GMVDOPK55Q4MLXV5SGA3VLXPD67ABLBNMHWFF6BLL2IZBUVEP';
+const AMOUNT_STROOPS = BigInt(process.env.E2E_AMOUNT_STROOPS ?? 10_000_000n); // 1 XLM
+
+// Invoice/offer status discriminants — must match invofi-contracts.
+const INVOICE_STATUS = { Pending: 0, Financed: 1, Repaid: 2, Overdue: 3, Cancelled: 4 } as const;
+const OFFER_STATUS = { Pending: 0, Accepted: 1, Rejected: 2, Repaid: 3, Defaulted: 4 } as const;
+
+const INTEREST_RATE_BPS = 500; // 5.00%
+const DURATION_SECS = 30 * 86_400; // 30 days
+const FEE = '100';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function log(msg: string): void {
+  console.log(`[${new Date().toISOString()}] ${msg}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function encodeSymbol(value: string): xdr.ScVal {
+  return nativeToScVal(value, { type: 'symbol' });
+}
+
+function encodeAddress(value: string): xdr.ScVal {
+  return nativeToScVal(value, { type: 'address' });
+}
+
+function encodeI128(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: 'i128' });
+}
+
+function encodeU32(value: number): xdr.ScVal {
+  return nativeToScVal(value, { type: 'u32' });
+}
+
+/**
+ * Normalizes a status field to its numeric discriminant. The SDK types these
+ * as the mirror's string union, but the contract serializes them as u32.
+ */
+function statusOf(value: unknown): number {
+  if (typeof value === 'number') return value;
+  const n = Number.parseInt(String(value), 10);
+  return Number.isNaN(n) ? -1 : n;
+}
+
+function requireSecret(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required (a funded Stellar testnet secret key).`);
+  return value;
+}
+
+/** Fund a testnet account via Friendbot if it does not exist yet. */
+async function ensureAccount(rpcServer: SorobanRpc.Server, address: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await rpcServer.getAccount(address);
+      return;
+    } catch {
+      /* account missing — fund below */
+    }
+    if (NETWORK_PASSPHRASE !== Networks.TESTNET) {
+      throw new Error(`Account ${address} missing and network is not testnet — fund it manually.`);
+    }
+    const net = await rpcServer.getNetwork();
+    const friendbotUrl = net.friendbotUrl ?? 'https://friendbot.stellar.org';
+    log(`funding ${address.slice(0, 8)}… via friendbot`);
+    const res = await fetch(`${friendbotUrl}?addr=${address}`);
+    if (!res.ok && res.status !== 400) {
+      throw new Error(`Friendbot funding failed (${res.status}): ${await res.text()}`);
+    }
+    for (let i = 0; i < 10; i++) {
+      await sleep(1_000);
+      try {
+        await rpcServer.getAccount(address);
+        return;
+      } catch {
+        /* keep polling */
+      }
+    }
+  }
+  throw new Error(`Account ${address} could not be confirmed after funding`);
+}
+
+/** Read-only contract call via simulateTransaction (no signing). */
+async function readContract(
+  rpcServer: SorobanRpc.Server,
+  sourceAccount: string,
+  contractId: string,
+  method: string,
+  args: xdr.ScVal[],
+): Promise<unknown> {
+  const account = await rpcServer.getAccount(sourceAccount);
+  const tx = new TransactionBuilder(account, {
+    fee: FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(new Contract(contractId).call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const sim = await rpcServer.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Read ${method} failed: ${sim.error}`);
+  }
+  if (!SorobanRpc.Api.isSimulationSuccess(sim) || !sim.result) {
+    throw new Error(`Read ${method} returned no result`);
+  }
+  return scValToNative(sim.result.retval);
+}
+
+/** Sign-and-submit a single contract invocation and wait for confirmation. */
+async function invoke(
+  rpcServer: SorobanRpc.Server,
+  kp: Keypair,
+  contractId: string,
+  method: string,
+  args: xdr.ScVal[],
+): Promise<void> {
+  await ensureAccount(rpcServer, kp.publicKey());
+  const account = await rpcServer.getAccount(kp.publicKey());
+  let tx = new TransactionBuilder(account, {
+    fee: FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(new Contract(contractId).call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const sim = await rpcServer.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(sim)) {
+    throw new Error(`${method} simulation failed: ${sim.error}`);
+  }
+  tx = SorobanRpc.assembleTransaction(tx, sim).build();
+  tx.sign(kp);
+
+  const sent = await rpcServer.sendTransaction(tx);
+  if (sent.status === 'ERROR') {
+    throw new Error(`${method} failed: ${JSON.stringify(sent.errorResult)}`);
+  }
+  let result = await rpcServer.getTransaction(sent.hash);
+  for (let i = 0; i < 20 && result.status === 'NOT_FOUND'; i++) {
+    await sleep(1_000);
+    result = await rpcServer.getTransaction(sent.hash);
+  }
+  if (result.status !== 'SUCCESS') {
+    throw new Error(`${method} did not succeed: ${result.status}`);
+  }
+}
+
+/** Lender approves the financing contract to pull `amount` of the settlement token. */
+async function approveSettlementToken(
+  rpcServer: SorobanRpc.Server,
+  lender: Keypair,
+  tokenId: string,
+  spender: string,
+  amount: bigint,
+): Promise<void> {
+  const latest = (await rpcServer.getLatestLedger()).sequence;
+  const liveUntil = latest + 1_000_000; // ~1 week of ledgers; u32-safe on testnet
+  log(`approving ${spender.slice(0, 8)}… to spend ${amount} of ${tokenId.slice(0, 8)}…`);
+  await invoke(rpcServer, lender, tokenId, 'approve', [
+    encodeAddress(lender.publicKey()),
+    encodeAddress(spender),
+    encodeI128(amount),
+    encodeU32(liveUntil),
+  ]);
+}
+
+/** Poll the position token's balance read until the lender's trustline is visible to the RPC. */
+async function waitForTrustline(
+  rpcServer: SorobanRpc.Server,
+  lender: Keypair,
+  tokenId: string,
+): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    try {
+      await readContract(rpcServer, lender.publicKey(), tokenId, 'balance', [
+        encodeAddress(lender.publicKey()),
+      ]);
+      return;
+    } catch {
+      await sleep(1_000);
+    }
+  }
+  throw new Error('Position-token trustline did not become visible to the RPC in time.');
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const originator = Keypair.fromSecret(requireSecret('E2E_ORIGINATOR_SECRET_KEY'));
+  const lender = Keypair.fromSecret(requireSecret('E2E_LENDER_SECRET_KEY'));
+  if (originator.publicKey() === lender.publicKey()) {
+    throw new Error('The originator and lender identities must differ (the financing contract rejects self-lending).');
+  }
+
+  const rpcServer = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
+  await ensureAccount(rpcServer, originator.publicKey());
+  await ensureAccount(rpcServer, lender.publicKey());
+
+  // ── Discover the settlement + position tokens before building the clients ──
+  const settlementToken = (await readContract(
+    rpcServer,
+    originator.publicKey(),
+    FINANCING_ID,
+    'get_currency_token',
+    [encodeSymbol('XLM')],
+  )) as string;
+
+  const positionTokenId = (await readContract(
+    rpcServer,
+    originator.publicKey(),
+    FINANCING_ID,
+    'get_position_token',
+    [],
+  )) as string | null;
+  if (!positionTokenId) throw new Error('Financing contract returned no position token.');
+
+  const positionTokenName = (await readContract(
+    rpcServer,
+    originator.publicKey(),
+    positionTokenId,
+    'name',
+    [],
+  )) as string;
+  if (!positionTokenName.includes(':')) {
+    throw new Error(`Unexpected position-token name (expected "CODE:ISSUER"): ${positionTokenName}`);
+  }
+  const positionTokenAsset = positionTokenName; // e.g. "POSI:GBDD…"
+
+  const signWith = (kp: Keypair) => async (txXdr: string): Promise<string> => {
+    const tx = new Transaction(txXdr, NETWORK_PASSPHRASE);
+    tx.sign(kp);
+    return tx.toXDR();
+  };
+
+  const makeClient = (kp: Keypair) =>
+    createInvofiClient({
+      rpcUrl: RPC_URL,
+      horizonUrl: HORIZON_URL,
+      networkPassphrase: NETWORK_PASSPHRASE as typeof Networks.TESTNET | typeof Networks.PUBLIC,
+      registryId: REGISTRY_ID,
+      financingId: FINANCING_ID,
+      repaymentId: REPAYMENT_ID,
+      positionTokenAsset,
+      signTransaction: signWith(kp),
+    });
+
+  const originatorClient = makeClient(originator);
+  const lenderClient = makeClient(lender);
+
+  log(`originator   = ${originator.publicKey()}`);
+  log(`lender       = ${lender.publicKey()}`);
+  log(`registry     = ${REGISTRY_ID.slice(0, 8)}…`);
+  log(`settlement   = ${settlementToken.slice(0, 8)}…`);
+  log(`position     = ${positionTokenId.slice(0, 8)}… (${positionTokenAsset})`);
+
+  // ── The lifecycle ──────────────────────────────────────────────────────────
+  const invoiceId = `inv_e2e_${Date.now().toString(36)}`;
+  const offerId = `off_e2e_${Date.now().toString(36)}`;
+  const dueDate = Math.floor(Date.now() / 1000) + 30 * 86_400;
+
+  log(`register_invoice ${invoiceId}`);
+  await originatorClient.registerInvoice(
+    { id: invoiceId, amount: AMOUNT_STROOPS, currency: 'XLM', dueDate },
+    originator.publicKey(),
+  );
+
+  log(`create_offer ${offerId} → ${invoiceId}`);
+  await lenderClient.createOffer(
+    {
+      offerId,
+      invoiceId,
+      amount: AMOUNT_STROOPS,
+      currency: 'XLM',
+      interestRate: INTEREST_RATE_BPS,
+      duration: DURATION_SECS,
+    },
+    lender.publicKey(),
+  );
+
+  await approveSettlementToken(rpcServer, lender, settlementToken, FINANCING_ID, AMOUNT_STROOPS);
+
+  if (!(await lenderClient.hasPositionTrustline(lender.publicKey()))) {
+    log('adding position-token trustline');
+    await lenderClient.addPositionTrustline(lender.publicKey());
+    await waitForTrustline(rpcServer, lender, positionTokenId);
+  }
+
+  log(`accept_offer ${offerId}`);
+  await originatorClient.acceptOffer(offerId, originator.publicKey());
+
+  // ── Verify the resulting state ─────────────────────────────────────────────
+  const invoice = await originatorClient.getInvoice(invoiceId, originator.publicKey());
+  const offer = await originatorClient.getOffer(offerId, originator.publicKey());
+
+  // The SDK types `status` as the mirror's string union, but the contract
+  // actually serializes it as the u32 discriminant. Normalize defensively.
+  const invoiceStatus = statusOf(invoice.status);
+  const offerStatus = statusOf(offer.status);
+  if (invoiceStatus !== INVOICE_STATUS.Financed) {
+    throw new Error(`Expected invoice ${invoiceId} to be Financed (1), got ${invoiceStatus}`);
+  }
+  if (offerStatus !== OFFER_STATUS.Accepted) {
+    throw new Error(`Expected offer ${offerId} to be Accepted (1), got ${offerStatus}`);
+  }
+
+  log(`✓ invoice ${invoiceId} → Financed`);
+  log(`✓ offer   ${offerId} → Accepted`);
+  log(`e2e on-chain flow complete`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err: unknown) => {
+    console.error(`e2e on-chain flow FAILED: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  });

--- a/invofi/scripts/package.json
+++ b/invofi/scripts/package.json
@@ -5,6 +5,7 @@
   "description": "InvoFi keeper automation: overdue marking + TTL extension on Stellar Soroban",
   "scripts": {
     "keeper": "tsx keeper.ts",
+    "e2e:onchain": "tsx e2e-onchain.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/invofi/scripts/tsconfig.json
+++ b/invofi/scripts/tsconfig.json
@@ -11,5 +11,5 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["keeper.ts"]
+  "include": ["keeper.ts", "e2e-onchain.ts"]
 }


### PR DESCRIPTION
## Summary

Adds the end-to-end test coverage requested in #171: a Playwright smoke suite for the core user lifecycle and a scripted on-chain `register → offer → accept` flow against Stellar testnet.

## What's included

**Playwright smoke suite** (`invofi/apps/frontend/e2e`, `npm run test:e2e`) — 8 tests on the Chromium project:

- Landing page renders the hero and links to register/marketplace
- Login renders wallet + email sign-in
- Register renders the role picker and form, and preselects the lender role from `?role=lender`
- Wallet-connect dialog lists the approved Freighter and LOBSTR wallets
- Marketplace loads mirrored invoices for an authenticated lender
- Invoice detail renders the on-chain fields and the print CTA
- Print view opens the printable invoice document

The suite runs against the live testnet contracts and stubs Supabase auth/mirror plus the on-chain invoice read with fixtures (`e2e/fixtures.ts`), so it needs no Supabase credentials and is deterministic.

**Scripted on-chain flow** (`invofi/scripts/e2e-onchain.ts`, `npm run e2e:onchain`) — exercises the SDK's contract wiring end-to-end on testnet with two seeded identities, and asserts the invoice reaches `Financed` and the offer reaches `Accepted`.

**CI** — an opt-in `.github/workflows/e2e.yml` (manual `workflow_dispatch` + weekly schedule) with two jobs: `smoke` (no secrets) and `onchain` (needs `E2E_ORIGINATOR_SECRET_KEY` / `E2E_LENDER_SECRET_KEY`).

**Docs** — README and CONTRIBUTING updated with run instructions and identity setup.

## Notes for reviewers

- **CI workflow vs. the PR template policy.** The template says CI is maintainer-managed and must not be touched in contributor PRs. This PR adds one workflow because #171's acceptance criteria explicitly require "CI job exists and can run on demand". It is strictly additive and opt-in — not wired into the every-PR `ci.yml` — and modifies no existing check. Happy to split it out into a separate maintainer PR if preferred.
- **On-chain `status` is numeric, not a string.** The Soroban contract serializes `status` as a `u32` discriminant (0=Pending, 1=Financed, …), while the Supabase mirror and the frontend types use strings. Fixtures and the script normalize this defensively; worth a follow-up to align the SDK types with the contract.
- **Position token is `POSI`, not `POS`.** `constants.ts` defaults to a `POS` asset, but the live financing contract issues `POSI` via a Stellar Asset Contract. The script derives the asset from the SAC's `name()` so it tracks the deployed contract.
- **Two identities are required.** `create_offer` rejects a lender equal to the originator, and `accept_offer` needs the lender to `approve` XLM and hold a position-token trustline — the script handles both.

## Testing

- [x] `npm run type-check` passes (frontend + scripts)
- [x] `npm run lint` passes (frontend)
- [x] `npx playwright test` — 8/8 smoke tests pass locally against testnet
- [x] `npm run e2e:onchain` — register → offer → accept completes and asserts Financed/Accepted on testnet (two fresh identities)

## Checklist

- [x] My branch is up to date with `main`
- [x] I followed the commit message format in CONTRIBUTING.md
- [x] I added tests for new behavior
- [x] I updated the relevant documentation
- [x] I have not introduced any hardcoded secrets or keys

Closes #171 