### PR TITLE
ci(infra): pin GitHub Actions to commit SHAs (#159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       run:
         working-directory: invofi/apps/frontend
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 20
           cache: npm
@@ -47,8 +47,8 @@ jobs:
       NEXT_PUBLIC_RPC_URL: https://soroban-testnet.stellar.org
       NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 20
           cache: npm
@@ -65,10 +65,10 @@ jobs:
     # contributor PR, which is where it adds value.
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
 
   # Smart contract tests and WASM builds moved to Stellar-VaultLink/invofi-contracts
   # (Rust-only CI) as part of the two-repo topology migration.

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to automate contrib in readme
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Contribute List
-        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        uses: akhilmhdh/contributors-readme-action@83ea0b4f1ac928fbfe88b9e8460a932a528eb79f # v2.3.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,8 +33,8 @@ jobs:
       run:
         working-directory: invofi/apps/frontend
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 20
           cache: npm
@@ -46,7 +46,7 @@ jobs:
         run: npm run test:e2e
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: invofi/apps/frontend/playwright-report
@@ -59,8 +59,8 @@ jobs:
       run:
         working-directory: invofi/scripts
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # Node 22+ required: @stellar/stellar-sdk@16.2+ declares engines
           # node >=22.

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -35,8 +35,8 @@ jobs:
       run:
         working-directory: invofi/apps/indexer
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # Node 22+ required: @supabase/supabase-js@2.112+ and
           # @stellar/stellar-sdk@16.2+ declare engines node >=22.

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -30,8 +30,8 @@ jobs:
       run:
         working-directory: invofi/scripts
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # Node 22+ required: @stellar/stellar-sdk@16.2+ declares engines
           # node >=22 (keeper deps also use @types/node ^26).


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full 40-char commit SHAs instead of floating tags, a supply-chain hardening best practice that also satisfies security reviewers.

Fixes #159

## What changed

Every `uses:` line across 5 workflow files now references a full commit SHA with an inline comment recording the original tag for deliberate future upgrades.

| Action | Tag | Pinned SHA |
|--------|-----|------------|
| `actions/checkout` | `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `actions/setup-node` | `v7` | `820762786026740c76f36085b0efc47a31fe5020` |
| `actions/upload-artifact` | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `wagoid/commitlint-github-action` | `v6` | `b948419dd99f3fd78a6548d48f94e3df7f6bf3ed` |
| `akhilmhdh/contributors-readme-action` | `v2.3.11` | `83ea0b4f1ac928fbfe88b9e8460a932a528eb79f` |

### Format

```yaml
# Before (floating tag)
- uses: actions/checkout@v7

# After (pinned SHA with tag comment)
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

## Files touched

- `.github/workflows/ci.yml` — 5 pinning edits (3× checkout, 2× setup-node, 1× commitlint)
- `.github/workflows/contributors.yml` — 2 pinning edits (checkout, contributors-readme-action)
- `.github/workflows/e2e.yml` — 5 pinning edits (2× checkout, 2× setup-node, 1× upload-artifact)
- `.github/workflows/indexer.yml` — 2 pinning edits (checkout, setup-node)
- `.github/workflows/keeper.yml` — 2 pinning edits (checkout, setup-node)

`auto-merge.yml` was not touched — it uses only shell commands (`gh` CLI), no third-party actions.

## Verification

- ✅ All 6 workflow files pass YAML validation
- ✅ Frontend lint passes (`npm run lint`)
- ✅ Frontend type-check passes (`npm run type-check`)
- ✅ No floating tags remain in any workflow file (`grep` confirmed)
- ✅ Version numbers are NOT changed — only the reference format

## Scope

This change is **pin-only** — no action version upgrades. Upgrading to newer versions should be a separate, deliberate PR.