### PR TITLE
feat(sdk): runtime input validation at client boundary

### DIFF
--- a/invofi/apps/sdk/package-lock.json
+++ b/invofi/apps/sdk/package-lock.json
@@ -12,7 +12,426 @@
       },
       "devDependencies": {
         "@types/node": "^22.5.4",
-        "typescript": "^5.5.4"
+        "typescript": "^5.5.4",
+        "vitest": "^2.0.5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@noble/ed25519": {
@@ -31,6 +450,395 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@stellar/js-xdr": {
       "version": "4.0.0",
@@ -68,12 +876,132 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/agent-base": {
@@ -84,6 +1012,16 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -153,6 +1091,16 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "license": "MIT",
@@ -162,6 +1110,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/combined-stream": {
@@ -194,6 +1169,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/delayed-stream": {
@@ -229,6 +1214,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "license": "MIT",
@@ -252,6 +1244,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "4.1.1",
       "license": "MIT",
@@ -267,6 +1308,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/feaxios": {
@@ -306,6 +1357,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -430,6 +1496,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -458,12 +1541,137 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/smol-toml": {
       "version": "1.7.1",
@@ -473,6 +1681,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -503,6 +1779,172 @@
       "version": "6.21.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/invofi/apps/sdk/package.json
+++ b/invofi/apps/sdk/package.json
@@ -6,13 +6,16 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.5.4",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
   }
 }

--- a/invofi/apps/sdk/src/client.ts
+++ b/invofi/apps/sdk/src/client.ts
@@ -19,6 +19,20 @@ import {
 } from '@stellar/stellar-sdk';
 import type { InvofiClientConfig } from './config';
 import type { Currency, FinancingOffer, Invoice } from './types';
+import { SdkValidationError, ErrorCode } from './validation';
+import {
+  validateStellarAddress,
+  validatePositiveI128,
+  validateInterestRate,
+  validateDuration,
+  validateFutureTimestamp,
+  validateSymbolId,
+  validateCurrency,
+  validateAssetString,
+  validateConfigField,
+} from './validation';
+
+export { SdkValidationError, ErrorCode };
 
 const BASE_FEE = '100';
 
@@ -57,6 +71,25 @@ function encodeU64(value: bigint): xdr.ScVal {
 }
 
 export function createInvofiClient(cfg: InvofiClientConfig) {
+  // ── Validate config at construction time ──────────────────────────────────
+  validateConfigField(cfg.rpcUrl,           'cfg.rpcUrl');
+  validateConfigField(cfg.horizonUrl,       'cfg.horizonUrl');
+  validateConfigField(cfg.networkPassphrase,'cfg.networkPassphrase');
+  validateConfigField(cfg.registryId,       'cfg.registryId');
+  validateConfigField(cfg.financingId,      'cfg.financingId');
+  validateConfigField(cfg.repaymentId,      'cfg.repaymentId');
+  if (typeof cfg.signTransaction !== 'function') {
+    throw new SdkValidationError(
+      ErrorCode.MISSING_CONFIG,
+      'cfg.signTransaction',
+      'cfg.signTransaction: required configuration field is missing or not a function',
+    );
+  }
+  // positionTokenAsset is optional; validate format only when supplied
+  if (cfg.positionTokenAsset !== undefined) {
+    validateAssetString(cfg.positionTokenAsset, 'cfg.positionTokenAsset');
+  }
+
   const server = () => new SorobanRpc.Server(cfg.rpcUrl, { allowHttp: false });
   const horizon = () => new Horizon.Server(cfg.horizonUrl);
 
@@ -188,10 +221,25 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
 
   return {
     // ── Registry contract ────────────────────────────────────────────────────
+
+    /**
+     * Register a new invoice on-chain.
+     *
+     * Validates: originator address, invoice ID, amount (> 0), currency,
+     * and due date (must be in the future).
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     registerInvoice: async (
       params: { id: string; amount: bigint; currency: Currency; dueDate: number },
       originatorAddress: string,
     ): Promise<Invoice> => {
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+      validateSymbolId(params.id, 'params.id');
+      validatePositiveI128(params.amount, 'params.amount');
+      validateCurrency(params.currency, 'params.currency');
+      validateFutureTimestamp(params.dueDate, 'params.dueDate');
+
       const val = await invokeContract(
         cfg.registryId,
         'register_invoice',
@@ -207,10 +255,30 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       return parseInvoice(val);
     },
 
-    getInvoice: (id: string, sourceAccount?: string): Promise<Invoice> =>
-      readContract(cfg.registryId, 'get_invoice', [encodeSymbol(id)], sourceAccount).then(parseInvoice),
+    /**
+     * Fetch a single invoice by ID (read-only).
+     *
+     * Validates: invoice ID.
+     *
+     * @throws {SdkValidationError} before any RPC call when ID is invalid.
+     */
+    getInvoice: (id: string, sourceAccount?: string): Promise<Invoice> => {
+      validateSymbolId(id, 'id');
+      if (sourceAccount !== undefined) validateStellarAddress(sourceAccount, 'sourceAccount');
+      return readContract(cfg.registryId, 'get_invoice', [encodeSymbol(id)], sourceAccount).then(parseInvoice);
+    },
 
+    /**
+     * Cancel a pending invoice.
+     *
+     * Validates: invoice ID and originator address.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     cancelInvoice: async (invoiceId: string, originatorAddress: string): Promise<Invoice> => {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+
       const val = await invokeContract(
         cfg.registryId,
         'cancel_invoice',
@@ -221,6 +289,15 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
     },
 
     // ── Financing contract ───────────────────────────────────────────────────
+
+    /**
+     * Submit a financing offer for an invoice.
+     *
+     * Validates: lender address, offer ID, invoice ID, amount (> 0), currency,
+     * interest rate (1–10 000 bps), duration (1–MAX_DURATION_SECS seconds).
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     createOffer: async (
       params: {
         offerId: string;
@@ -232,6 +309,14 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       },
       lenderAddress: string,
     ): Promise<FinancingOffer> => {
+      validateStellarAddress(lenderAddress, 'lenderAddress');
+      validateSymbolId(params.offerId, 'params.offerId');
+      validateSymbolId(params.invoiceId, 'params.invoiceId');
+      validatePositiveI128(params.amount, 'params.amount');
+      validateCurrency(params.currency, 'params.currency');
+      validateInterestRate(params.interestRate, 'params.interestRate');
+      validateDuration(params.duration, 'params.duration');
+
       const val = await invokeContract(
         cfg.financingId,
         'create_offer',
@@ -249,10 +334,30 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       return parseOffer(val);
     },
 
-    getOffer: (id: string, sourceAccount?: string): Promise<FinancingOffer> =>
-      readContract(cfg.financingId, 'get_offer', [encodeSymbol(id)], sourceAccount).then(parseOffer),
+    /**
+     * Fetch a single offer by ID (read-only).
+     *
+     * Validates: offer ID.
+     *
+     * @throws {SdkValidationError} before any RPC call when ID is invalid.
+     */
+    getOffer: (id: string, sourceAccount?: string): Promise<FinancingOffer> => {
+      validateSymbolId(id, 'id');
+      if (sourceAccount !== undefined) validateStellarAddress(sourceAccount, 'sourceAccount');
+      return readContract(cfg.financingId, 'get_offer', [encodeSymbol(id)], sourceAccount).then(parseOffer);
+    },
 
+    /**
+     * Accept a financing offer (business side).
+     *
+     * Validates: offer ID and originator address.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     acceptOffer: async (offerId: string, originatorAddress: string): Promise<FinancingOffer> => {
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+
       const val = await invokeContract(
         cfg.financingId,
         'accept_offer',
@@ -262,7 +367,17 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       return parseOffer(val);
     },
 
+    /**
+     * Reject a financing offer (business side).
+     *
+     * Validates: offer ID and originator address.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     rejectOffer: async (offerId: string, originatorAddress: string): Promise<FinancingOffer> => {
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+
       const val = await invokeContract(
         cfg.financingId,
         'reject_offer',
@@ -273,12 +388,25 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
     },
 
     // ── Repayment contract ───────────────────────────────────────────────────
+
+    /**
+     * Submit a (partial or full) repayment toward a financed invoice.
+     *
+     * Validates: invoice ID, offer ID, repayer address, repayment amount (> 0).
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     repayInvoice: async (
       invoiceId: string,
       offerId: string,
       repayerAddress: string,
       amount: bigint,
     ): Promise<Invoice> => {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(repayerAddress, 'repayerAddress');
+      validatePositiveI128(amount, 'amount');
+
       const val = await invokeContract(
         cfg.repaymentId,
         'repay_invoice',
@@ -293,12 +421,38 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       return parseInvoice(val);
     },
 
+    /**
+     * Mark a past-due Financed invoice as Overdue (permissionless keeper call).
+     *
+     * Validates: invoice ID and caller address.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     markOverdue: async (invoiceId: string, callerAddress: string): Promise<Invoice> => {
-      const val = await invokeContract(cfg.repaymentId, 'mark_overdue', [encodeSymbol(invoiceId)], callerAddress);
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateStellarAddress(callerAddress, 'callerAddress');
+
+      const val = await invokeContract(
+        cfg.repaymentId,
+        'mark_overdue',
+        [encodeSymbol(invoiceId)],
+        callerAddress,
+      );
       return parseInvoice(val);
     },
 
+    /**
+     * Reclaim an overdue invoice after the grace period (lender call).
+     *
+     * Validates: invoice ID, offer ID, lender address.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     reclaimInvoice: async (invoiceId: string, offerId: string, lenderAddress: string): Promise<FinancingOffer> => {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(lenderAddress, 'lenderAddress');
+
       const val = await invokeContract(
         cfg.repaymentId,
         'reclaim_invoice',
@@ -314,23 +468,60 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
     // SEP-41 token-contract calls; the token address comes from the financing
     // contract (single source of truth, no separate env var).
 
-    getPositionTokenId: (sourceAccount?: string): Promise<string | null> =>
-      readContract(cfg.financingId, 'get_position_token', [], sourceAccount).then(
+    /**
+     * Get the position token contract ID from the financing contract.
+     */
+    getPositionTokenId: (sourceAccount?: string): Promise<string | null> => {
+      if (sourceAccount !== undefined) validateStellarAddress(sourceAccount, 'sourceAccount');
+      return readContract(cfg.financingId, 'get_position_token', [], sourceAccount).then(
         val => (scValToNative(val) as string | null) ?? null,
-      ),
+      );
+    },
 
-    getTokenBalance: (tokenId: string, address: string): Promise<bigint> =>
-      readContract(tokenId, 'balance', [encodeAddress(address)]).then(val => scValToNative(val) as bigint),
+    /**
+     * Get the token balance for an address.
+     *
+     * Validates: token contract ID and holder address.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
+    getTokenBalance: (tokenId: string, address: string): Promise<bigint> => {
+      validateStellarAddress(tokenId, 'tokenId');
+      validateStellarAddress(address, 'address');
+      return readContract(tokenId, 'balance', [encodeAddress(address)]).then(val => scValToNative(val) as bigint);
+    },
 
-    getTokenDecimals: (tokenId: string): Promise<number> =>
-      readContract(tokenId, 'decimals', []).then(val => scValToNative(val) as number),
+    /**
+     * Get the decimal precision of a token contract.
+     *
+     * Validates: token contract ID.
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
+    getTokenDecimals: (tokenId: string): Promise<number> => {
+      validateStellarAddress(tokenId, 'tokenId');
+      return readContract(tokenId, 'decimals', []).then(val => scValToNative(val) as number);
+    },
 
+    /**
+     * Transfer position tokens from one wallet to another.
+     *
+     * Validates: token contract ID, sender address, recipient address,
+     * and transfer amount (> 0).
+     *
+     * @throws {SdkValidationError} before any RPC call when inputs are invalid.
+     */
     transferPositionToken: async (
       tokenId: string,
       fromAddress: string,
       toAddress: string,
       amount: bigint,
     ): Promise<void> => {
+      validateStellarAddress(tokenId, 'tokenId');
+      validateStellarAddress(fromAddress, 'fromAddress');
+      validateStellarAddress(toAddress, 'toAddress');
+      validatePositiveI128(amount, 'amount');
+
       await invokeContract(
         tokenId,
         'transfer',
@@ -344,8 +535,23 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
     // financing contract can mint to them (accept_offer) or a transfer can
     // credit them.
 
+    /**
+     * Check whether an address has a trustline for the position token.
+     *
+     * Validates: holder address. Also requires `cfg.positionTokenAsset` to be set.
+     *
+     * @throws {SdkValidationError} if address is invalid or config is missing.
+     */
     hasPositionTrustline: async (address: string): Promise<boolean> => {
-      const { code, issuer } = parseAssetParts(cfg.positionTokenAsset ?? '');
+      validateStellarAddress(address, 'address');
+      if (!cfg.positionTokenAsset) {
+        throw new SdkValidationError(
+          ErrorCode.MISSING_CONFIG,
+          'cfg.positionTokenAsset',
+          'cfg.positionTokenAsset: required for trustline operations but not set in config',
+        );
+      }
+      const { code, issuer } = parseAssetParts(cfg.positionTokenAsset);
       const account = await horizon().loadAccount(address);
       return account.balances.some(
         b =>
@@ -354,8 +560,23 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       );
     },
 
+    /**
+     * Add a trustline for the position token to the given wallet.
+     *
+     * Validates: holder address. Also requires `cfg.positionTokenAsset` to be set.
+     *
+     * @throws {SdkValidationError} if address is invalid or config is missing.
+     */
     addPositionTrustline: async (address: string): Promise<void> => {
-      const { code, issuer } = parseAssetParts(cfg.positionTokenAsset ?? '');
+      validateStellarAddress(address, 'address');
+      if (!cfg.positionTokenAsset) {
+        throw new SdkValidationError(
+          ErrorCode.MISSING_CONFIG,
+          'cfg.positionTokenAsset',
+          'cfg.positionTokenAsset: required for trustline operations but not set in config',
+        );
+      }
+      const { code, issuer } = parseAssetParts(cfg.positionTokenAsset);
       const account = await horizon().loadAccount(address);
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,

--- a/invofi/apps/sdk/src/index.ts
+++ b/invofi/apps/sdk/src/index.ts
@@ -7,9 +7,19 @@
 // The frontend binds it once in `apps/frontend/src/lib/contract.ts` and
 // re-exports the typed methods — no contract-call code is duplicated there.
 
-export { createInvofiClient, type InvofiClient } from './client';
+export { createInvofiClient, type InvofiClient, SdkValidationError, ErrorCode } from './client';
 export type { InvofiClientConfig } from './config';
 export type { Currency, FinancingOffer, Invoice, InvoiceStatus, OfferStatus } from './types';
+
+// Validation helpers re-exported for consumers who want to pre-validate
+// before calling SDK methods (e.g. form-level validation in the frontend).
+export { validate, type ErrorCode as ValidationErrorCode } from './validation';
+export {
+  MIN_AMOUNT,
+  MAX_INTEREST_RATE_BPS,
+  MAX_DURATION_SECS,
+  VALID_CURRENCIES,
+} from './validation';
 
 // Stellar primitives the client surface needs — re-exported so consumers
 // don't need a direct @stellar/stellar-sdk dependency for common cases.

--- a/invofi/apps/sdk/src/validation.ts
+++ b/invofi/apps/sdk/src/validation.ts
@@ -1,0 +1,265 @@
+// ── SDK input validation (fast-fail client boundary) ─────────────────────────
+//
+// Every SDK method validates its arguments here before any RPC call is made.
+// Error codes mirror the convention used in invofi-contracts#107 so library
+// consumers can programmatically match errors without string-parsing.
+//
+// Usage:
+//   import { validate, SdkValidationError } from './validation';
+//   validate.stellarAddress(address, 'originatorAddress');
+//   validate.positiveI128(amount, 'amount');
+
+// ── Error codes ───────────────────────────────────────────────────────────────
+// Aligned with invofi-contracts#107 error-code conventions.
+
+export const ErrorCode = {
+  // Generic field errors
+  MISSING_FIELD:       'MISSING_FIELD',
+  INVALID_TYPE:        'INVALID_TYPE',
+
+  // Address / identity
+  INVALID_ADDRESS:     'INVALID_ADDRESS',
+
+  // Numeric / amount
+  INVALID_AMOUNT:      'INVALID_AMOUNT',     // non-positive amount
+  INVALID_RATE:        'INVALID_RATE',       // interest rate out of range
+  INVALID_DURATION:    'INVALID_DURATION',   // duration <= 0
+
+  // Timestamps
+  INVALID_DUE_DATE:    'INVALID_DUE_DATE',   // due date not in the future
+
+  // Identifiers (invoice id, offer id, token id)
+  INVALID_ID:          'INVALID_ID',
+
+  // Asset / token
+  INVALID_ASSET:       'INVALID_ASSET',      // bad "CODE:ISSUER" format
+  INVALID_CURRENCY:    'INVALID_CURRENCY',   // not XLM | USDC
+
+  // Config
+  MISSING_CONFIG:      'MISSING_CONFIG',     // required config field absent
+} as const;
+
+export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
+
+// ── Typed error class ─────────────────────────────────────────────────────────
+
+export class SdkValidationError extends Error {
+  readonly code: ErrorCode;
+  readonly field: string;
+
+  constructor(code: ErrorCode, field: string, message: string) {
+    super(message);
+    this.name = 'SdkValidationError';
+    this.code = code;
+    this.field = field;
+    // Maintain proper prototype chain for compiled ES5 targets
+    Object.setPrototypeOf(this, SdkValidationError.prototype);
+  }
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * Stellar public-key / contract-ID format: G… or C… — 56 base-32 characters.
+ * Stellar base32 uses A-Z and digits 2-7 only (no 0, 1, 8, 9).
+ */
+const STELLAR_ADDRESS_RE = /^[GC][A-Z2-7]{55}$/;
+
+/**
+ * Minimum invoice amount: 1 stroop (10^-7 XLM / USDC unit).
+ * Must match invofi-registry's `MIN_INVOICE_AMOUNT` constant.
+ */
+export const MIN_AMOUNT = 1n;
+
+/**
+ * Maximum interest rate in basis points: 10 000 bp = 100%.
+ * Mirrors invofi-financing's upper guard.
+ */
+export const MAX_INTEREST_RATE_BPS = 10_000;
+
+/**
+ * Maximum offer duration in seconds: 365 days.
+ * Mirrors invofi-financing's `MAX_OFFER_DURATION_SECS`.
+ */
+export const MAX_DURATION_SECS = 365 * 24 * 60 * 60;
+
+/**
+ * Valid currencies accepted by the protocol.
+ */
+export const VALID_CURRENCIES = new Set(['XLM', 'USDC'] as const);
+
+// ── Internal helper ───────────────────────────────────────────────────────────
+
+function fail(code: ErrorCode, field: string, msg: string): never {
+  throw new SdkValidationError(code, field, msg);
+}
+
+// ── Validation functions ──────────────────────────────────────────────────────
+// Declared as standalone functions (not object method shorthand) so that
+// TypeScript's strict `asserts` typing (TS2775) is satisfied correctly.
+
+/**
+ * Validates a Stellar account (G…) or contract (C…) address.
+ */
+export function validateStellarAddress(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(ErrorCode.INVALID_ADDRESS, field, `${field}: expected a non-empty Stellar address string`);
+  }
+  if (!STELLAR_ADDRESS_RE.test(value)) {
+    fail(
+      ErrorCode.INVALID_ADDRESS,
+      field,
+      `${field}: "${value.slice(0, 10)}…" is not a valid Stellar address (expected G… or C… with 56 base-32 characters)`,
+    );
+  }
+}
+
+/**
+ * Validates that a bigint amount is positive (≥ MIN_AMOUNT stroops).
+ */
+export function validatePositiveI128(value: unknown, field: string): asserts value is bigint {
+  if (typeof value !== 'bigint') {
+    fail(ErrorCode.INVALID_AMOUNT, field, `${field}: expected a bigint, got ${typeof value}`);
+  }
+  if (value < MIN_AMOUNT) {
+    fail(
+      ErrorCode.INVALID_AMOUNT,
+      field,
+      `${field}: amount must be ≥ ${MIN_AMOUNT} stroop (got ${value})`,
+    );
+  }
+}
+
+/**
+ * Validates interest rate in basis points: 1–10 000 (0.01 % – 100 %).
+ */
+export function validateInterestRate(value: unknown, field: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    fail(ErrorCode.INVALID_RATE, field, `${field}: interest rate must be an integer number of basis points`);
+  }
+  if (value < 1 || value > MAX_INTEREST_RATE_BPS) {
+    fail(
+      ErrorCode.INVALID_RATE,
+      field,
+      `${field}: interest rate must be between 1 and ${MAX_INTEREST_RATE_BPS} basis points (got ${value})`,
+    );
+  }
+}
+
+/**
+ * Validates offer duration in seconds: 1 – MAX_DURATION_SECS.
+ */
+export function validateDuration(value: unknown, field: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    fail(ErrorCode.INVALID_DURATION, field, `${field}: duration must be an integer number of seconds`);
+  }
+  if (value < 1 || value > MAX_DURATION_SECS) {
+    fail(
+      ErrorCode.INVALID_DURATION,
+      field,
+      `${field}: duration must be between 1 and ${MAX_DURATION_SECS} seconds (got ${value})`,
+    );
+  }
+}
+
+/**
+ * Validates a Unix timestamp (in seconds) is strictly in the future.
+ */
+export function validateFutureTimestamp(value: unknown, field: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    fail(ErrorCode.INVALID_DUE_DATE, field, `${field}: due date must be an integer Unix timestamp (seconds)`);
+  }
+  const nowSecs = Math.floor(Date.now() / 1000);
+  if (value <= nowSecs) {
+    fail(
+      ErrorCode.INVALID_DUE_DATE,
+      field,
+      `${field}: due date must be in the future (got ${value}, current time ${nowSecs})`,
+    );
+  }
+}
+
+/**
+ * Validates a non-empty, printable symbol / ID string.
+ * Mirrors Soroban Symbol type: ≤ 32 ASCII alphanumeric/underscore chars.
+ */
+export function validateSymbolId(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(ErrorCode.INVALID_ID, field, `${field}: expected a non-empty string identifier`);
+  }
+  if (value.length > 32) {
+    fail(ErrorCode.INVALID_ID, field, `${field}: identifier exceeds 32 characters (got ${value.length})`);
+  }
+  if (!/^[A-Za-z0-9_]+$/.test(value)) {
+    fail(
+      ErrorCode.INVALID_ID,
+      field,
+      `${field}: identifier must only contain letters, digits, or underscores (got "${value}")`,
+    );
+  }
+}
+
+/**
+ * Validates currency is one of the protocol-supported values: XLM | USDC.
+ */
+export function validateCurrency(value: unknown, field: string): asserts value is 'XLM' | 'USDC' {
+  if (typeof value !== 'string' || !VALID_CURRENCIES.has(value as 'XLM' | 'USDC')) {
+    fail(
+      ErrorCode.INVALID_CURRENCY,
+      field,
+      `${field}: currency must be one of ${[...VALID_CURRENCIES].join(' | ')} (got "${value}")`,
+    );
+  }
+}
+
+/**
+ * Validates a "CODE:ISSUER" position-token asset string.
+ */
+export function validateAssetString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(ErrorCode.INVALID_ASSET, field, `${field}: expected a non-empty asset string`);
+  }
+  const parts = value.split(':');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    fail(
+      ErrorCode.INVALID_ASSET,
+      field,
+      `${field}: asset must be in "CODE:ISSUER" format (got "${value}")`,
+    );
+  }
+  if (!STELLAR_ADDRESS_RE.test(parts[1])) {
+    fail(
+      ErrorCode.INVALID_ASSET,
+      field,
+      `${field}: asset issuer "${parts[1].slice(0, 10)}…" is not a valid Stellar address`,
+    );
+  }
+}
+
+/**
+ * Validates that a required config field is present and non-empty.
+ */
+export function validateConfigField(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(
+      ErrorCode.MISSING_CONFIG,
+      field,
+      `${field}: required configuration field is missing or empty`,
+    );
+  }
+}
+
+// ── Convenience namespace ─────────────────────────────────────────────────────
+// Re-export as a `validate.*` namespace so call sites read naturally.
+
+export const validate = {
+  stellarAddress:   validateStellarAddress,
+  positiveI128:     validatePositiveI128,
+  interestRate:     validateInterestRate,
+  duration:         validateDuration,
+  futureTimestamp:  validateFutureTimestamp,
+  symbolId:         validateSymbolId,
+  currency:         validateCurrency,
+  assetString:      validateAssetString,
+  configField:      validateConfigField,
+};

--- a/invofi/apps/sdk/tests/validation.test.ts
+++ b/invofi/apps/sdk/tests/validation.test.ts
@@ -1,0 +1,994 @@
+/**
+ * Unit tests — SDK input validation
+ *
+ * Covers every rule in validation.ts and verifies that createInvofiClient
+ * guards each method against invalid inputs before any RPC call is made.
+ *
+ * Strategy: all tests are pure in-process — no network calls, no Soroban RPC.
+ * Each test imports the validation helpers directly and also exercises the
+ * client-factory guards by asserting that SdkValidationError is thrown with
+ * the correct `code` and `field` *before* any async work starts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validate,
+  validateStellarAddress,
+  SdkValidationError,
+  ErrorCode,
+  MIN_AMOUNT,
+  MAX_INTEREST_RATE_BPS,
+  MAX_DURATION_SECS,
+} from '../src/validation';
+import { createInvofiClient } from '../src/client';
+import type { InvofiClientConfig } from '../src/config';
+import { Networks } from '@stellar/stellar-sdk';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/**
+ * Valid Stellar G-address (56 chars, base32 A-Z/2-7).
+ * Using a well-known Stellar Labs testnet account.
+ */
+const VALID_G_ADDRESS = 'GCHVSUK5XKL44CSZ3WGI2W2OZCC7SXZMM5B34TCOQ2YNEGPNP3BLOVMT';
+/** A second valid G-address (from the invofi codebase). */
+const VALID_G_ADDRESS_2 = 'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
+/** A valid Stellar contract address (C…) — invofi testnet registry. */
+const VALID_C_ADDRESS = 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7';
+/** A valid position-token asset string. */
+const VALID_ASSET = `POS:${VALID_G_ADDRESS}`;
+/** Unix timestamp 1 year in the future. */
+const FUTURE_TS = Math.floor(Date.now() / 1000) + 365 * 24 * 3600;
+/** Unix timestamp in the past. */
+const PAST_TS = Math.floor(Date.now() / 1000) - 1;
+
+/** Minimal valid config for createInvofiClient. */
+const VALID_CONFIG: InvofiClientConfig = {
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  horizonUrl: 'https://horizon-testnet.stellar.org',
+  networkPassphrase: Networks.TESTNET as typeof Networks.PUBLIC | typeof Networks.TESTNET,
+  registryId: VALID_C_ADDRESS,
+  financingId: VALID_C_ADDRESS,
+  repaymentId: VALID_C_ADDRESS,
+  signTransaction: async (xdr: string, _np: string) => xdr,
+};
+
+/** Helper: assert a sync call throws SdkValidationError with given code/field. */
+function expectValidationError(fn: () => unknown, code: ErrorCode, field?: string) {
+  let thrown: unknown;
+  try { fn(); } catch (e) { thrown = e; }
+  expect(thrown).toBeInstanceOf(SdkValidationError);
+  const err = thrown as SdkValidationError;
+  expect(err.code).toBe(code);
+  if (field !== undefined) expect(err.field).toBe(field);
+}
+
+/**
+ * Helper: assert an async SDK method throws/rejects with SdkValidationError
+ * before any IO. Handles both sync throws (when validation fires before any
+ * `await` in the method body) and proper async rejections.
+ */
+async function expectAsyncValidationError(fn: () => Promise<unknown>, code: ErrorCode, field?: string) {
+  let promise: Promise<unknown>;
+  try {
+    // Validation in some methods fires synchronously before the first await
+    promise = fn();
+  } catch (e) {
+    expect(e).toBeInstanceOf(SdkValidationError);
+    const err = e as SdkValidationError;
+    expect(err.code).toBe(code);
+    if (field !== undefined) expect(err.field).toBe(field);
+    return;
+  }
+  await promise.then(
+    () => { throw new Error('Expected SdkValidationError but promise resolved without error'); },
+    (e: unknown) => {
+      expect(e).toBeInstanceOf(SdkValidationError);
+      const err = e as SdkValidationError;
+      expect(err.code).toBe(code);
+      if (field !== undefined) expect(err.field).toBe(field);
+    },
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.stellarAddress
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.stellarAddress', () => {
+  it('accepts a valid G-address', () => {
+    expect(() => validate.stellarAddress(VALID_G_ADDRESS, 'addr')).not.toThrow();
+  });
+
+  it('accepts a valid C-address (contract)', () => {
+    expect(() => validate.stellarAddress(VALID_C_ADDRESS, 'addr')).not.toThrow();
+  });
+
+  it('throws INVALID_ADDRESS on empty string', () => {
+    expectValidationError(() => validate.stellarAddress('', 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+  });
+
+  it('throws INVALID_ADDRESS on whitespace-only string', () => {
+    expectValidationError(() => validate.stellarAddress('   ', 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+  });
+
+  it('throws INVALID_ADDRESS on non-string input', () => {
+    expectValidationError(() => validate.stellarAddress(null, 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+    expectValidationError(() => validate.stellarAddress(undefined, 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+    expectValidationError(() => validate.stellarAddress(123, 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+  });
+
+  it('throws INVALID_ADDRESS on wrong length', () => {
+    expectValidationError(
+      () => validate.stellarAddress('GABC', 'addr'),
+      ErrorCode.INVALID_ADDRESS, 'addr',
+    );
+  });
+
+  it('throws INVALID_ADDRESS on wrong prefix (not G or C)', () => {
+    // Build a 56-char string starting with S
+    const bad = 'S' + 'A'.repeat(55);
+    expectValidationError(() => validate.stellarAddress(bad, 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+  });
+
+  it('throws INVALID_ADDRESS on lowercase characters', () => {
+    const bad = VALID_G_ADDRESS.toLowerCase();
+    expectValidationError(() => validate.stellarAddress(bad, 'addr'), ErrorCode.INVALID_ADDRESS, 'addr');
+  });
+
+  it('includes the field name in the thrown error', () => {
+    let err: SdkValidationError | undefined;
+    try { validateStellarAddress('bad', 'myField'); } catch (e) { err = e as SdkValidationError; }
+    expect(err?.field).toBe('myField');
+    expect(err?.message).toContain('myField');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.positiveI128
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.positiveI128', () => {
+  it('accepts MIN_AMOUNT (1n)', () => {
+    expect(() => validate.positiveI128(MIN_AMOUNT, 'amount')).not.toThrow();
+  });
+
+  it('accepts a large positive bigint', () => {
+    expect(() => validate.positiveI128(100_000_000n, 'amount')).not.toThrow();
+  });
+
+  it('throws INVALID_AMOUNT for 0n', () => {
+    expectValidationError(() => validate.positiveI128(0n, 'amount'), ErrorCode.INVALID_AMOUNT, 'amount');
+  });
+
+  it('throws INVALID_AMOUNT for negative bigint', () => {
+    expectValidationError(() => validate.positiveI128(-1n, 'amount'), ErrorCode.INVALID_AMOUNT, 'amount');
+  });
+
+  it('throws INVALID_AMOUNT for number type', () => {
+    expectValidationError(() => validate.positiveI128(100, 'amount'), ErrorCode.INVALID_AMOUNT, 'amount');
+  });
+
+  it('throws INVALID_AMOUNT for string type', () => {
+    expectValidationError(() => validate.positiveI128('100', 'amount'), ErrorCode.INVALID_AMOUNT, 'amount');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.interestRate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.interestRate', () => {
+  it('accepts 1 (minimum)', () => {
+    expect(() => validate.interestRate(1, 'rate')).not.toThrow();
+  });
+
+  it(`accepts ${MAX_INTEREST_RATE_BPS} (maximum)`, () => {
+    expect(() => validate.interestRate(MAX_INTEREST_RATE_BPS, 'rate')).not.toThrow();
+  });
+
+  it('accepts 500 (5 %)', () => {
+    expect(() => validate.interestRate(500, 'rate')).not.toThrow();
+  });
+
+  it('throws INVALID_RATE for 0', () => {
+    expectValidationError(() => validate.interestRate(0, 'rate'), ErrorCode.INVALID_RATE, 'rate');
+  });
+
+  it('throws INVALID_RATE for negative', () => {
+    expectValidationError(() => validate.interestRate(-1, 'rate'), ErrorCode.INVALID_RATE, 'rate');
+  });
+
+  it(`throws INVALID_RATE for ${MAX_INTEREST_RATE_BPS + 1}`, () => {
+    expectValidationError(() => validate.interestRate(MAX_INTEREST_RATE_BPS + 1, 'rate'), ErrorCode.INVALID_RATE, 'rate');
+  });
+
+  it('throws INVALID_RATE for non-integer (float)', () => {
+    expectValidationError(() => validate.interestRate(1.5, 'rate'), ErrorCode.INVALID_RATE, 'rate');
+  });
+
+  it('throws INVALID_RATE for string', () => {
+    expectValidationError(() => validate.interestRate('500' as unknown as number, 'rate'), ErrorCode.INVALID_RATE, 'rate');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.duration
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.duration', () => {
+  it('accepts 1 second', () => {
+    expect(() => validate.duration(1, 'duration')).not.toThrow();
+  });
+
+  it(`accepts MAX_DURATION_SECS (${MAX_DURATION_SECS})`, () => {
+    expect(() => validate.duration(MAX_DURATION_SECS, 'duration')).not.toThrow();
+  });
+
+  it('throws INVALID_DURATION for 0', () => {
+    expectValidationError(() => validate.duration(0, 'duration'), ErrorCode.INVALID_DURATION, 'duration');
+  });
+
+  it('throws INVALID_DURATION for negative', () => {
+    expectValidationError(() => validate.duration(-3600, 'duration'), ErrorCode.INVALID_DURATION, 'duration');
+  });
+
+  it(`throws INVALID_DURATION for ${MAX_DURATION_SECS + 1}`, () => {
+    expectValidationError(
+      () => validate.duration(MAX_DURATION_SECS + 1, 'duration'),
+      ErrorCode.INVALID_DURATION, 'duration',
+    );
+  });
+
+  it('throws INVALID_DURATION for float', () => {
+    expectValidationError(() => validate.duration(86400.5, 'duration'), ErrorCode.INVALID_DURATION, 'duration');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.futureTimestamp
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.futureTimestamp', () => {
+  it('accepts a timestamp 1 year in the future', () => {
+    expect(() => validate.futureTimestamp(FUTURE_TS, 'dueDate')).not.toThrow();
+  });
+
+  it('throws INVALID_DUE_DATE for a past timestamp', () => {
+    expectValidationError(() => validate.futureTimestamp(PAST_TS, 'dueDate'), ErrorCode.INVALID_DUE_DATE, 'dueDate');
+  });
+
+  it('throws INVALID_DUE_DATE for current time (exactly now)', () => {
+    const nowSecs = Math.floor(Date.now() / 1000);
+    expectValidationError(() => validate.futureTimestamp(nowSecs, 'dueDate'), ErrorCode.INVALID_DUE_DATE, 'dueDate');
+  });
+
+  it('throws INVALID_DUE_DATE for 0 (epoch)', () => {
+    expectValidationError(() => validate.futureTimestamp(0, 'dueDate'), ErrorCode.INVALID_DUE_DATE, 'dueDate');
+  });
+
+  it('throws INVALID_DUE_DATE for float', () => {
+    expectValidationError(() => validate.futureTimestamp(FUTURE_TS + 0.5, 'dueDate'), ErrorCode.INVALID_DUE_DATE, 'dueDate');
+  });
+
+  it('throws INVALID_DUE_DATE for string', () => {
+    expectValidationError(
+      () => validate.futureTimestamp('2030-01-01' as unknown as number, 'dueDate'),
+      ErrorCode.INVALID_DUE_DATE, 'dueDate',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.symbolId
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.symbolId', () => {
+  it('accepts alphanumeric IDs', () => {
+    expect(() => validate.symbolId('inv001', 'id')).not.toThrow();
+    expect(() => validate.symbolId('OFF_2024_001', 'id')).not.toThrow();
+  });
+
+  it('accepts IDs with underscores', () => {
+    expect(() => validate.symbolId('invoice_001', 'id')).not.toThrow();
+  });
+
+  it('accepts single-character ID', () => {
+    expect(() => validate.symbolId('A', 'id')).not.toThrow();
+  });
+
+  it('accepts exactly 32 characters', () => {
+    expect(() => validate.symbolId('A'.repeat(32), 'id')).not.toThrow();
+  });
+
+  it('throws INVALID_ID for empty string', () => {
+    expectValidationError(() => validate.symbolId('', 'id'), ErrorCode.INVALID_ID, 'id');
+  });
+
+  it('throws INVALID_ID for 33+ characters', () => {
+    expectValidationError(() => validate.symbolId('A'.repeat(33), 'id'), ErrorCode.INVALID_ID, 'id');
+  });
+
+  it('throws INVALID_ID for IDs with spaces', () => {
+    expectValidationError(() => validate.symbolId('inv 001', 'id'), ErrorCode.INVALID_ID, 'id');
+  });
+
+  it('throws INVALID_ID for IDs with hyphens', () => {
+    expectValidationError(() => validate.symbolId('inv-001', 'id'), ErrorCode.INVALID_ID, 'id');
+  });
+
+  it('throws INVALID_ID for IDs with special characters', () => {
+    expectValidationError(() => validate.symbolId('inv#001', 'id'), ErrorCode.INVALID_ID, 'id');
+  });
+
+  it('throws INVALID_ID for non-string', () => {
+    expectValidationError(() => validate.symbolId(null, 'id'), ErrorCode.INVALID_ID, 'id');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.currency
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.currency', () => {
+  it('accepts XLM', () => {
+    expect(() => validate.currency('XLM', 'currency')).not.toThrow();
+  });
+
+  it('accepts USDC', () => {
+    expect(() => validate.currency('USDC', 'currency')).not.toThrow();
+  });
+
+  it('throws INVALID_CURRENCY for lowercase', () => {
+    expectValidationError(() => validate.currency('xlm', 'currency'), ErrorCode.INVALID_CURRENCY, 'currency');
+  });
+
+  it('throws INVALID_CURRENCY for unknown token', () => {
+    expectValidationError(() => validate.currency('BTC', 'currency'), ErrorCode.INVALID_CURRENCY, 'currency');
+  });
+
+  it('throws INVALID_CURRENCY for empty string', () => {
+    expectValidationError(() => validate.currency('', 'currency'), ErrorCode.INVALID_CURRENCY, 'currency');
+  });
+
+  it('throws INVALID_CURRENCY for non-string', () => {
+    expectValidationError(() => validate.currency(null, 'currency'), ErrorCode.INVALID_CURRENCY, 'currency');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.assetString
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.assetString', () => {
+  it('accepts a valid CODE:ISSUER string', () => {
+    expect(() => validate.assetString(VALID_ASSET, 'asset')).not.toThrow();
+  });
+
+  it('throws INVALID_ASSET for empty string', () => {
+    expectValidationError(() => validate.assetString('', 'asset'), ErrorCode.INVALID_ASSET, 'asset');
+  });
+
+  it('throws INVALID_ASSET for missing issuer', () => {
+    expectValidationError(() => validate.assetString('POS', 'asset'), ErrorCode.INVALID_ASSET, 'asset');
+  });
+
+  it('throws INVALID_ASSET for malformed issuer', () => {
+    expectValidationError(() => validate.assetString('POS:badissuer', 'asset'), ErrorCode.INVALID_ASSET, 'asset');
+  });
+
+  it('throws INVALID_ASSET for non-string', () => {
+    expectValidationError(() => validate.assetString(42, 'asset'), ErrorCode.INVALID_ASSET, 'asset');
+  });
+
+  it('throws INVALID_ASSET when code is empty', () => {
+    expectValidationError(() => validate.assetString(`:${VALID_G_ADDRESS}`, 'asset'), ErrorCode.INVALID_ASSET, 'asset');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate.configField
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate.configField', () => {
+  it('accepts a non-empty string', () => {
+    expect(() => validate.configField('https://rpc.example.com', 'cfg.rpcUrl')).not.toThrow();
+  });
+
+  it('throws MISSING_CONFIG for empty string', () => {
+    expectValidationError(() => validate.configField('', 'cfg.rpcUrl'), ErrorCode.MISSING_CONFIG, 'cfg.rpcUrl');
+  });
+
+  it('throws MISSING_CONFIG for whitespace-only string', () => {
+    expectValidationError(() => validate.configField('  ', 'cfg.rpcUrl'), ErrorCode.MISSING_CONFIG, 'cfg.rpcUrl');
+  });
+
+  it('throws MISSING_CONFIG for undefined', () => {
+    expectValidationError(() => validate.configField(undefined, 'cfg.rpcUrl'), ErrorCode.MISSING_CONFIG, 'cfg.rpcUrl');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SdkValidationError class
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SdkValidationError', () => {
+  it('is an instance of Error', () => {
+    const err = new SdkValidationError(ErrorCode.INVALID_ADDRESS, 'addr', 'bad address');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(SdkValidationError);
+  });
+
+  it('has name "SdkValidationError"', () => {
+    const err = new SdkValidationError(ErrorCode.INVALID_AMOUNT, 'amount', 'bad amount');
+    expect(err.name).toBe('SdkValidationError');
+  });
+
+  it('exposes code and field properties', () => {
+    const err = new SdkValidationError(ErrorCode.INVALID_RATE, 'interestRate', 'bad rate');
+    expect(err.code).toBe(ErrorCode.INVALID_RATE);
+    expect(err.field).toBe('interestRate');
+    expect(err.message).toBe('bad rate');
+  });
+
+  it('instanceof check survives prototype chain (ES5 targets)', () => {
+    // Re-create via factory to simulate compiled output
+    try {
+      validateStellarAddress('', 'x');
+    } catch (e) {
+      expect(e instanceof SdkValidationError).toBe(true);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createInvofiClient — config-level validation (sync, at construction time)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createInvofiClient — config validation', () => {
+  it('constructs successfully with a valid config', () => {
+    expect(() => createInvofiClient(VALID_CONFIG)).not.toThrow();
+  });
+
+  it('throws MISSING_CONFIG when rpcUrl is empty', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, rpcUrl: '' }),
+      ErrorCode.MISSING_CONFIG, 'cfg.rpcUrl',
+    );
+  });
+
+  it('throws MISSING_CONFIG when horizonUrl is empty', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, horizonUrl: '' }),
+      ErrorCode.MISSING_CONFIG, 'cfg.horizonUrl',
+    );
+  });
+
+  it('throws MISSING_CONFIG when registryId is empty', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, registryId: '' }),
+      ErrorCode.MISSING_CONFIG, 'cfg.registryId',
+    );
+  });
+
+  it('throws MISSING_CONFIG when financingId is empty', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, financingId: '' }),
+      ErrorCode.MISSING_CONFIG, 'cfg.financingId',
+    );
+  });
+
+  it('throws MISSING_CONFIG when repaymentId is empty', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, repaymentId: '' }),
+      ErrorCode.MISSING_CONFIG, 'cfg.repaymentId',
+    );
+  });
+
+  it('throws MISSING_CONFIG when signTransaction is not a function', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, signTransaction: null as unknown as () => Promise<string> }),
+      ErrorCode.MISSING_CONFIG, 'cfg.signTransaction',
+    );
+  });
+
+  it('throws INVALID_ASSET when positionTokenAsset is malformed', () => {
+    expectValidationError(
+      () => createInvofiClient({ ...VALID_CONFIG, positionTokenAsset: 'BAD_NO_ISSUER' }),
+      ErrorCode.INVALID_ASSET, 'cfg.positionTokenAsset',
+    );
+  });
+
+  it('accepts a valid positionTokenAsset', () => {
+    expect(() => createInvofiClient({ ...VALID_CONFIG, positionTokenAsset: VALID_ASSET })).not.toThrow();
+  });
+
+  it('accepts config without positionTokenAsset', () => {
+    // VALID_CONFIG has no positionTokenAsset — it's already a valid minimal config
+    expect(() => createInvofiClient(VALID_CONFIG)).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// registerInvoice — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('registerInvoice — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS for empty originator', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: 'inv001', amount: 1000n, currency: 'XLM', dueDate: FUTURE_TS }, ''),
+      ErrorCode.INVALID_ADDRESS, 'originatorAddress',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed originator', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: 'inv001', amount: 1000n, currency: 'XLM', dueDate: FUTURE_TS }, 'not-an-address'),
+      ErrorCode.INVALID_ADDRESS, 'originatorAddress',
+    );
+  });
+
+  it('throws INVALID_ID for empty invoice ID', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: '', amount: 1000n, currency: 'XLM', dueDate: FUTURE_TS }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'params.id',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for zero amount', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: 'inv001', amount: 0n, currency: 'XLM', dueDate: FUTURE_TS }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_AMOUNT, 'params.amount',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for negative amount', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: 'inv001', amount: -1n, currency: 'XLM', dueDate: FUTURE_TS }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_AMOUNT, 'params.amount',
+    );
+  });
+
+  it('throws INVALID_CURRENCY for unknown currency', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: 'inv001', amount: 1000n, currency: 'BTC' as 'XLM', dueDate: FUTURE_TS }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_CURRENCY, 'params.currency',
+    );
+  });
+
+  it('throws INVALID_DUE_DATE for past due date', async () => {
+    await expectAsyncValidationError(
+      () => client.registerInvoice({ id: 'inv001', amount: 1000n, currency: 'XLM', dueDate: PAST_TS }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_DUE_DATE, 'params.dueDate',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getInvoice — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getInvoice — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty id', async () => {
+    await expectAsyncValidationError(
+      () => client.getInvoice(''),
+      ErrorCode.INVALID_ID, 'id',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed sourceAccount', async () => {
+    await expectAsyncValidationError(
+      () => client.getInvoice('inv001', 'bad-address'),
+      ErrorCode.INVALID_ADDRESS, 'sourceAccount',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cancelInvoice — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('cancelInvoice — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty invoice ID', async () => {
+    await expectAsyncValidationError(
+      () => client.cancelInvoice('', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'invoiceId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed originator', async () => {
+    await expectAsyncValidationError(
+      () => client.cancelInvoice('inv001', 'bad'),
+      ErrorCode.INVALID_ADDRESS, 'originatorAddress',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createOffer — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createOffer — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+  const validParams = {
+    offerId: 'off001',
+    invoiceId: 'inv001',
+    amount: 5000n,
+    currency: 'USDC' as const,
+    interestRate: 500,
+    duration: 86400,
+  };
+
+  it('throws INVALID_ADDRESS for empty lender', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer(validParams, ''),
+      ErrorCode.INVALID_ADDRESS, 'lenderAddress',
+    );
+  });
+
+  it('throws INVALID_ID for empty offerId', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, offerId: '' }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'params.offerId',
+    );
+  });
+
+  it('throws INVALID_ID for empty invoiceId', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, invoiceId: '' }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'params.invoiceId',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for zero amount', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, amount: 0n }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_AMOUNT, 'params.amount',
+    );
+  });
+
+  it('throws INVALID_CURRENCY for unknown currency', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, currency: 'ETH' as 'USDC' }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_CURRENCY, 'params.currency',
+    );
+  });
+
+  it('throws INVALID_RATE for zero interest rate', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, interestRate: 0 }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_RATE, 'params.interestRate',
+    );
+  });
+
+  it('throws INVALID_RATE for rate > 10 000 bps', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, interestRate: 10_001 }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_RATE, 'params.interestRate',
+    );
+  });
+
+  it('throws INVALID_DURATION for zero duration', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, duration: 0 }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_DURATION, 'params.duration',
+    );
+  });
+
+  it('throws INVALID_DURATION for duration > MAX_DURATION_SECS', async () => {
+    await expectAsyncValidationError(
+      () => client.createOffer({ ...validParams, duration: MAX_DURATION_SECS + 1 }, VALID_G_ADDRESS),
+      ErrorCode.INVALID_DURATION, 'params.duration',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// acceptOffer — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('acceptOffer — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty offerId', async () => {
+    await expectAsyncValidationError(
+      () => client.acceptOffer('', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'offerId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed originator', async () => {
+    await expectAsyncValidationError(
+      () => client.acceptOffer('off001', 'not-valid'),
+      ErrorCode.INVALID_ADDRESS, 'originatorAddress',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rejectOffer — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('rejectOffer — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty offerId', async () => {
+    await expectAsyncValidationError(
+      () => client.rejectOffer('', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'offerId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed originator', async () => {
+    await expectAsyncValidationError(
+      () => client.rejectOffer('off001', 'bad'),
+      ErrorCode.INVALID_ADDRESS, 'originatorAddress',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getOffer — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getOffer — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty id', async () => {
+    await expectAsyncValidationError(
+      () => client.getOffer(''),
+      ErrorCode.INVALID_ID, 'id',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed sourceAccount', async () => {
+    await expectAsyncValidationError(
+      () => client.getOffer('off001', 'bad-address'),
+      ErrorCode.INVALID_ADDRESS, 'sourceAccount',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// repayInvoice — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('repayInvoice — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty invoiceId', async () => {
+    await expectAsyncValidationError(
+      () => client.repayInvoice('', 'off001', VALID_G_ADDRESS, 1000n),
+      ErrorCode.INVALID_ID, 'invoiceId',
+    );
+  });
+
+  it('throws INVALID_ID for empty offerId', async () => {
+    await expectAsyncValidationError(
+      () => client.repayInvoice('inv001', '', VALID_G_ADDRESS, 1000n),
+      ErrorCode.INVALID_ID, 'offerId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed repayer', async () => {
+    await expectAsyncValidationError(
+      () => client.repayInvoice('inv001', 'off001', 'not-valid', 1000n),
+      ErrorCode.INVALID_ADDRESS, 'repayerAddress',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for zero repayment', async () => {
+    await expectAsyncValidationError(
+      () => client.repayInvoice('inv001', 'off001', VALID_G_ADDRESS, 0n),
+      ErrorCode.INVALID_AMOUNT, 'amount',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for negative repayment', async () => {
+    await expectAsyncValidationError(
+      () => client.repayInvoice('inv001', 'off001', VALID_G_ADDRESS, -100n),
+      ErrorCode.INVALID_AMOUNT, 'amount',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// markOverdue — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('markOverdue — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty invoiceId', async () => {
+    await expectAsyncValidationError(
+      () => client.markOverdue('', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'invoiceId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed caller', async () => {
+    await expectAsyncValidationError(
+      () => client.markOverdue('inv001', 'bad'),
+      ErrorCode.INVALID_ADDRESS, 'callerAddress',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reclaimInvoice — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('reclaimInvoice — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ID for empty invoiceId', async () => {
+    await expectAsyncValidationError(
+      () => client.reclaimInvoice('', 'off001', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'invoiceId',
+    );
+  });
+
+  it('throws INVALID_ID for empty offerId', async () => {
+    await expectAsyncValidationError(
+      () => client.reclaimInvoice('inv001', '', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ID, 'offerId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for malformed lender', async () => {
+    await expectAsyncValidationError(
+      () => client.reclaimInvoice('inv001', 'off001', 'bad'),
+      ErrorCode.INVALID_ADDRESS, 'lenderAddress',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// transferPositionToken — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('transferPositionToken — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS for bad tokenId', async () => {
+    await expectAsyncValidationError(
+      () => client.transferPositionToken('not-a-contract', VALID_G_ADDRESS, VALID_G_ADDRESS, 100n),
+      ErrorCode.INVALID_ADDRESS, 'tokenId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for bad fromAddress', async () => {
+    await expectAsyncValidationError(
+      () => client.transferPositionToken(VALID_C_ADDRESS, 'bad', VALID_G_ADDRESS, 100n),
+      ErrorCode.INVALID_ADDRESS, 'fromAddress',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for bad toAddress', async () => {
+    await expectAsyncValidationError(
+      () => client.transferPositionToken(VALID_C_ADDRESS, VALID_G_ADDRESS, 'bad', 100n),
+      ErrorCode.INVALID_ADDRESS, 'toAddress',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for zero amount', async () => {
+    await expectAsyncValidationError(
+      () => client.transferPositionToken(VALID_C_ADDRESS, VALID_G_ADDRESS, VALID_G_ADDRESS, 0n),
+      ErrorCode.INVALID_AMOUNT, 'amount',
+    );
+  });
+
+  it('throws INVALID_AMOUNT for negative amount', async () => {
+    await expectAsyncValidationError(
+      () => client.transferPositionToken(VALID_C_ADDRESS, VALID_G_ADDRESS, VALID_G_ADDRESS, -1n),
+      ErrorCode.INVALID_AMOUNT, 'amount',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getTokenBalance — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getTokenBalance — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS for bad tokenId', async () => {
+    await expectAsyncValidationError(
+      () => client.getTokenBalance('bad', VALID_G_ADDRESS),
+      ErrorCode.INVALID_ADDRESS, 'tokenId',
+    );
+  });
+
+  it('throws INVALID_ADDRESS for bad holder address', async () => {
+    await expectAsyncValidationError(
+      () => client.getTokenBalance(VALID_C_ADDRESS, 'bad'),
+      ErrorCode.INVALID_ADDRESS, 'address',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getTokenDecimals — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getTokenDecimals — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS for bad tokenId', async () => {
+    await expectAsyncValidationError(
+      () => client.getTokenDecimals('bad-token'),
+      ErrorCode.INVALID_ADDRESS, 'tokenId',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// hasPositionTrustline — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('hasPositionTrustline — input validation', () => {
+  const clientWithAsset = createInvofiClient({ ...VALID_CONFIG, positionTokenAsset: VALID_ASSET });
+  const clientNoAsset   = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS for bad address', async () => {
+    await expectAsyncValidationError(
+      () => clientWithAsset.hasPositionTrustline('bad'),
+      ErrorCode.INVALID_ADDRESS, 'address',
+    );
+  });
+
+  it('throws MISSING_CONFIG when positionTokenAsset not set', async () => {
+    await expectAsyncValidationError(
+      () => clientNoAsset.hasPositionTrustline(VALID_G_ADDRESS),
+      ErrorCode.MISSING_CONFIG, 'cfg.positionTokenAsset',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// addPositionTrustline — method-level validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('addPositionTrustline — input validation', () => {
+  const clientWithAsset = createInvofiClient({ ...VALID_CONFIG, positionTokenAsset: VALID_ASSET });
+  const clientNoAsset   = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS for bad address', async () => {
+    await expectAsyncValidationError(
+      () => clientWithAsset.addPositionTrustline('bad'),
+      ErrorCode.INVALID_ADDRESS, 'address',
+    );
+  });
+
+  it('throws MISSING_CONFIG when positionTokenAsset not set', async () => {
+    await expectAsyncValidationError(
+      () => clientNoAsset.addPositionTrustline(VALID_G_ADDRESS),
+      ErrorCode.MISSING_CONFIG, 'cfg.positionTokenAsset',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getPositionTokenId — optional sourceAccount validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getPositionTokenId — input validation', () => {
+  const client = createInvofiClient(VALID_CONFIG);
+
+  it('throws INVALID_ADDRESS when bad sourceAccount is supplied', async () => {
+    await expectAsyncValidationError(
+      () => client.getPositionTokenId('not-an-address'),
+      ErrorCode.INVALID_ADDRESS, 'sourceAccount',
+    );
+  });
+
+  // No sourceAccount → falls back to fixed read account; validation passes
+  // (we cannot test the RPC call here without mocking the server)
+});

--- a/invofi/apps/sdk/tsconfig.json
+++ b/invofi/apps/sdk/tsconfig.json
@@ -11,5 +11,5 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary

Closes #165

Adds a fast-fail validation layer to `@invofi/sdk` so every exported method validates its arguments and throws a typed `SdkValidationError` **before any RPC call is made**.

---

## What was changed

### `apps/sdk/src/validation.ts` (new)
- **`SdkValidationError`** — typed error class with `code: ErrorCode` and `field: string` properties. Proper prototype chain for compiled targets.
- **`ErrorCode`** const enum — `INVALID_ADDRESS`, `INVALID_AMOUNT`, `INVALID_RATE`, `INVALID_DURATION`, `INVALID_DUE_DATE`, `INVALID_ID`, `INVALID_ASSET`, `INVALID_CURRENCY`, `MISSING_CONFIG`. Aligned with invofi-contracts#107.
- **9 standalone assertion functions** — `validateStellarAddress`, `validatePositiveI128`, `validateInterestRate`, `validateDuration`, `validateFutureTimestamp`, `validateSymbolId`, `validateCurrency`, `validateAssetString`, `validateConfigField` — plus a `validate.*` convenience namespace.
- **Exported constants** — `MIN_AMOUNT` (1n stroop), `MAX_INTEREST_RATE_BPS` (10 000), `MAX_DURATION_SECS` (365 days), `VALID_CURRENCIES`. All mirror the contract-side limits.

### `apps/sdk/src/client.ts` (updated)
- `createInvofiClient` validates the full config at construction time (`rpcUrl`, `horizonUrl`, `networkPassphrase`, `registryId`, `financingId`, `repaymentId`, `signTransaction`, optional `positionTokenAsset`).
- Every exported method validates its arguments before the first `await`:
  - `registerInvoice` — address, id, amount, currency, dueDate
  - `getInvoice` / `cancelInvoice` — id, optional sourceAccount/originator
  - `createOffer` — address, offerId, invoiceId, amount, currency, interestRate, duration
  - `getOffer` / `acceptOffer` / `rejectOffer` — id, address
  - `repayInvoice` — invoiceId, offerId, address, amount
  - `markOverdue` / `reclaimInvoice` — ids, address
  - `transferPositionToken` — tokenId (C…), fromAddress, toAddress, amount
  - `getTokenBalance` / `getTokenDecimals` — tokenId
  - `hasPositionTrustline` / `addPositionTrustline` — address, config guard
- `SdkValidationError` and `ErrorCode` re-exported so consumers can `catch (e) { if (e instanceof SdkValidationError)` without a separate import.

### `apps/sdk/src/index.ts` (updated)
- Re-exports `SdkValidationError`, `ErrorCode`, `validate`, `MIN_AMOUNT`, `MAX_INTEREST_RATE_BPS`, `MAX_DURATION_SECS`, `VALID_CURRENCIES`.

### `apps/sdk/tests/validation.test.ts` (new — 124 tests)
- Pure in-process unit tests (vitest) — no RPC, no network.
- Covers every assertion rule (happy path + all failure modes) and every method-level guard.

### `apps/sdk/package.json` / `tsconfig.json`
- Added `vitest@^2.0.5` to `devDependencies`.
- Added `"test": "vitest run"` script.
- Added `tests` to `tsconfig.json` `include`.

---

## Acceptance criteria

| | |
|---|---|
| ✅ Every SDK method validates its arguments | All 11 state-mutating methods + 4 read methods guarded |
| ✅ Invalid inputs throw descriptive, typed errors before any RPC call | `SdkValidationError` thrown synchronously at method entry |
| ✅ Validation is covered by unit tests | 124 tests, 0 failures, type-check clean |

## Testing

```bash
cd invofi/apps/sdk
npm install
npm test          # 124 passed
npm run type-check  # clean
```