### PR TITLE
fix(frontend): enforce Content Security Policy headers in next.config

### DIFF
--- a/invofi/apps/frontend/next.config.mjs
+++ b/invofi/apps/frontend/next.config.mjs
@@ -3,8 +3,70 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Content Security Policy (issue #186).
+ *
+ * Strict-but-practical: `default-src 'self'` with an explicit allowlist for
+ * the few origins the app must talk to (Stellar RPC, Horizon, Friendbot,
+ * Supabase). External script/style/img/font origins are all blocked — that is
+ * the second line of defense against XSS that this policy exists to provide.
+ *
+ * `script-src`/`style-src` include 'unsafe-inline' because the Next.js App
+ * Router ships its RSC bootstrap as inline <script> tags in the production
+ * HTML (verified against the built output), and next/font injects inline
+ * @font-face styles. A nonce-based policy is the stricter upgrade path, but
+ * nonces must be generated per-request in middleware and can't live in a
+ * static `headers()` block — out of scope here per the issue ("Don't
+ * re-architect"). Inline scripts are still limited to same-origin because
+ * 'unsafe-inline' does not weaken `script-src 'self'` for *external* scripts.
+ *
+ * `connect-src` is built from the same env vars the app uses at runtime
+ * (src/lib/constants.ts), with matching defaults, so a deployment that only
+ * sets NEXT_PUBLIC_* keeps working without CSP edits.
+ */
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+// Friendbot is testnet-only but harmless to allow on mainnet; the app itself
+// refuses to call it outside testnet (src/lib/horizon.ts).
+const FRIENDBOT_URL = 'https://friendbot.stellar.org';
+
+const connectSrc = [
+  "'self'",
+  RPC_URL,
+  HORIZON_URL,
+  FRIENDBOT_URL,
+  ...(SUPABASE_URL ? [SUPABASE_URL] : []),
+].join(' ');
+
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  `connect-src ${connectSrc}`,
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: CONTENT_SECURITY_POLICY,
+          },
+        ],
+      },
+    ];
+  },
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback = {

--- a/invofi/apps/frontend/src/app/invoices/[id]/print/InvoicePrintView.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/print/InvoicePrintView.tsx
@@ -75,9 +75,12 @@ export default function InvoicePrintView() {
   return (
     <>
       {/* ── Print / screen styles ─────────────────────────────────────────── */}
+      {/*
+        Note: no @import of Google Fonts here — Inter is already self-hosted
+        by next/font (root layout) and served from this origin, so the print
+        view keeps a strict, third-party-free CSP (issue #186).
+      */}
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
         *, *::before, *::after { box-sizing: border-box; }
 
         body {


### PR DESCRIPTION
## Summary

Closes #186 — **security(frontend): enforce Content Security Policy headers in next.config**

Adds a strict-but-practical Content Security Policy via a `headers()` block in `next.config.mjs`. The app previously shipped with **no CSP**, meaning an XSS payload that slipped past React's escaping had no second line of defense. This is a global policy (not a per-page retrofit) and adds **no** third-party analytics/error-monitoring domains, per the issue's "Stop" section.

## Problem

`next.config.mjs` had no `headers()` block, so every response went out with no `Content-Security-Policy`. For a DeFi app that connects wallets and signs transactions, CSP is table stakes.

## Changes

### 1. CSP in `next.config.mjs` (`headers()` block)

Served on **all routes** (`source: '/(.*)'`):

```
default-src 'self';
script-src 'self' 'unsafe-inline';
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob:;
font-src 'self' data:;
connect-src 'self' <Soroban RPC> <Horizon> <Friendbot> <Supabase>;
object-src 'none';
base-uri 'self';
form-action 'self';
frame-ancestors 'none';
```

- **`default-src 'self'`** — everything not explicitly allowlisted stays same-origin only.
- **`connect-src`** covers exactly the endpoints the app talks to, built from the **same `NEXT_PUBLIC_*` env vars the app uses at runtime** (`src/lib/constants.ts`, `src/lib/horizon.ts`) with matching defaults:
  - Soroban RPC (`NEXT_PUBLIC_RPC_URL`, default `https://soroban-testnet.stellar.org`)
  - Horizon (`NEXT_PUBLIC_HORIZON_URL`, default `https://horizon-testnet.stellar.org`)
  - Friendbot (`https://friendbot.stellar.org`, testnet-only funding helper)
  - Supabase (`NEXT_PUBLIC_SUPABASE_URL` — only added when set)
  
  Existing deployments that only set env vars get a working policy with **zero CSP edits**.
- **`script-src 'self' 'unsafe-inline'` / `style-src 'self' 'unsafe-inline'`** — verified against the production build that the Next.js 14 App Router ships its RSC bootstrap as **inline `<script>` tags** (5 per page) and `next/font` injects inline `@font-face` styles, so `'unsafe-inline'` is required for the app to hydrate. **External script/style origins remain blocked** — the XSS protection this policy exists to provide — and `'unsafe-inline'` does not weaken `script-src 'self'` for external scripts. The nonce-based approach is the documented stricter upgrade path, but nonces must be generated per-request in middleware and cannot live in a static `headers()` block — out of scope for this issue ("Don't re-architect").
- **`frame-ancestors 'none'`** (clickjacking), **`base-uri 'self'`** (base-tag injection), **`object-src 'none'`** (plugin/object injection), **`form-action 'self'`**.

### 2. Removed the app's only third-party subresource (`InvoicePrintView.tsx`)

The invoice print view had a `@import url('https://fonts.googleapis.com/css2?...')` — the app's **only** external style origin. Inter is already self-hosted via `next/font` on every page (including the print page, through the root layout), so the `@import` was redundant. Removing it keeps the policy **third-party-free** (`default-src 'self'` stays true) and avoids needing a Google Fonts allowlist.

## Security rationale

| Directive | Value | Why |
|---|---|---|
| `default-src` | `'self'` | Nothing external unless explicitly listed |
| `script-src` | `'self' 'unsafe-inline'` | Blocks all external scripts; `'unsafe-inline'` required by Next's inline RSC bootstrap |
| `connect-src` | `'self'` + RPC/Horizon/Friendbot/Supabase | Only the API endpoints the app uses |
| `frame-ancestors` | `'none'` | Clickjacking protection |
| `object-src` | `'none'` | Blocks plugin/object-based XSS |
| `base-uri` | `'self'` | Blocks base-tag URL spoofing |

No analytics, error-monitoring, or any other third-party domain was added (per the issue's "Stop" section).

## Verification (all run locally)

1. **Production build succeeds** — `npm run build` with the CI env placeholders.
2. **Header is returned on every page** — `curl -I` against the production server (`next start`) confirms `Content-Security-Policy` on `/`, `/marketplace`, and `/dashboard` with the exact policy above.
3. **Zero console CSP violations** — loaded `/`, `/marketplace`, `/dashboard`, and the print route in headless Chrome with console logging enabled: **0** "Refused to…" / CSP-violation messages. The logging method itself was validated by loading a deliberately-violating test page, which produced the expected violation messages (so a violation would not have been missed).
4. **Full CI checks pass locally** — `npm run lint` (clean), `npm run type-check` (clean), `npm run build` (success). CI jobs that will run on this PR: Frontend / Lint & Type Check, Frontend / Build, Conventional Commits (message: `fix(frontend): enforce Content Security Policy headers in next.config`).

## Notes for reviewers

- **`curl -I` after deploy (Vercel):** the issue's DoD asks to verify the deployed header via `curl -I` — that final check happens after this PR merges and Vercel redeploys; the same header mechanism was verified locally with `next start` and is applied by the Next server on Vercel with no additional config.
- **`'unsafe-inline'` trade-off:** documented in-code and in the PR body. If the maintainers prefer the stricter nonce-based policy (generated in `middleware.ts`), that's a follow-up; the `headers()`-block location was kept because the issue's DoD explicitly requires the CSP block to ship in `next.config.mjs`.
- No changes to routes, components (other than the removed font `@import`), the wallet kit, or middleware logic.
