### PR TITLE
feat(sdk): local mock harness for frontend dev without testnet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,34 @@ npm install
 npm run dev
 ```
 
+### Frontend setup — offline demo mode (no testnet, no Supabase)
+
+For UI work you don't need testnet access, seeded accounts, or a Supabase
+project. The frontend ships an in-memory mock harness ([#177](https://github.com/Stellar-VaultLink/invofi/issues/177))
+that serves deterministic fixtures — invoices in every status, financing
+offers, position-token balances, protocol stats — and auto-connects a mock
+demo wallet:
+
+```bash
+cd invofi/apps/frontend
+npm install
+NEXT_PUBLIC_USE_MOCK=1 npm run dev
+```
+
+- **Only the mock flag is required.** No `.env.local`, Supabase keys, RPC URL,
+  or contract IDs are needed; the app runs fully offline.
+- On-chain calls route through `@invofi/sdk`'s `createMockClient`
+  (`apps/sdk/src/mock.ts`); Supabase reads/writes route through the in-memory
+  mock client in `apps/frontend/src/lib/mock.ts`.
+- With the flag set, `/dashboard`, `/marketplace`, and `/portfolio` render the
+  seeded data immediately — a visitor reaches a populated portfolio without
+  creating an account.
+- It is **UI development only**: there is no crypto, signing, or account
+  funding simulation, and state resets when the process restarts.
+
+To return to the real (testnet + Supabase) app, unset the flag and follow the
+[Frontend setup](#frontend-setup) instructions above.
+
 ### Contract setup
 
 Contracts live in the dedicated [invofi-contracts](https://github.com/Stellar-VaultLink/invofi-contracts) repo:

--- a/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
@@ -9,6 +9,8 @@ import {
   probeWalletNetwork,
 } from '@/lib/walletkit';
 import { APPROVED_WALLETS } from '@/lib/approved-wallets';
+import { isMockMode } from '@/lib/mock-mode';
+import { MOCK_WALLET_ADDRESS } from '@/lib/mock';
 import type { WalletState } from '@/types';
 
 interface WalletContextValue extends WalletState {
@@ -32,6 +34,10 @@ const WalletContext = createContext<WalletContextValue>({
 const EXPECTED_NETWORK = (
   process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet'
 ).toLowerCase();
+
+// Offline demo mode (#177): auto-connect a mock wallet so protected pages are
+// reachable without a browser extension or testnet access.
+const MOCK_MODE = isMockMode();
 
 function networkMismatchFor(walletNet: string | null): boolean {
   if (!walletNet) return false;
@@ -84,15 +90,26 @@ function persistLastWallet(walletId: string, publicKey: string): void {
 }
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const [isCheckingWallet, setIsCheckingWallet] = useState(true);
-  const [state, setState] = useState<WalletState>({
-    publicKey: null,
-    walletId: null,
-    isConnected: false,
-    isConnecting: false,
-    isInstalled: false,
-    networkMismatch: false,
-  });
+  const [isCheckingWallet, setIsCheckingWallet] = useState(!MOCK_MODE);
+  const [state, setState] = useState<WalletState>(
+    MOCK_MODE
+      ? {
+          publicKey: MOCK_WALLET_ADDRESS,
+          walletId: 'mock',
+          isConnected: true,
+          isConnecting: false,
+          isInstalled: true,
+          networkMismatch: false,
+        }
+      : {
+          publicKey: null,
+          walletId: null,
+          isConnected: false,
+          isConnecting: false,
+          isInstalled: false,
+          networkMismatch: false,
+        },
+  );
 
   /**
    * Attempts to restore a previously-granted wallet session (Freighter returns
@@ -128,6 +145,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (MOCK_MODE) return;
+
     initWalletKit();
 
     (async () => {
@@ -163,6 +182,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   }, [tryRestoreWallet]);
 
   const connect = useCallback(async (walletId: string): Promise<string> => {
+    if (MOCK_MODE) return MOCK_WALLET_ADDRESS;
     setState(s => ({ ...s, isConnecting: true }));
     try {
       StellarWalletsKit.setWallet(walletId);
@@ -192,6 +212,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const disconnect = useCallback(() => {
+    // The demo stays connected — there is no real wallet to disconnect.
+    if (MOCK_MODE) return;
     setActiveWallet(null);
     setState(s => ({
       ...s,

--- a/invofi/apps/frontend/src/lib/contract.ts
+++ b/invofi/apps/frontend/src/lib/contract.ts
@@ -3,7 +3,8 @@
 // single binding point: it wires the SDK to this app's env vars (contract IDs,
 // RPC/Horizon endpoints) and to the connected wallet's signer, then re-exports
 // the typed methods so components keep importing from '@/lib/contract'.
-import { Contract, Networks, createInvofiClient } from '@invofi/sdk';
+import { Contract, Networks, createInvofiClient, createMockClient } from '@invofi/sdk';
+import { isMockMode } from './mock-mode';
 import { signTransactionWithActiveWallet } from './walletkit';
 import { POSITION_TOKEN_ASSET } from './constants';
 
@@ -26,6 +27,9 @@ const NETWORK_PASSPHRASE = NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TE
 
 /** Returns true when all three contracts are configured and StrKey-valid. */
 export function isContractConfigured(): boolean {
+  // Offline demo mode (#177): the mock client is always "configured" — there
+  // are no contract ids to validate.
+  if (isMockMode()) return true;
   return [REGISTRY_ID, FINANCING_ID, REPAYMENT_ID].every(id => {
     if (!id) return false;
     try {
@@ -37,16 +41,18 @@ export function isContractConfigured(): boolean {
   });
 }
 
-const client = createInvofiClient({
-  rpcUrl: RPC_URL,
-  horizonUrl: HORIZON_URL,
-  networkPassphrase: NETWORK_PASSPHRASE,
-  registryId: REGISTRY_ID,
-  financingId: FINANCING_ID,
-  repaymentId: REPAYMENT_ID,
-  positionTokenAsset: POSITION_TOKEN_ASSET,
-  signTransaction: signTransactionWithActiveWallet,
-});
+const client = isMockMode()
+  ? createMockClient({ positionTokenAsset: POSITION_TOKEN_ASSET })
+  : createInvofiClient({
+      rpcUrl: RPC_URL,
+      horizonUrl: HORIZON_URL,
+      networkPassphrase: NETWORK_PASSPHRASE,
+      registryId: REGISTRY_ID,
+      financingId: FINANCING_ID,
+      repaymentId: REPAYMENT_ID,
+      positionTokenAsset: POSITION_TOKEN_ASSET,
+      signTransaction: signTransactionWithActiveWallet,
+    });
 
 export const {
   // Registry

--- a/invofi/apps/frontend/src/lib/horizon.ts
+++ b/invofi/apps/frontend/src/lib/horizon.ts
@@ -1,4 +1,6 @@
 import { Horizon } from '@stellar/stellar-sdk';
+import { isMockMode } from './mock-mode';
+import { mockXlmBalance } from './mock';
 
 const HORIZON_URL =
   process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
@@ -15,17 +17,22 @@ export interface AccountBalance {
 }
 
 export async function getAccountBalances(publicKey: string): Promise<AccountBalance[]> {
+  if (isMockMode()) {
+    return [{ asset_type: 'native', balance: mockXlmBalance() }];
+  }
   const account = await horizon().loadAccount(publicKey);
   return account.balances as AccountBalance[];
 }
 
 export async function getXlmBalance(publicKey: string): Promise<string> {
+  if (isMockMode()) return mockXlmBalance();
   const balances = await getAccountBalances(publicKey);
   const native = balances.find(b => b.asset_type === 'native');
   return native?.balance ?? '0';
 }
 
 export async function getUsdcBalance(publicKey: string): Promise<string> {
+  if (isMockMode()) return '0';
   const USDC_ISSUER = process.env.NEXT_PUBLIC_USDC_ISSUER ?? '';
   const balances = await getAccountBalances(publicKey);
   const usdc = balances.find(
@@ -46,6 +53,7 @@ export async function getRecentTransactions(
   publicKey: string,
   limit = 10,
 ): Promise<TxRecord[]> {
+  if (isMockMode()) return [];
   const response = await horizon()
     .transactions()
     .forAccount(publicKey)
@@ -69,6 +77,7 @@ export function explorerUrl(hash: string): string {
 
 /** Returns true if the account exists on the network (i.e. has been funded). */
 export async function accountExists(publicKey: string): Promise<boolean> {
+  if (isMockMode()) return true;
   try {
     await horizon().loadAccount(publicKey);
     return true;
@@ -82,6 +91,7 @@ export async function accountExists(publicKey: string): Promise<boolean> {
  * Only works on testnet — safe to call; does nothing on mainnet.
  */
 export async function fundAccountViaFriendbot(publicKey: string): Promise<void> {
+  if (isMockMode()) return;
   const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
   if (network === 'mainnet' || network === 'public') {
     throw new Error('Friendbot is only available on testnet.');

--- a/invofi/apps/frontend/src/lib/mock-mode.ts
+++ b/invofi/apps/frontend/src/lib/mock-mode.ts
@@ -1,0 +1,14 @@
+/**
+ * Offline demo-mode flag.
+ *
+ * The frontend runs fully offline (no Supabase, no Stellar RPC/Horizon) when
+ * `NEXT_PUBLIC_USE_MOCK=1` is set. Everything routes through the mock layers in
+ * `@/lib/mock` (data + auth), `@/lib/contract` (SDK MockClient), and
+ * `@/lib/horizon` (mock balances).
+ *
+ * Kept in its own tiny module so server code (middleware) can check the flag
+ * without pulling the heavier mock client into its bundle.
+ */
+export function isMockMode(): boolean {
+  return process.env.NEXT_PUBLIC_USE_MOCK === '1';
+}

--- a/invofi/apps/frontend/src/lib/mock.test.ts
+++ b/invofi/apps/frontend/src/lib/mock.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests — offline mock data + auth layer (#177)
+ *
+ * Verifies the in-memory Supabase stand-in returns the deterministic seed data
+ * through the same query-builder surface the app's hooks/pages already use.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockSupabaseClient, resetMockDb, MOCK_USER, MOCK_USER_ID } from './mock';
+
+beforeEach(() => resetMockDb());
+
+describe('mock auth', () => {
+  it('returns the seeded demo user from getUser()', async () => {
+    const { data } = await createMockSupabaseClient().auth.getUser();
+    expect(data.user!.id).toBe(MOCK_USER_ID);
+    expect(data.user!.email).toBe(MOCK_USER.email);
+  });
+
+  it('signs out without error (no-op in demo mode)', async () => {
+    const { error } = await createMockSupabaseClient().auth.signOut();
+    expect(error).toBeNull();
+  });
+});
+
+describe('mock query builder', () => {
+  it('lists pending invoices for the marketplace', async () => {
+    const client = createMockSupabaseClient();
+    const { data, error } = await client
+      .from('invoices')
+      .select('*')
+      .eq('status', 'Pending')
+      .order('created_at', { ascending: false });
+    expect(error).toBeNull();
+    expect(data).toHaveLength(5);
+    expect(data!.every(row => row.status === 'Pending')).toBe(true);
+  });
+
+  it('returns the demo lender seeded portfolio offers', async () => {
+    const client = createMockSupabaseClient();
+    const { data } = await client
+      .from('financing_offers')
+      .select('*')
+      .eq('lender_id', MOCK_USER_ID);
+    expect(data).toHaveLength(5);
+    expect(data!.every(row => row.lender_id === MOCK_USER_ID)).toBe(true);
+  });
+
+  it('fetches a single row with .single()', async () => {
+    const client = createMockSupabaseClient();
+    const { data, error } = await client.from('invoices').select('*').eq('id', 'inv_mock_p001').single();
+    expect(error).toBeNull();
+    expect(data.id).toBe('inv_mock_p001');
+    expect(data.amount).toBe(10_000n * 10_000_000n);
+  });
+
+  it('returns PGRST116 from .single() when no row matches', async () => {
+    const client = createMockSupabaseClient();
+    const { data, error } = await client.from('invoices').select('*').eq('id', 'missing').single();
+    expect(data).toBeNull();
+    expect((error as { code?: string }).code).toBe('PGRST116');
+  });
+
+  it('returns null from .maybeSingle() when no row matches', async () => {
+    const client = createMockSupabaseClient();
+    const { data, error } = await client.from('protocol_stats').select('*').eq('id', 999).maybeSingle();
+    expect(data).toBeNull();
+    expect(error).toBeNull();
+  });
+
+  it('resolves the invoices(originator) join for matching history', async () => {
+    const client = createMockSupabaseClient();
+    const { data } = await client
+      .from('financing_offers')
+      .select('status, invoices(originator)')
+      .in('status', ['Repaid', 'Defaulted', 'Financed']);
+    expect(data!.length).toBeGreaterThan(0);
+    const first = data![0] as { invoices: { originator: string } | { originator: string }[] };
+    const joined = Array.isArray(first.invoices) ? first.invoices[0] : first.invoices;
+    expect(joined.originator).toMatch(/^G[A-Z2-7]{55}$/);
+  });
+
+  it('inserts and reads back a new row', async () => {
+    const client = createMockSupabaseClient();
+    const { data: inserted } = await client
+      .from('invoices')
+      .insert({ id: 'inv_new_001', originator: MOCK_USER.user_metadata.wallet_address, status: 'Pending' })
+      .select()
+      .single();
+    expect(inserted.id).toBe('inv_new_001');
+    const { data: fetched } = await client.from('invoices').select('*').eq('id', 'inv_new_001').single();
+    expect(fetched.status).toBe('Pending');
+  });
+
+  it('updates a row in place', async () => {
+    const client = createMockSupabaseClient();
+    await client.from('invoices').update({ status: 'Cancelled' }).eq('id', 'inv_mock_p001');
+    const { data } = await client.from('invoices').select('*').eq('id', 'inv_mock_p001').single();
+    expect(data.status).toBe('Cancelled');
+  });
+});

--- a/invofi/apps/frontend/src/lib/mock.ts
+++ b/invofi/apps/frontend/src/lib/mock.ts
@@ -1,0 +1,512 @@
+/**
+ * Offline demo-mode data + auth layer (#177).
+ *
+ * When `NEXT_PUBLIC_USE_MOCK=1` the frontend must run with no Supabase project
+ * and no Stellar testnet access. This module provides:
+ *
+ *   1. Deterministic fixtures mirroring the Supabase tables the UI reads
+ *      (invoices, financing_offers, user_profiles, position_listings,
+ *      lender_preferences, protocol_stats) plus a mock authenticated user and
+ *      a mock wallet balance.
+ *   2. `createMockSupabaseClient()` — a minimal, in-memory implementation of
+ *      the small slice of the Supabase JS API this app uses (`.auth` +
+ *      `.from().select/eq/in/ilike/order/single/maybeSingle/insert/update/
+ *      upsert/delete`). It is returned by `createClient()` in mock mode so the
+ *      existing hooks/pages keep working unchanged.
+ *
+ * This is for UI development only — there is deliberately no crypto, no
+ * signing, and no persistence beyond the in-memory store.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Currency, FinancingOffer, Invoice, InvoiceStatus, OfferStatus } from '@/types';
+import type { UserProfile } from '@/types';
+import type { PositionListing } from '@/types';
+
+// Deterministic identities are owned by the SDK's MockClient so the two mock
+// layers agree on ids/addresses without duplication.
+import {
+  MOCK_WALLET_ADDRESS,
+  MOCK_BUSINESS_A,
+  MOCK_BUSINESS_B,
+  MOCK_BUSINESS_C,
+  MOCK_LENDER_B,
+  MOCK_POSITION_TOKEN_ID,
+} from '@invofi/sdk';
+
+export { MOCK_WALLET_ADDRESS, MOCK_POSITION_TOKEN_ID };
+
+/** Supabase user id the mock session reports. */
+export const MOCK_USER_ID = 'mock-user-demo';
+
+/** A small-but-plausible XLM balance the mock wallet reports (in XLM). */
+export const MOCK_XLM_BALANCE = '12500.0';
+
+const BASE = 10_000_000n;
+const xlm = (n: number): bigint => BigInt(n) * BASE;
+const days = (nowSecs: number, n: number): number => nowSecs + n * 86_400;
+const iso = (nowSecs: number, daysAgo: number): string =>
+  new Date((nowSecs - daysAgo * 86_400) * 1000).toISOString();
+
+// ── Mock user (Supabase `User`-shaped) ───────────────────────────────────────
+
+export const MOCK_USER = {
+  id: MOCK_USER_ID,
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'demo@invofi.mock',
+  phone: '',
+  email_confirmed_at: new Date().toISOString(),
+  confirmed_at: new Date().toISOString(),
+  last_sign_in_at: new Date().toISOString(),
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: {
+    display_name: 'Demo Lender',
+    role: 'lender',
+    wallet_address: MOCK_WALLET_ADDRESS,
+  },
+  identities: [],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  is_anonymous: false,
+};
+
+// ── Fixture builders (relative to a per-session `now` anchor) ────────────────
+
+interface MockInvoiceRow extends Invoice {
+  originator_id: string | null;
+  created_at: string;
+}
+
+interface MockOfferRow extends FinancingOffer {
+  lender_id: string | null;
+  created_at: string;
+}
+
+function seedInvoices(nowSecs: number): MockInvoiceRow[] {
+  const invoice = (
+    id: string,
+    originator: string,
+    amount: bigint,
+    currency: Currency,
+    dueDate: number,
+    status: InvoiceStatus,
+    createdDaysAgo: number,
+  ): MockInvoiceRow => ({
+    id,
+    originator,
+    originator_id: null, // external businesses — the demo user is a lender
+    amount,
+    currency,
+    due_date: dueDate,
+    status,
+    created_at: iso(nowSecs, createdDaysAgo),
+  });
+
+  return [
+    // Pending — marketplace inventory
+    invoice('inv_mock_p001', MOCK_BUSINESS_A, xlm(10_000), 'XLM', days(nowSecs, 30), 'Pending', 6),
+    invoice('inv_mock_p002', MOCK_BUSINESS_B, xlm(25_000), 'XLM', days(nowSecs, 45), 'Pending', 5),
+    invoice('inv_mock_p003', MOCK_BUSINESS_A, xlm(5_000), 'USDC', days(nowSecs, 20), 'Pending', 4),
+    invoice('inv_mock_p004', MOCK_BUSINESS_B, xlm(75_000), 'XLM', days(nowSecs, 60), 'Pending', 3),
+    invoice('inv_mock_p005', MOCK_BUSINESS_C, xlm(120_000), 'USDC', days(nowSecs, 90), 'Pending', 2),
+    // Financed
+    invoice('inv_mock_f001', MOCK_BUSINESS_A, xlm(40_000), 'XLM', days(nowSecs, 15), 'Financed', 14),
+    invoice('inv_mock_f002', MOCK_BUSINESS_B, xlm(18_000), 'USDC', days(nowSecs, 10), 'Financed', 12),
+    // Repaid
+    invoice('inv_mock_r001', MOCK_BUSINESS_A, xlm(8_000), 'XLM', days(nowSecs, -5), 'Repaid', 45),
+    invoice('inv_mock_r002', MOCK_BUSINESS_B, xlm(12_000), 'USDC', days(nowSecs, -20), 'Repaid', 40),
+    // Overdue
+    invoice('inv_mock_o001', MOCK_BUSINESS_A, xlm(15_000), 'XLM', days(nowSecs, -3), 'Overdue', 30),
+    // Cancelled
+    invoice('inv_mock_c001', MOCK_BUSINESS_B, xlm(6_000), 'XLM', days(nowSecs, 14), 'Cancelled', 18),
+    // Disputed
+    invoice('inv_mock_d001', MOCK_BUSINESS_A, xlm(22_000), 'USDC', days(nowSecs, 7), 'Disputed', 9),
+    // Defaulted
+    invoice('inv_mock_def001', MOCK_BUSINESS_B, xlm(9_000), 'XLM', days(nowSecs, -30), 'Defaulted', 60),
+  ];
+}
+
+function seedOffers(nowSecs: number): MockOfferRow[] {
+  const offer = (
+    id: string,
+    invoiceId: string,
+    lenderId: string | null,
+    lender: string,
+    amount: bigint,
+    currency: Currency,
+    interestRate: number,
+    durationDays: number,
+    status: OfferStatus,
+    amountRepaid: bigint,
+    fundedDaysAgo: number,
+    createdDaysAgo: number,
+  ): MockOfferRow => ({
+    id,
+    invoice_id: invoiceId,
+    lender_id: lenderId,
+    lender,
+    amount,
+    currency,
+    interest_rate: interestRate,
+    duration: durationDays * 86_400,
+    amount_repaid: amountRepaid,
+    status,
+    funded_at: fundedDaysAgo <= 0 ? 0 : nowSecs - fundedDaysAgo * 86_400,
+    created_at: iso(nowSecs, createdDaysAgo),
+  });
+
+  return [
+    // The demo lender's portfolio.
+    offer('off_mock_001', 'inv_mock_f001', MOCK_USER_ID, MOCK_WALLET_ADDRESS, xlm(40_000), 'XLM', 500, 30, 'Financed', xlm(10_000), 10, 14),
+    offer('off_mock_002', 'inv_mock_r001', MOCK_USER_ID, MOCK_WALLET_ADDRESS, xlm(8_000), 'XLM', 450, 45, 'Repaid', xlm(8_360), 40, 45),
+    offer('off_mock_003', 'inv_mock_p001', MOCK_USER_ID, MOCK_WALLET_ADDRESS, xlm(10_000), 'XLM', 500, 30, 'Pending', 0n, 0, 5),
+    offer('off_mock_004', 'inv_mock_o001', MOCK_USER_ID, MOCK_WALLET_ADDRESS, xlm(15_000), 'XLM', 600, 30, 'Accepted', 0n, 35, 30),
+    offer('off_mock_005', 'inv_mock_def001', MOCK_USER_ID, MOCK_WALLET_ADDRESS, xlm(9_000), 'XLM', 550, 30, 'Defaulted', 0n, 60, 60),
+    // Other lenders (invoice detail + matching history).
+    offer('off_mock_006', 'inv_mock_p002', 'mock-lender-b', MOCK_LENDER_B, xlm(25_000), 'XLM', 480, 30, 'Pending', 0n, 0, 4),
+    offer('off_mock_007', 'inv_mock_f002', 'mock-lender-b', MOCK_LENDER_B, xlm(18_000), 'USDC', 520, 30, 'Financed', xlm(6_000), 8, 11),
+    offer('off_mock_008', 'inv_mock_r002', 'mock-lender-b', MOCK_LENDER_B, xlm(12_000), 'USDC', 500, 30, 'Repaid', xlm(12_500), 35, 40),
+  ];
+}
+
+function seedProfiles(nowSecs: number): UserProfile[] {
+  return [
+    {
+      id: MOCK_USER_ID,
+      email: MOCK_USER.email,
+      role: 'lender',
+      display_name: 'Demo Lender',
+      wallet_address: MOCK_WALLET_ADDRESS,
+      created_at: iso(nowSecs, 90),
+    },
+  ];
+}
+
+function seedListings(nowSecs: number): PositionListing[] {
+  return [
+    {
+      id: 'listing_mock_001',
+      seller: MOCK_WALLET_ADDRESS,
+      seller_id: MOCK_USER_ID,
+      invoice_id: 'inv_mock_f001',
+      offer_id: 'off_mock_001',
+      token_amount: '10000.00',
+      asking_price: '10500.00',
+      price_currency: 'XLM',
+      status: 'Open',
+      note: 'Fully financed invoice, 30-day term remaining.',
+      created_at: iso(nowSecs, 2),
+    },
+    {
+      id: 'listing_mock_002',
+      seller: MOCK_LENDER_B,
+      seller_id: 'mock-lender-b',
+      invoice_id: 'inv_mock_f002',
+      offer_id: 'off_mock_007',
+      token_amount: '6000.00',
+      asking_price: '6300.00',
+      price_currency: 'USDC',
+      status: 'Open',
+      note: 'USDC position, partial repayment already received.',
+      created_at: iso(nowSecs, 1),
+    },
+  ];
+}
+
+function seedStats(nowSecs: number): Record<string, unknown>[] {
+  return [
+    {
+      id: 1,
+      total_invoices: 13,
+      total_offers: 8,
+      invoices_financed: 2,
+      total_volume: (250_000n * BASE).toString(),
+      total_repaid: (20_000n * BASE).toString(),
+      repayment_rate: 0.42,
+      active_lenders: 3,
+      defaulted_invoices: 1,
+      insurance_pool: (50_000n * BASE).toString(),
+      last_ledger: 2_147_483,
+      updated_at: iso(nowSecs, 0),
+    },
+  ];
+}
+
+// ── In-memory store ───────────────────────────────────────────────────────────
+
+type MockRow = Record<string, unknown>;
+
+let tables: Record<string, MockRow[]> | null = null;
+
+function getTables(): Record<string, MockRow[]> {
+  if (tables) return tables;
+  const nowSecs = Math.floor(Date.now() / 1000);
+  tables = {
+    invoices: seedInvoices(nowSecs) as unknown as MockRow[],
+    financing_offers: seedOffers(nowSecs) as unknown as MockRow[],
+    user_profiles: seedProfiles(nowSecs) as unknown as MockRow[],
+    position_listings: seedListings(nowSecs) as unknown as MockRow[],
+    lender_preferences: [],
+    protocol_stats: seedStats(nowSecs),
+  };
+  return tables;
+}
+
+/** Resets the mock store to its seeded state (used by tests / dev tooling). */
+export function resetMockDb(): void {
+  tables = null;
+}
+
+// ── Minimal query builder ─────────────────────────────────────────────────────
+
+const PGRST116 = {
+  code: 'PGRST116',
+  details: 'The result contains 0 rows',
+  hint: null,
+  message: 'JSON object requested, multiple (or no) rows returned',
+};
+
+type Comparator = (a: MockRow, b: MockRow) => number;
+
+function compareValues(a: unknown, b: unknown): number {
+  if (a === b) return 0;
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  if (typeof a === 'bigint' && typeof b === 'bigint') return a < b ? -1 : a > b ? 1 : 0;
+  const sa = String(a ?? '');
+  const sb = String(b ?? '');
+  return sa < sb ? -1 : sa > sb ? 1 : 0;
+}
+
+/** Attach a joined `invoices` relation when a select requests one. */
+function applyJoins(row: MockRow, selectStr: string): MockRow {
+  if (!selectStr || selectStr === '*') return row;
+  if (!row.invoice_id) return row;
+  const out: MockRow = { ...row };
+  const related = getTables().invoices.find(i => i.id === row.invoice_id);
+  if (/invoices\(originator\)/.test(selectStr)) {
+    out.invoices = related ? { originator: related.originator } : null;
+  } else if (/invoices\(\*\)/.test(selectStr)) {
+    out.invoices = related ? [related] : [];
+  }
+  if (/invoice:invoices\(\*\)/.test(selectStr)) {
+    out.invoice = related ?? null;
+  }
+  return out;
+}
+
+type MockMutation =
+  | { kind: 'insert'; payload: MockRow | MockRow[] }
+  | { kind: 'update'; payload: MockRow }
+  | { kind: 'upsert'; payload: MockRow | MockRow[]; options?: { onConflict?: string } }
+  | { kind: 'delete' };
+
+class MockQueryBuilder {
+  private readonly table: string;
+  private filters: ((row: MockRow) => boolean)[] = [];
+  private sort: { col: string; ascending: boolean } | null = null;
+  private selectStr = '*';
+  private selectAfterMutation = false;
+  private mutation: MockMutation | null = null;
+
+  constructor(table: string) {
+    this.table = table;
+  }
+
+  select(columns = '*'): this {
+    this.selectStr = columns;
+    this.selectAfterMutation = true;
+    return this;
+  }
+
+  eq(column: string, value: unknown): this {
+    this.filters.push(row => row[column] === value);
+    return this;
+  }
+
+  in(column: string, values: unknown[]): this {
+    this.filters.push(row => values.includes(row[column]));
+    return this;
+  }
+
+  ilike(column: string, pattern: string): this {
+    const re = new RegExp(`^${pattern.replace(/[%]/g, '.*')}$`, 'i');
+    this.filters.push(row => typeof row[column] === 'string' && re.test(row[column] as string));
+    return this;
+  }
+
+  order(column: string, options?: { ascending?: boolean }): this {
+    this.sort = { col: column, ascending: options?.ascending ?? true };
+    return this;
+  }
+
+  insert(rows: MockRow | MockRow[]): this {
+    this.mutation = { kind: 'insert', payload: rows };
+    return this;
+  }
+
+  update(values: MockRow): this {
+    this.mutation = { kind: 'update', payload: values };
+    return this;
+  }
+
+  upsert(rows: MockRow | MockRow[], options?: { onConflict?: string }): this {
+    this.mutation = { kind: 'upsert', payload: rows, options };
+    return this;
+  }
+
+  delete(): this {
+    this.mutation = { kind: 'delete' };
+    return this;
+  }
+
+  // ── Terminal / thenable behaviour ─────────────────────────────────────────
+
+  single(): Promise<{ data: MockRow | null; error: unknown }> {
+    const rows = this.execute();
+    if (rows.length === 0) return Promise.resolve({ data: null, error: PGRST116 });
+    if (rows.length > 1) return Promise.resolve({ data: null, error: PGRST116 });
+    return Promise.resolve({ data: this.applyJoins(rows[0]), error: null });
+  }
+
+  maybeSingle(): Promise<{ data: MockRow | null; error: null }> {
+    const rows = this.execute();
+    return Promise.resolve({ data: rows[0] ? this.applyJoins(rows[0]) : null, error: null });
+  }
+
+  then<TResult1 = { data: MockRow[] | null; error: null }, TResult2 = never>(
+    onfulfilled?: (value: { data: MockRow[] | null; error: null }) => TResult1 | PromiseLike<TResult1>,
+    onrejected?: (reason: unknown) => TResult2 | PromiseLike<TResult2>,
+  ): Promise<TResult1 | TResult2> {
+    let result: { data: MockRow[] | null; error: null };
+    if (this.mutation) {
+      const affected = this.execute();
+      // insert/update/upsert/delete without a following `.select()` → null data
+      result = this.selectAfterMutation
+        ? { data: affected.map(r => this.applyJoins(r)), error: null }
+        : { data: null, error: null };
+    } else {
+      result = { data: this.execute().map(r => this.applyJoins(r)), error: null };
+    }
+    return Promise.resolve(result).then(onfulfilled, onrejected);
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────────────
+
+  private applyJoins(row: MockRow): MockRow {
+    return applyJoins(row, this.selectStr);
+  }
+
+  /** Applies a pending mutation once (idempotent) and returns affected rows. */
+  private execute(): MockRow[] {
+    if (this.mutation) {
+      const affected = this.applyMutation(this.mutation);
+      this.mutation = null;
+      return affected;
+    }
+    return this.readRows();
+  }
+
+  private applyMutation(mutation: MockMutation): MockRow[] {
+    const store = getTables();
+    const rows = (store[this.table] ??= []);
+
+    switch (mutation.kind) {
+      case 'insert': {
+        const input = (Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload]) as MockRow[];
+        return input.map(row => {
+          const withId = { id: row.id ?? `${this.table}_${Math.random().toString(36).slice(2, 10)}`, ...row };
+          rows.push(withId);
+          return withId;
+        });
+      }
+      case 'update': {
+        const matched = rows.filter(row => this.filters.every(f => f(row)));
+        return matched.map(row => {
+          Object.assign(row, mutation.payload);
+          return row;
+        });
+      }
+      case 'upsert': {
+        const input = (Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload]) as MockRow[];
+        const key = mutation.options?.onConflict ?? 'id';
+        return input.map(row => {
+          const existing = rows.find(r => r[key] === row[key]);
+          if (existing) {
+            Object.assign(existing, row);
+            return existing;
+          }
+          rows.push({ ...row });
+          return row;
+        });
+      }
+      case 'delete': {
+        const matched = rows.filter(row => this.filters.every(f => f(row)));
+        const matchSet = new Set(matched);
+        store[this.table] = rows.filter(row => !matchSet.has(row));
+        return matched;
+      }
+    }
+  }
+
+  private readRows(): MockRow[] {
+    const store = getTables();
+    let rows = (store[this.table] ?? []).filter(row => this.filters.every(f => f(row)));
+    if (this.sort) {
+      const { col, ascending } = this.sort;
+      rows = [...rows].sort((a, b) => {
+        const cmp = compareValues(a[col], b[col]);
+        return ascending ? cmp : -cmp;
+      });
+    }
+    return rows;
+  }
+}
+
+// ── Mock Supabase client ──────────────────────────────────────────────────────
+
+function mockAuth() {
+  let user = { ...MOCK_USER, user_metadata: { ...MOCK_USER.user_metadata } };
+  const session = { user, access_token: 'mock-access-token', expires_at: Math.floor(Date.now() / 1000) + 3600 };
+
+  return {
+    async getUser(): Promise<{ data: { user: typeof user }; error: null }> {
+      return { data: { user }, error: null };
+    },
+    async getSession(): Promise<{ data: { session: typeof session }; error: null }> {
+      return { data: { session }, error: null };
+    },
+    async signOut(): Promise<{ error: null }> {
+      return { error: null };
+    },
+    async signInWithPassword(): Promise<{ data: { user: typeof user; session: typeof session }; error: null }> {
+      return { data: { user, session }, error: null };
+    },
+    async signInAnonymously(): Promise<{ data: { user: typeof user }; error: null }> {
+      return { data: { user }, error: null };
+    },
+    async signUp(): Promise<{ data: { user: typeof user; session: typeof session }; error: null }> {
+      return { data: { user, session }, error: null };
+    },
+    async updateUser(attrs: { data?: Record<string, unknown> }): Promise<{ data: { user: typeof user }; error: null }> {
+      if (attrs.data) user = { ...user, user_metadata: { ...user.user_metadata, ...attrs.data } };
+      return { data: { user }, error: null };
+    },
+    onAuthStateChange(): { data: { subscription: { unsubscribe: () => void } }; error: null } {
+      return { data: { subscription: { unsubscribe: () => undefined } }, error: null };
+    },
+  };
+}
+
+export function createMockSupabaseClient(): SupabaseClient {
+  const client = {
+    auth: mockAuth(),
+    from: (table: string) => new MockQueryBuilder(table),
+  };
+  return client as unknown as SupabaseClient;
+}
+
+/** Convenience for the mock XLM balance read in `@/lib/horizon`. */
+export function mockXlmBalance(): string {
+  return MOCK_XLM_BALANCE;
+}

--- a/invofi/apps/frontend/src/utils/supabase/client.ts
+++ b/invofi/apps/frontend/src/utils/supabase/client.ts
@@ -1,11 +1,20 @@
 import { createBrowserClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { isMockMode } from '@/lib/mock-mode';
+import { createMockSupabaseClient } from '@/lib/mock';
 
 // Deferred client factory to avoid build-time initialization during static generation
 let clientInstance: SupabaseClient | null = null;
 
 export function createClient(): SupabaseClient {
   if (!clientInstance) {
+    // Offline demo mode (#177): serve the in-memory mock client so no
+    // Supabase project or env vars are required.
+    if (isMockMode()) {
+      clientInstance = createMockSupabaseClient();
+      return clientInstance;
+    }
+
     // Only read environment variables when actually creating the client
     const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
     // Supabase renamed "anon key" to "publishable key" in late 2024.

--- a/invofi/apps/frontend/src/utils/supabase/middleware.ts
+++ b/invofi/apps/frontend/src/utils/supabase/middleware.ts
@@ -6,6 +6,12 @@ type CookieToSet = Parameters<NonNullable<CookieMethodsServer['setAll']>>[0][num
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
+  // Offline demo mode (#177): no Supabase project configured — skip the
+  // session refresh entirely so `npm run dev` works with no env vars.
+  if (process.env.NEXT_PUBLIC_USE_MOCK === '1') {
+    return supabaseResponse;
+  }
+
   // Lazy initialization of Supabase client to avoid build-time errors during static generation
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const key = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)!;

--- a/invofi/apps/sdk/src/index.ts
+++ b/invofi/apps/sdk/src/index.ts
@@ -11,6 +11,25 @@ export { createInvofiClient, type InvofiClient, SdkValidationError, ErrorCode } 
 export type { InvofiClientConfig } from './config';
 export type { Currency, FinancingOffer, Invoice, InvoiceStatus, OfferStatus } from './types';
 
+// ── Offline mock client (#177) ──────────────────────────────────────────────
+// `createMockClient` is a drop-in replacement for `createInvofiClient` backed
+// by in-memory state — no RPC, Horizon, wallet, or testnet required. It is for
+// UI development only (no crypto/signing simulation). Deterministic fixtures
+// cover every invoice status, offers, and position-token balances.
+export {
+  createMockClient,
+  type MockClient,
+  type MockClientOptions,
+  // Deterministic mock identities + fixtures (shared with the frontend mock).
+  MOCK_WALLET_ADDRESS,
+  MOCK_BUSINESS_A,
+  MOCK_BUSINESS_B,
+  MOCK_BUSINESS_C,
+  MOCK_LENDER_B,
+  MOCK_POSITION_TOKEN_ID,
+  MOCK_POSITION_BALANCE,
+} from './mock';
+
 // Validation helpers re-exported for consumers who want to pre-validate
 // before calling SDK methods (e.g. form-level validation in the frontend).
 export { validate, type ErrorCode as ValidationErrorCode } from './validation';

--- a/invofi/apps/sdk/src/mock.ts
+++ b/invofi/apps/sdk/src/mock.ts
@@ -1,0 +1,361 @@
+// ── MockClient — in-memory client for offline UI development (#177) ─────────
+//
+// `createMockClient` returns an object with the exact same method surface as
+// `createInvofiClient` (`InvofiClient`) but backed by in-memory state instead
+// of Soroban RPC/Horizon. It is intended for frontend development only — there
+// is deliberately no crypto/signing simulation, no account funding, and no
+// network access. Fixtures are deterministic: the same invoice/offer IDs,
+// amounts and statuses on every instantiation.
+//
+// Validation is shared with the real client (imported from `./validation`), so
+// a caller cannot tell the two apart from their error behaviour — only that
+// the mock never performs any IO.
+
+import type { InvofiClient } from './client';
+import type { Currency, FinancingOffer, Invoice } from './types';
+import {
+  validateStellarAddress,
+  validatePositiveI128,
+  validateInterestRate,
+  validateDuration,
+  validateFutureTimestamp,
+  validateSymbolId,
+  validateCurrency,
+} from './validation';
+
+// ── Deterministic identities ────────────────────────────────────────────────
+// Mock-only public keys. They pass the SDK's Stellar address format validation
+// (`G…` 56 base-32 chars) but correspond to no real accounts.
+
+/** The connected "demo wallet" — used as the default signer/owner. */
+export const MOCK_WALLET_ADDRESS = 'GCHVSUK5XKL44CSZ3WGI2W2OZCC7SXZMM5B34TCOQ2YNEGPNP3BLOVMT';
+
+/** A couple of other businesses/lenders so marketplace data isn't self-referential. */
+export const MOCK_BUSINESS_A = 'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
+export const MOCK_BUSINESS_B = 'GBDDLOWR6YUEEYUKFKS6ISTCLBQKDPUXAOVJMNJYAACT6UYQGEKYEVZR';
+export const MOCK_BUSINESS_C = `G${'C'.repeat(55)}`;
+export const MOCK_LENDER_B = `G${'L'.repeat(55)}`;
+
+/** Position-token contract id the mock reports (a valid `C…` contract address). */
+export const MOCK_POSITION_TOKEN_ID = 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7';
+
+/** 1 XLM / USDC base unit in stroops — mirrors the protocol's 7-decimal convention. */
+const BASE = 10_000_000n;
+const xlm = (n: number | bigint): bigint => BigInt(n) * BASE;
+
+// Timestamps are computed relative to a single process-start anchor so the
+// fixture *set* is stable within a session while Overdue/Defaulted invoices
+// stay genuinely past-due and Pending ones stay in the future.
+const NOW = Math.floor(Date.now() / 1000);
+const days = (n: number): number => NOW + n * 86_400;
+
+/** Seed balances (stroops) for the demo wallet so position-token reads are non-zero. */
+export const MOCK_POSITION_BALANCE = xlm(55_000);
+
+export interface MockClientOptions {
+  /**
+   * Accepted for parity with the real client's config; the mock ignores it
+   * (trustlines are simulated, not resolved against Horizon).
+   */
+  positionTokenAsset?: string;
+  /** Optional override for the position-token contract id returned by `getPositionTokenId`. */
+  positionTokenId?: string;
+  /** Optional override for the token decimals returned by `getTokenDecimals`. */
+  tokenDecimals?: number;
+  /** Optional override for the demo wallet's starting token balance (stroops). */
+  positionBalance?: bigint;
+}
+
+// ── Deterministic fixtures ───────────────────────────────────────────────────
+
+function seedInvoices(): Invoice[] {
+  const at = (id: string, originator: string, amount: bigint, currency: Currency, dueDate: number, status: Invoice['status'], createdDaysAgo: number): Invoice => ({
+    id,
+    originator,
+    amount,
+    currency,
+    due_date: dueDate,
+    status,
+    created_at: new Date((NOW - createdDaysAgo * 86_400) * 1000).toISOString(),
+  });
+
+  return [
+    // Pending — visible in the marketplace
+    at('inv_mock_p001', MOCK_BUSINESS_A, xlm(10_000), 'XLM', days(30), 'Pending', 6),
+    at('inv_mock_p002', MOCK_BUSINESS_B, xlm(25_000), 'XLM', days(45), 'Pending', 5),
+    at('inv_mock_p003', MOCK_BUSINESS_A, xlm(5_000), 'USDC', days(20), 'Pending', 4),
+    at('inv_mock_p004', MOCK_BUSINESS_B, xlm(75_000), 'XLM', days(60), 'Pending', 3),
+    at('inv_mock_p005', MOCK_BUSINESS_C, xlm(120_000), 'USDC', days(90), 'Pending', 2),
+    // Financed
+    at('inv_mock_f001', MOCK_BUSINESS_A, xlm(40_000), 'XLM', days(15), 'Financed', 14),
+    at('inv_mock_f002', MOCK_BUSINESS_B, xlm(18_000), 'USDC', days(10), 'Financed', 12),
+    // Repaid
+    at('inv_mock_r001', MOCK_BUSINESS_A, xlm(8_000), 'XLM', days(-5), 'Repaid', 45),
+    at('inv_mock_r002', MOCK_BUSINESS_B, xlm(12_000), 'USDC', days(-20), 'Repaid', 40),
+    // Overdue
+    at('inv_mock_o001', MOCK_BUSINESS_A, xlm(15_000), 'XLM', days(-3), 'Overdue', 30),
+    // Cancelled
+    at('inv_mock_c001', MOCK_BUSINESS_B, xlm(6_000), 'XLM', days(14), 'Cancelled', 18),
+    // Disputed
+    at('inv_mock_d001', MOCK_BUSINESS_A, xlm(22_000), 'USDC', days(7), 'Disputed', 9),
+    // Defaulted
+    at('inv_mock_def001', MOCK_BUSINESS_B, xlm(9_000), 'XLM', days(-30), 'Defaulted', 60),
+  ];
+}
+
+function seedOffers(): FinancingOffer[] {
+  const offer = (
+    id: string,
+    invoiceId: string,
+    lender: string,
+    amount: bigint,
+    currency: Currency,
+    interestRate: number,
+    durationDays: number,
+    status: FinancingOffer['status'],
+    amountRepaid: bigint,
+    fundedDaysAgo: number,
+  ): FinancingOffer => ({
+    id,
+    invoice_id: invoiceId,
+    lender,
+    amount,
+    currency,
+    interest_rate: interestRate,
+    duration: durationDays * 86_400,
+    amount_repaid: amountRepaid,
+    status,
+    funded_at: fundedDaysAgo <= 0 ? 0 : NOW - fundedDaysAgo * 86_400,
+  });
+
+  return [
+    // The demo wallet's own offers — these populate the portfolio.
+    offer('off_mock_001', 'inv_mock_f001', MOCK_WALLET_ADDRESS, xlm(40_000), 'XLM', 500, 30, 'Financed', xlm(10_000), 10),
+    offer('off_mock_002', 'inv_mock_r001', MOCK_WALLET_ADDRESS, xlm(8_000), 'XLM', 450, 45, 'Repaid', xlm(8_360), 40),
+    offer('off_mock_003', 'inv_mock_p001', MOCK_WALLET_ADDRESS, xlm(10_000), 'XLM', 500, 30, 'Pending', 0n, 0),
+    offer('off_mock_004', 'inv_mock_o001', MOCK_WALLET_ADDRESS, xlm(15_000), 'XLM', 600, 30, 'Accepted', 0n, 35),
+    offer('off_mock_005', 'inv_mock_def001', MOCK_WALLET_ADDRESS, xlm(9_000), 'XLM', 550, 30, 'Defaulted', 0n, 60),
+    // Offers from other lenders — visible on invoice detail + matching history.
+    offer('off_mock_006', 'inv_mock_p002', MOCK_LENDER_B, xlm(25_000), 'XLM', 480, 30, 'Pending', 0n, 0),
+    offer('off_mock_007', 'inv_mock_f002', MOCK_LENDER_B, xlm(18_000), 'USDC', 520, 30, 'Financed', xlm(6_000), 8),
+    offer('off_mock_008', 'inv_mock_r002', MOCK_LENDER_B, xlm(12_000), 'USDC', 500, 30, 'Repaid', xlm(12_500), 35),
+  ];
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+export function createMockClient(options: MockClientOptions = {}): InvofiClient {
+  const positionTokenId = options.positionTokenId ?? MOCK_POSITION_TOKEN_ID;
+  const tokenDecimals = options.tokenDecimals ?? 7;
+  const positionBalance = options.positionBalance ?? MOCK_POSITION_BALANCE;
+
+  // In-memory state. Each call to createMockClient gets a fresh copy of the
+  // fixtures, so tests (and dev sessions) start from the same seed every time.
+  const invoices = new Map<string, Invoice>(seedInvoices().map(i => [i.id, i]));
+  const offers = new Map<string, FinancingOffer>(seedOffers().map(o => [o.id, o]));
+  const balances = new Map<string, bigint>([[MOCK_WALLET_ADDRESS, positionBalance]]);
+  const trustlines = new Set<string>([MOCK_WALLET_ADDRESS]);
+
+  const requireInvoice = (id: string): Invoice => {
+    const invoice = invoices.get(id);
+    if (!invoice) throw new Error(`Invoice not found: ${id}`);
+    return invoice;
+  };
+
+  const requireOffer = (id: string): FinancingOffer => {
+    const offer = offers.get(id);
+    if (!offer) throw new Error(`Offer not found: ${id}`);
+    return offer;
+  };
+
+  const client: InvofiClient = {
+    // ── Registry ────────────────────────────────────────────────────────────
+    async registerInvoice(params, originatorAddress) {
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+      validateSymbolId(params.id, 'params.id');
+      validatePositiveI128(params.amount, 'params.amount');
+      validateCurrency(params.currency, 'params.currency');
+      validateFutureTimestamp(params.dueDate, 'params.dueDate');
+
+      if (invoices.has(params.id)) {
+        throw new Error(`Invoice already exists: ${params.id}`);
+      }
+      const invoice: Invoice = {
+        id: params.id,
+        originator: originatorAddress,
+        amount: params.amount,
+        currency: params.currency,
+        due_date: params.dueDate,
+        status: 'Pending',
+        created_at: new Date().toISOString(),
+      };
+      invoices.set(invoice.id, invoice);
+      return invoice;
+    },
+
+    getInvoice(id, sourceAccount) {
+      validateSymbolId(id, 'id');
+      if (sourceAccount !== undefined) validateStellarAddress(sourceAccount, 'sourceAccount');
+      // Resolve asynchronously so a missing invoice rejects (matching the real
+      // client's RPC path) while argument validation still throws synchronously.
+      return Promise.resolve().then(() => requireInvoice(id));
+    },
+
+    async cancelInvoice(invoiceId, originatorAddress) {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+      const invoice = requireInvoice(invoiceId);
+      if (invoice.originator !== originatorAddress) {
+        throw new Error('Only the invoice originator can cancel an invoice');
+      }
+      invoice.status = 'Cancelled';
+      return invoice;
+    },
+
+    // ── Financing ───────────────────────────────────────────────────────────
+    async createOffer(params, lenderAddress) {
+      validateStellarAddress(lenderAddress, 'lenderAddress');
+      validateSymbolId(params.offerId, 'params.offerId');
+      validateSymbolId(params.invoiceId, 'params.invoiceId');
+      validatePositiveI128(params.amount, 'params.amount');
+      validateCurrency(params.currency, 'params.currency');
+      validateInterestRate(params.interestRate, 'params.interestRate');
+      validateDuration(params.duration, 'params.duration');
+
+      if (offers.has(params.offerId)) {
+        throw new Error(`Offer already exists: ${params.offerId}`);
+      }
+      requireInvoice(params.invoiceId);
+      const offer: FinancingOffer = {
+        id: params.offerId,
+        invoice_id: params.invoiceId,
+        lender: lenderAddress,
+        amount: params.amount,
+        currency: params.currency,
+        interest_rate: params.interestRate,
+        duration: params.duration,
+        amount_repaid: 0n,
+        status: 'Pending',
+        funded_at: 0,
+      };
+      offers.set(offer.id, offer);
+      return offer;
+    },
+
+    getOffer(id, sourceAccount) {
+      validateSymbolId(id, 'id');
+      if (sourceAccount !== undefined) validateStellarAddress(sourceAccount, 'sourceAccount');
+      return Promise.resolve().then(() => requireOffer(id));
+    },
+
+    async acceptOffer(offerId, originatorAddress) {
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+      const offer = requireOffer(offerId);
+      const invoice = requireInvoice(offer.invoice_id);
+      if (invoice.originator !== originatorAddress) {
+        throw new Error('Only the invoice originator can accept an offer');
+      }
+      offer.status = 'Accepted';
+      offer.funded_at = Math.floor(Date.now() / 1000);
+      invoice.status = 'Financed';
+      return offer;
+    },
+
+    async rejectOffer(offerId, originatorAddress) {
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(originatorAddress, 'originatorAddress');
+      const offer = requireOffer(offerId);
+      offer.status = 'Rejected';
+      return offer;
+    },
+
+    // ── Repayment ───────────────────────────────────────────────────────────
+    async repayInvoice(invoiceId, offerId, repayerAddress, amount) {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(repayerAddress, 'repayerAddress');
+      validatePositiveI128(amount, 'amount');
+
+      const invoice = requireInvoice(invoiceId);
+      const offer = requireOffer(offerId);
+      if (offer.invoice_id !== invoiceId) {
+        throw new Error(`Offer ${offerId} does not finance invoice ${invoiceId}`);
+      }
+
+      offer.amount_repaid += amount;
+      const totalDue = offer.amount + (offer.amount * BigInt(offer.interest_rate)) / 10_000n;
+      const fullyRepaid = offer.amount_repaid >= totalDue;
+      offer.status = fullyRepaid ? 'Repaid' : 'Financed';
+      invoice.status = fullyRepaid ? 'Repaid' : 'Financed';
+      return invoice;
+    },
+
+    async markOverdue(invoiceId, callerAddress) {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateStellarAddress(callerAddress, 'callerAddress');
+      const invoice = requireInvoice(invoiceId);
+      invoice.status = 'Overdue';
+      return invoice;
+    },
+
+    async reclaimInvoice(invoiceId, offerId, lenderAddress) {
+      validateSymbolId(invoiceId, 'invoiceId');
+      validateSymbolId(offerId, 'offerId');
+      validateStellarAddress(lenderAddress, 'lenderAddress');
+      const offer = requireOffer(offerId);
+      if (offer.lender !== lenderAddress) {
+        throw new Error('Only the lender can reclaim an invoice');
+      }
+      offer.status = 'Defaulted';
+      return offer;
+    },
+
+    // ── Position tokens ─────────────────────────────────────────────────────
+    getPositionTokenId(sourceAccount) {
+      if (sourceAccount !== undefined) validateStellarAddress(sourceAccount, 'sourceAccount');
+      return Promise.resolve(positionTokenId);
+    },
+
+    getTokenBalance(tokenId, address) {
+      validateStellarAddress(tokenId, 'tokenId');
+      validateStellarAddress(address, 'address');
+      if (tokenId !== positionTokenId) return Promise.resolve(0n);
+      return Promise.resolve(balances.get(address) ?? 0n);
+    },
+
+    getTokenDecimals(tokenId) {
+      validateStellarAddress(tokenId, 'tokenId');
+      return Promise.resolve(tokenDecimals);
+    },
+
+    async transferPositionToken(tokenId, fromAddress, toAddress, amount) {
+      validateStellarAddress(tokenId, 'tokenId');
+      validateStellarAddress(fromAddress, 'fromAddress');
+      validateStellarAddress(toAddress, 'toAddress');
+      validatePositiveI128(amount, 'amount');
+
+      const fromBalance = balances.get(fromAddress) ?? 0n;
+      if (amount > fromBalance) {
+        throw new Error('Insufficient position-token balance');
+      }
+      balances.set(fromAddress, fromBalance - amount);
+      balances.set(toAddress, (balances.get(toAddress) ?? 0n) + amount);
+    },
+
+    // ── Trustlines ──────────────────────────────────────────────────────────
+    async hasPositionTrustline(address) {
+      validateStellarAddress(address, 'address');
+      return trustlines.has(address);
+    },
+
+    async addPositionTrustline(address) {
+      validateStellarAddress(address, 'address');
+      trustlines.add(address);
+    },
+  };
+
+  return client;
+}
+
+export type MockClient = InvofiClient;

--- a/invofi/apps/sdk/tests/mock.test.ts
+++ b/invofi/apps/sdk/tests/mock.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests — offline MockClient (#177)
+ *
+ * Verifies that `createMockClient` is a drop-in replacement for
+ * `createInvofiClient`: same method surface, same validation errors, but pure
+ * in-memory state with deterministic fixtures. No network calls are made.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createMockClient,
+  MOCK_WALLET_ADDRESS,
+  MOCK_BUSINESS_A,
+  MOCK_BUSINESS_B,
+  MOCK_POSITION_TOKEN_ID,
+  MOCK_POSITION_BALANCE,
+} from '../src/mock';
+import { SdkValidationError, ErrorCode } from '../src/validation';
+import type { Invoice, FinancingOffer } from '../src/types';
+
+const FUTURE_TS = Math.floor(Date.now() / 1000) + 365 * 24 * 3600;
+
+describe('createMockClient — deterministic fixtures', () => {
+  it('seeds the same invoices across independent client instances', async () => {
+    const a = createMockClient();
+    const b = createMockClient();
+
+    const invA = await a.getInvoice('inv_mock_p001');
+    const invB = await b.getInvoice('inv_mock_p001');
+
+    expect(invA).toEqual(invB);
+    expect(invA.amount).toEqual(10_000n * 10_000_000n);
+    expect(invA.status).toBe('Pending');
+  });
+
+  it('seeds an invoice in every protocol status', async () => {
+    const client = createMockClient();
+    const ids = [
+      'inv_mock_p001',   // Pending
+      'inv_mock_f001',   // Financed
+      'inv_mock_r001',   // Repaid
+      'inv_mock_o001',   // Overdue
+      'inv_mock_c001',   // Cancelled
+      'inv_mock_d001',   // Disputed
+      'inv_mock_def001', // Defaulted
+    ];
+    const statuses = new Set<string>();
+    for (const id of ids) statuses.add((await client.getInvoice(id)).status);
+    expect(statuses).toEqual(
+      new Set(['Pending', 'Financed', 'Repaid', 'Overdue', 'Cancelled', 'Disputed', 'Defaulted']),
+    );
+  });
+
+  it('seeds offers and a non-zero position-token balance for the demo wallet', async () => {
+    const client = createMockClient();
+    const offer = await client.getOffer('off_mock_001');
+    expect(offer.lender).toBe(MOCK_WALLET_ADDRESS);
+    expect(await client.getTokenBalance(MOCK_POSITION_TOKEN_ID, MOCK_WALLET_ADDRESS)).toBe(MOCK_POSITION_BALANCE);
+  });
+
+  it('starts each instance from a fresh seed (mutations do not leak)', async () => {
+    const a = createMockClient();
+    await a.cancelInvoice('inv_mock_p001', MOCK_BUSINESS_A);
+    const b = createMockClient();
+    expect((await b.getInvoice('inv_mock_p001')).status).toBe('Pending');
+  });
+});
+
+describe('createMockClient — read methods', () => {
+  it('getInvoice throws a clear error for an unknown id', async () => {
+    const client = createMockClient();
+    await expect(client.getInvoice('inv_mock_missing')).rejects.toThrow(/Invoice not found/);
+  });
+
+  it('getOffer throws a clear error for an unknown id', async () => {
+    const client = createMockClient();
+    await expect(client.getOffer('off_mock_missing')).rejects.toThrow(/Offer not found/);
+  });
+
+  it('getPositionTokenId returns the mock token id', async () => {
+    const client = createMockClient();
+    await expect(client.getPositionTokenId()).resolves.toBe(MOCK_POSITION_TOKEN_ID);
+  });
+
+  it('getTokenBalance returns 0 for an unknown address', async () => {
+    const client = createMockClient();
+    await expect(client.getTokenBalance(MOCK_POSITION_TOKEN_ID, MOCK_BUSINESS_A)).resolves.toBe(0n);
+  });
+
+  it('hasPositionTrustline is true for the seeded demo wallet', async () => {
+    const client = createMockClient();
+    await expect(client.hasPositionTrustline(MOCK_WALLET_ADDRESS)).resolves.toBe(true);
+    await expect(client.hasPositionTrustline(MOCK_BUSINESS_A)).resolves.toBe(false);
+  });
+});
+
+describe('createMockClient — state-changing methods', () => {
+  it('registerInvoice adds an invoice and rejects duplicates', async () => {
+    const client = createMockClient();
+    const params = { id: 'inv_new_001', amount: 5_000n, currency: 'XLM' as const, dueDate: FUTURE_TS };
+    const invoice = await client.registerInvoice(params, MOCK_BUSINESS_A);
+    expect(invoice.status).toBe('Pending');
+    expect(invoice.originator).toBe(MOCK_BUSINESS_A);
+    await expect(client.getInvoice('inv_new_001')).resolves.toEqual(invoice);
+    await expect(client.registerInvoice(params, MOCK_BUSINESS_A)).rejects.toThrow(/already exists/);
+  });
+
+  it('cancelInvoice only succeeds for the originator', async () => {
+    const client = createMockClient();
+    await expect(client.cancelInvoice('inv_mock_p001', MOCK_WALLET_ADDRESS)).rejects.toThrow(/originator/);
+    const cancelled = await client.cancelInvoice('inv_mock_p001', MOCK_BUSINESS_A);
+    expect(cancelled.status).toBe('Cancelled');
+  });
+
+  it('createOffer → acceptOffer transitions the invoice to Financed', async () => {
+    const client = createMockClient();
+    const offer = await client.createOffer(
+      { offerId: 'off_new_001', invoiceId: 'inv_mock_p002', amount: 25_000n, currency: 'XLM', interestRate: 500, duration: 86_400 },
+      MOCK_WALLET_ADDRESS,
+    );
+    expect(offer.status).toBe('Pending');
+    const accepted = await client.acceptOffer('off_new_001', MOCK_BUSINESS_B);
+    expect(accepted.status).toBe('Accepted');
+    expect((await client.getInvoice('inv_mock_p002')).status).toBe('Financed');
+  });
+
+  it('rejectOffer marks the offer Rejected', async () => {
+    const client = createMockClient();
+    const offer = await client.createOffer(
+      { offerId: 'off_new_002', invoiceId: 'inv_mock_p002', amount: 25_000n, currency: 'XLM', interestRate: 500, duration: 86_400 },
+      MOCK_WALLET_ADDRESS,
+    );
+    expect((await client.rejectOffer(offer.id, MOCK_BUSINESS_B)).status).toBe('Rejected');
+  });
+
+  it('partial repayment keeps the invoice Financed and tracks amount_repaid', async () => {
+    const client = createMockClient();
+    const invoice = await client.repayInvoice('inv_mock_f001', 'off_mock_001', MOCK_BUSINESS_A, 1_000n);
+    expect(invoice.status).toBe('Financed');
+    const offer = await client.getOffer('off_mock_001');
+    expect(offer.amount_repaid).toBe(10_000n * 10_000_000n + 1_000n);
+  });
+
+  it('full repayment flips the invoice and offer to Repaid', async () => {
+    const client = createMockClient();
+    const offer = await client.getOffer('off_mock_001');
+    const totalDue = offer.amount + (offer.amount * BigInt(offer.interest_rate)) / 10_000n;
+    const outstanding = totalDue - offer.amount_repaid;
+    const invoice = await client.repayInvoice('inv_mock_f001', 'off_mock_001', MOCK_BUSINESS_A, outstanding);
+    expect(invoice.status).toBe('Repaid');
+    expect((await client.getOffer('off_mock_001')).status).toBe('Repaid');
+  });
+
+  it('transferPositionToken moves balance and rejects overdrafts', async () => {
+    const client = createMockClient();
+    await client.transferPositionToken(MOCK_POSITION_TOKEN_ID, MOCK_WALLET_ADDRESS, MOCK_BUSINESS_A, 1_000n);
+    expect(await client.getTokenBalance(MOCK_POSITION_TOKEN_ID, MOCK_BUSINESS_A)).toBe(1_000n);
+    expect(await client.getTokenBalance(MOCK_POSITION_TOKEN_ID, MOCK_WALLET_ADDRESS)).toBe(MOCK_POSITION_BALANCE - 1_000n);
+    await expect(
+      client.transferPositionToken(MOCK_POSITION_TOKEN_ID, MOCK_BUSINESS_A, MOCK_WALLET_ADDRESS, 999_999n),
+    ).rejects.toThrow(/Insufficient/);
+  });
+
+  it('addPositionTrustline enables holding the position token', async () => {
+    const client = createMockClient();
+    await client.addPositionTrustline(MOCK_BUSINESS_A);
+    await expect(client.hasPositionTrustline(MOCK_BUSINESS_A)).resolves.toBe(true);
+  });
+});
+
+describe('createMockClient — validation parity', () => {
+  it('reuses the real SDK validators (same SdkValidationError contract)', async () => {
+    const client = createMockClient();
+    // getInvoice validates its id synchronously, exactly like the real client.
+    expect(() => client.getInvoice('')).toThrow(SdkValidationError);
+    await expect(
+      client.registerInvoice(
+        { id: 'inv_x', amount: 0n, currency: 'XLM', dueDate: FUTURE_TS },
+        MOCK_BUSINESS_A,
+      ),
+    ).rejects.toBeInstanceOf(SdkValidationError);
+  });
+
+  it('throws the expected error code for an invalid address', async () => {
+    const client = createMockClient();
+    try {
+      await client.getTokenBalance(MOCK_POSITION_TOKEN_ID, 'not-an-address');
+      expect.unreachable('expected SdkValidationError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SdkValidationError);
+      expect((err as SdkValidationError).code).toBe(ErrorCode.INVALID_ADDRESS);
+    }
+  });
+
+  it('returns the canonical SDK shapes (Invoice / FinancingOffer)', async () => {
+    const client = createMockClient();
+    const invoice: Invoice = await client.getInvoice('inv_mock_f001');
+    const offer: FinancingOffer = await client.getOffer('off_mock_001');
+    expect(typeof invoice.amount).toBe('bigint');
+    expect(typeof offer.amount).toBe('bigint');
+    expect(typeof offer.interest_rate).toBe('number');
+  });
+});


### PR DESCRIPTION
## What & why

Closes #177.

New contributors currently need testnet access, seeded accounts, and live contracts before they can write any UI code. This PR adds an offline mock harness so the frontend can run entirely without those dependencies.

## Changes

### SDK (`@invofi/sdk`)
- New `createMockClient()` in `apps/sdk/src/mock.ts` — an in-memory, drop-in replacement for `createInvofiClient` implementing the exact `InvofiClient` interface.
- Deterministic fixtures: invoices in every status (`Pending`, `Financed`, `Repaid`, `Overdue`, `Cancelled`, `Disputed`, `Defaulted`), financing offers, and position-token balances.
- Reuses the real client's validation module, so error behaviour (`SdkValidationError` / `ErrorCode`) is identical — only the IO is mocked.
- No crypto/signing simulation, per the issue's "Stop" scope.
- Exported from `apps/sdk/src/index.ts` alongside the shared mock identities/constants.
- Unit tests in `apps/sdk/tests/mock.test.ts` (20 tests).

### Frontend
- `NEXT_PUBLIC_USE_MOCK=1` makes `npm run dev` fully offline — no Supabase project, RPC/Horizon, or contract IDs required.
- `apps/frontend/src/lib/mock.ts` — deterministic mirror fixtures plus an in-memory mock Supabase client (`auth` + a query builder) so the existing hooks/pages keep working unchanged.
- `lib/contract.ts` wires `createMockClient` when the flag is set; `utils/supabase/client.ts` serves the mock client; the middleware skips session refresh; Horizon reads and the wallet provider return mock values / auto-connect a demo wallet.
- Unit tests in `apps/frontend/src/lib/mock.test.ts` (10 tests).

### Docs
- `CONTRIBUTING.md` documents the offline workflow.

## How to test

```bash
cd invofi/apps/frontend
npm install
NEXT_PUBLIC_USE_MOCK=1 npm run dev
```

Open `/portfolio`, `/marketplace`, and `/dashboard` — they render the seeded data immediately (a mock lender wallet is connected automatically, so a visitor reaches a populated portfolio without creating an account).

## Verification

- `cd invofi/apps/sdk && npm run type-check && npm test` — 202 tests pass.
- `cd invofi/apps/frontend && npm run type-check && npx vitest run` — 88 tests pass.
- Smoke-tested `NEXT_PUBLIC_USE_MOCK=1 npm run dev` — `/`, `/dashboard`, `/portfolio`, `/marketplace`, `/stats`, `/marketplace/positions`, `/auth/login`, and `/invoices/new` all return 200 with no server errors.

## Out of scope

- No realistic crypto/signing, account funding, or persistence — mock state resets on restart (UI development only).
- The "Try the demo" landing-page entry point belongs to #107, not this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline demo mode with deterministic sample data and a mock wallet.
  * Enabled UI development without testnet, wallet, or Supabase configuration.
  * Added simulated invoice, financing, repayment, balance, trustline, and portfolio interactions.
  * Mock mode automatically starts with a connected demo wallet and preserves state during the session.
  * Added setup instructions and guidance for returning to the standard application mode.

* **Tests**
  * Added coverage for mock authentication, queries, transactions, state updates, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->