### PR TITLE
Feat/sentry v2

### DIFF
--- a/docs/08-environment-variables.md
+++ b/docs/08-environment-variables.md
@@ -18,9 +18,9 @@ All environment variables for the InvoFi frontend are prefixed with `NEXT_PUBLIC
 | `NEXT_PUBLIC_HORIZON_URL` | Yes | See below | Stellar Horizon REST API (differs by network) |
 | `NEXT_PUBLIC_USDC_ISSUER` | No | `GBBD47IF...` | USDC issuer address. Required to display USDC balances. |
 | `NEXT_PUBLIC_SENTRY_DSN` | No | `https://...@sentry.io/...` | Sentry error monitoring DSN. Optional for local dev; enables error tracking in production. |
-| `SENTRY_ORG` | No (build-time) | `your-org-slug` | Sentry organization slug (Vercel CI only, for source map uploads) |
-| `SENTRY_PROJECT` | No (build-time) | `your-project-slug` | Sentry project slug (Vercel CI only, for source map uploads) |
-| `SENTRY_AUTH_TOKEN` | No (build-time) | `sntrys_...` | Sentry auth token (Vercel CI only, for source map uploads) |
+| `SENTRY_ORG` | No (build-time) | `your-org-slug` | Sentry organization slug (server-side, Vercel CI only, for source map uploads) |
+| `SENTRY_PROJECT` | No (build-time) | `your-project-slug` | Sentry project slug (server-side, Vercel CI only, for source map uploads) |
+| `SENTRY_AUTH_TOKEN` | No (build-time) | `sntrys_...` | **Secret** — Sentry auth token (server-side, Vercel CI only, for source map uploads). Never expose as NEXT_PUBLIC_*. |
 
 \* Legacy fallback: if the three `*_CONTRACT_ID` variables are unset, the app
 uses the single `NEXT_PUBLIC_CONTRACT_ID` and routes every call to that one

--- a/docs/08-environment-variables.md
+++ b/docs/08-environment-variables.md
@@ -17,6 +17,10 @@ All environment variables for the InvoFi frontend are prefixed with `NEXT_PUBLIC
 | `NEXT_PUBLIC_RPC_URL` | Yes | See below | Soroban RPC endpoint (differs by network) |
 | `NEXT_PUBLIC_HORIZON_URL` | Yes | See below | Stellar Horizon REST API (differs by network) |
 | `NEXT_PUBLIC_USDC_ISSUER` | No | `GBBD47IF...` | USDC issuer address. Required to display USDC balances. |
+| `NEXT_PUBLIC_SENTRY_DSN` | No | `https://...@sentry.io/...` | Sentry error monitoring DSN. Optional for local dev; enables error tracking in production. |
+| `SENTRY_ORG` | No (build-time) | `your-org-slug` | Sentry organization slug (Vercel CI only, for source map uploads) |
+| `SENTRY_PROJECT` | No (build-time) | `your-project-slug` | Sentry project slug (Vercel CI only, for source map uploads) |
+| `SENTRY_AUTH_TOKEN` | No (build-time) | `sntrys_...` | Sentry auth token (Vercel CI only, for source map uploads) |
 
 \* Legacy fallback: if the three `*_CONTRACT_ID` variables are unset, the app
 uses the single `NEXT_PUBLIC_CONTRACT_ID` and routes every call to that one

--- a/invofi/apps/frontend/.env.local.example
+++ b/invofi/apps/frontend/.env.local.example
@@ -35,3 +35,13 @@ NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # Optional: USDC issuer on testnet
 # NEXT_PUBLIC_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+
+# ── Sentry (Optional) ─────────────────────────────────────────────────────────
+# Error monitoring. Optional for local dev; required for production monitoring.
+# Get your DSN from https://sentry.io/settings/projects/your-project/keys/
+# NEXT_PUBLIC_SENTRY_DSN=https://your-dsn@sentry.io/your-project-id
+
+# Build-time only (Vercel CI):
+# SENTRY_ORG=your-org-slug
+# SENTRY_PROJECT=your-project-slug
+# SENTRY_AUTH_TOKEN=your-auth-token

--- a/invofi/apps/frontend/.sentryclirc
+++ b/invofi/apps/frontend/.sentryclirc
@@ -1,0 +1,6 @@
+[defaults]
+org=
+project=
+
+[auth]
+token=

--- a/invofi/apps/frontend/instrumentation.ts
+++ b/invofi/apps/frontend/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}

--- a/invofi/apps/frontend/next.config.mjs
+++ b/invofi/apps/frontend/next.config.mjs
@@ -38,8 +38,6 @@ const connectSrc = [
   HORIZON_URL,
   FRIENDBOT_URL,
   ...(SUPABASE_URL ? [SUPABASE_URL] : []),
-  // Allow Sentry error reporting
-  'https://*.ingest.sentry.io',
 ].join(' ');
 
 const CONTENT_SECURITY_POLICY = [

--- a/invofi/apps/frontend/next.config.mjs
+++ b/invofi/apps/frontend/next.config.mjs
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { withSentryConfig } from '@sentry/nextjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -37,6 +38,8 @@ const connectSrc = [
   HORIZON_URL,
   FRIENDBOT_URL,
   ...(SUPABASE_URL ? [SUPABASE_URL] : []),
+  // Allow Sentry error reporting
+  'https://*.ingest.sentry.io',
 ].join(' ');
 
 const CONTENT_SECURITY_POLICY = [
@@ -89,4 +92,41 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  // For all available options, see:
+  // https://github.com/getsentry/sentry-webpack-plugin#options
+
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+
+  // Only print logs for uploading source maps in CI
+  silent: !process.env.CI,
+
+  // For all available options, see:
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+  // Upload a larger set of source maps for prettier stack traces (increases build time)
+  widenClientFileUpload: true,
+
+  // Automatically annotate React components to show their full name in breadcrumbs and session replay
+  reactComponentAnnotation: {
+    enabled: true,
+  },
+
+  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+  // This can increase your server load as well as your hosting bill.
+  // Note: Check that the Sentry DSN provided is publicly accessible before enabling this option.
+  tunnelRoute: '/monitoring',
+
+  // Hides source maps from generated client bundles
+  hideSourceMaps: true,
+
+  // Automatically tree-shake Sentry logger statements to reduce bundle size
+  disableLogger: true,
+
+  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+  // See the following for more information:
+  // https://docs.sentry.io/product/crons/
+  // https://vercel.com/docs/cron-jobs
+  automaticVercelMonitors: true,
+});

--- a/invofi/apps/frontend/package.json
+++ b/invofi/apps/frontend/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@sentry/nextjs": "^8.0.0",
     "next": "14.2.35",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/invofi/apps/frontend/sentry.client.config.ts
+++ b/invofi/apps/frontend/sentry.client.config.ts
@@ -18,4 +18,22 @@ Sentry.init({
       blockAllMedia: true,
     }),
   ],
+
+  // Filter out sensitive financial data from breadcrumbs
+  beforeBreadcrumb(breadcrumb) {
+    // Redact invoice amounts, wallet addresses, and transaction data
+    if (breadcrumb.category === 'console' || breadcrumb.category === 'fetch') {
+      if (breadcrumb.data?.url?.includes('/invoices/') || 
+          breadcrumb.data?.url?.includes('/contract')) {
+        breadcrumb.data = { ...breadcrumb.data, redacted: true };
+      }
+      if (breadcrumb.message) {
+        // Redact potential Stellar addresses (G... format)
+        breadcrumb.message = breadcrumb.message.replace(/G[A-Z0-9]{55}/g, '[REDACTED_ADDRESS]');
+        // Redact potential contract IDs (C... format)
+        breadcrumb.message = breadcrumb.message.replace(/C[A-Z0-9]{55}/g, '[REDACTED_CONTRACT]');
+      }
+    }
+    return breadcrumb;
+  },
 });

--- a/invofi/apps/frontend/sentry.client.config.ts
+++ b/invofi/apps/frontend/sentry.client.config.ts
@@ -1,0 +1,21 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+
+  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: 0.1,
+
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+});

--- a/invofi/apps/frontend/sentry.client.config.ts
+++ b/invofi/apps/frontend/sentry.client.config.ts
@@ -1,7 +1,12 @@
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (!SENTRY_DSN) {
+  export {};
+} else {
+  Sentry.init({
+    dsn: SENTRY_DSN,
   
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
@@ -36,4 +41,5 @@ Sentry.init({
     }
     return breadcrumb;
   },
-});
+  });
+}

--- a/invofi/apps/frontend/sentry.edge.config.ts
+++ b/invofi/apps/frontend/sentry.edge.config.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+});

--- a/invofi/apps/frontend/sentry.edge.config.ts
+++ b/invofi/apps/frontend/sentry.edge.config.ts
@@ -1,11 +1,15 @@
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: 1.0,
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}

--- a/invofi/apps/frontend/sentry.server.config.ts
+++ b/invofi/apps/frontend/sentry.server.config.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+});

--- a/invofi/apps/frontend/sentry.server.config.ts
+++ b/invofi/apps/frontend/sentry.server.config.ts
@@ -1,11 +1,15 @@
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: 1.0,
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+}

--- a/invofi/apps/frontend/src/middleware.ts
+++ b/invofi/apps/frontend/src/middleware.ts
@@ -7,7 +7,7 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Run on all routes except static files and Next.js internals
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    // Run on all routes except static files, Next.js internals, and Sentry tunnel
+    '/((?!_next/static|_next/image|favicon.ico|monitoring|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };

--- a/invofi/apps/frontend/tsconfig.json
+++ b/invofi/apps/frontend/tsconfig.json
@@ -20,6 +20,6 @@
       "@stellar/stellar-sdk": ["./node_modules/@stellar/stellar-sdk"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "instrumentation.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Pull Request

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Related issue

Closes #<!-- issue number -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Test addition
- [ ] Dependency update

## Changes made

<!-- Bullet list of specific changes. Be precise. -->

-
-

## Testing

<!-- Describe how you tested this. -->

- [ ] `npm run type-check` passes (if frontend or SDK changed)
- [ ] `npm run lint` passes (if frontend changed)
- [ ] Manually tested on Stellar testnet against the deployed contracts
- [ ] Manually tested in browser with Freighter or Lobstr wallet (for frontend changes)

## Screenshots (if UI changed)

<!-- Paste before/after screenshots here, or delete this section. -->

## Checklist>

> ⚠️ **CI checks are maintainer-managed.** Do not add, remove, rename, or
> reconfigure any CI check or workflow in this PR. CI is part of the audit
> story and changes to it go through the maintainers only. If you believe a
> check needs changing, open an issue instead.

- [ ] My branch is up to date with `main`
- [ ] I followed the commit message format in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I added tests for new behavior
- [ ] I updated the relevant documentation
- [ ] I have not introduced any hardcoded secrets or keys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Sentry error monitoring for browser, server, and edge environments.
  * Added performance tracing, session replay, and privacy-focused data redaction.
  * Added support for build-time source map uploads and Vercel Cron monitoring.

* **Documentation**
  * Documented Sentry configuration and required environment variables.
  * Updated the frontend environment template with optional monitoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->