### PR TITLE
feat(sdk): enforce SDK/frontend parity with contract call lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run type-check
+      - run: node ../../../scripts/check-sdk-parity.js
 
   frontend-test:
     name: Frontend / Unit Tests

--- a/invofi/apps/sdk/README.md
+++ b/invofi/apps/sdk/README.md
@@ -20,6 +20,25 @@ share one implementation instead of each holding a private copy.
   client once (contract IDs + the active wallet signer) and re-exports the
   typed methods. No duplicate contract-call code remains in the frontend.
 
+## Contract–SDK Method Mapping
+
+| Contract Method | SDK Export |
+|---|---|
+| `register_invoice` | `registerInvoice` |
+| `get_invoice` | `getInvoice` |
+| `cancel_invoice` | `cancelInvoice` |
+| `create_offer` | `createOffer` |
+| `get_offer` | `getOffer` |
+| `accept_offer` | `acceptOffer` |
+| `reject_offer` | `rejectOffer` |
+| `repay_invoice` | `repayInvoice` |
+| `mark_overdue` | `markOverdue` |
+| `reclaim_invoice` | `reclaimInvoice` |
+| `get_position_token` | `getPositionTokenId` |
+| `balance` | `getTokenBalance` |
+| `decimals` | `getTokenDecimals` |
+| `transfer` | `transferPositionToken`
+
 ## Usage
 
 ```ts

--- a/scripts/check-sdk-parity.js
+++ b/scripts/check-sdk-parity.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+const FRONTEND_SRC_DIR = path.join(__dirname, '..', 'invofi', 'apps', 'frontend', 'src');
+const EXCLUDED_FILES = [
+  path.join(FRONTEND_SRC_DIR, 'lib', 'contract.ts')
+];
+
+const PARITY_REGEX = /contract\.invoke|createInvofiClient|new\s+Contract\b/;
+const EXCEPTION_COMMENT = '// sdk-parity-exception';
+
+function walkDir(dir, callback) {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  const files = fs.readdirSync(dir);
+  for (const f of files) {
+    const dirPath = path.join(dir, f);
+    const isDirectory = fs.statSync(dirPath).isDirectory();
+    if (isDirectory) {
+      walkDir(dirPath, callback);
+    } else {
+      callback(path.join(dir, f));
+    }
+  }
+}
+
+let hasError = false;
+
+walkDir(FRONTEND_SRC_DIR, (filePath) => {
+  if (!filePath.endsWith('.ts') && !filePath.endsWith('.tsx')) {
+    return;
+  }
+
+  // Normalize paths for comparison (Windows/Unix)
+  const isExcluded = EXCLUDED_FILES.some(ex => path.resolve(ex) === path.resolve(filePath));
+  if (isExcluded) {
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    if (PARITY_REGEX.test(line) && !line.includes(EXCEPTION_COMMENT)) {
+      console.error(`Error: SDK parity violation found at ${filePath}:${index + 1}`);
+      console.error(`  > ${line.trim()}`);
+      hasError = true;
+    }
+  });
+});
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('SDK parity check passed. No raw contract usage found in frontend.');
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Adds a CI-enforced parity check to ensure all frontend contract interactions go through the `@invofi/sdk` rather than calling contracts directly. Prevents duplication from creeping back in as features move fast.

## Related issue

Closes #141

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional changes)
- [x] Documentation update
- [ ] Test addition
- [ ] Dependency update

## Changes made

- Added `scripts/check-sdk-parity.js` — scans `apps/frontend/src` for raw `contract.invoke`, `new Contract`, and `createInvofiClient` usage outside `lib/contract.ts`; exits 1 on violations, 0 if clean
- Wired the script into the `frontend-lint-and-typecheck` job in `.github/workflows/ci.yml`
- Added "Contract–SDK Method Mapping" section to `apps/sdk/README.md` documenting the full contract method → SDK export table
- Lines with `// sdk-parity-exception` are ignored by the check for legitimate custom calls

## Testing

- Ran `node scripts/check-sdk-parity.js` on the current codebase — exits 0
- Manually injected `contract.invoke("test")` into `apps/frontend/src/types/index.ts` — script caught it at the correct file and line, exited 1
- Removed test line, re-ran — exits 0

- [ ] `npm run type-check` passes (if frontend or SDK changed)
- [ ] `npm run lint` passes (if frontend changed)
- [ ] Manually tested on Stellar testnet against the deployed contracts
- [ ] Manually tested in browser with Freighter or Lobstr wallet (for frontend changes)

## Screenshots (if UI changed)

N/A

## Checklist

- [ ] My branch is up to date with `main`
- [ ] I followed the commit message format in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I added tests for new behavior
- [ ] I updated the relevant documentation
- [ ] I have not introduced any hardcoded secrets or keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference mapping contract operations to their corresponding typed SDK methods.

* **Quality Improvements**
  * Added automated checks to identify direct contract usage outside approved areas.
  * Integrated the check into frontend lint and type-check validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->