### PR TITLE
feat(frontend): on-chain event timeline on invoice detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ mechanically from the git history.
 
 ### Added
 
+- **Invoice on-chain activity timeline** — the invoice detail page lists the
+  invoice's lifecycle events (registered, offers created/accepted, repayments,
+  marked overdue, disputes, defaults) newest-first, sourced from Soroban RPC
+  `getEvents` scoped to one invoice id. Each row shows a human-readable label,
+  raw event type, timestamp, ledger number, and a Stellar Expert tx link.
+  Data layer is shaped for a drop-in switch to the indexer events table (#95)
 - **Secondary-market position listings** — `/marketplace/positions`: lenders
   publish an ask (invoice reference, position size, asking price) and browse,
   filter, and sort everyone else's. Discovery only — no matching, custody, or

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ invofi/
 │           │   ├── common/           ConfirmDialog, StatsCard, StatsGrid,
 │           │   │                     StatusBadge, PageHeader, EmptyState
 │           │   ├── invoices/         InvoiceCard, InvoiceForm, InvoiceTable,
-│           │   │                     OfferList
+│           │   │                     OfferList, EventTimeline (on-chain audit trail)
 │           │   ├── layout/           Navbar (dark mode + a11y), Footer
 │           │   ├── marketplace/      MarketplaceCard, PositionListingCard, etc.
 │           │   ├── portfolio/        LivePortfolioProvider, ConnectionStatus,

--- a/docs/04-frontend.md
+++ b/docs/04-frontend.md
@@ -75,6 +75,17 @@ Shows the full state of one invoice.
 - **Offer list** (the `OfferList` component):
   - If the viewer is the invoice originator: shows Accept and Reject buttons on pending offers
   - If the viewer is a lender: shows a "Make Offer" form (only when invoice is Pending and viewer is not the originator)
+- **On-chain activity timeline** (the `EventTimeline` component):
+  - Lists this invoice's lifecycle events newest-first — registered, offers
+    created/accepted/rejected, repayments, marked overdue, disputes, defaults
+  - Sourced live from the Soroban RPC `getEvents`, scoped to this invoice id;
+    each row shows a human-readable label plus the raw event type, timestamp,
+    ledger number, and tx hash deep-linked to Stellar Expert
+  - Empty state explains that the RPC keeps only ~5 days of event history;
+    hidden entirely in offline demo mode or when no contracts are configured
+  - Data layer (`lib/invoiceEvents.ts`) returns an `InvoiceTimelineEntry[]`
+    shape designed to be re-sourced from the indexer events table later (#95)
+    without touching the hook or component
 
 ### Marketplace — `/marketplace`
 
@@ -162,6 +173,10 @@ Displays offers on an invoice. Handles:
 - Accept/reject buttons (for originators)
 - Calling the Soroban contract and updating Supabase on each action
 
+### `components/invoices/EventTimeline.tsx`
+
+The invoice's on-chain audit trail as a simple vertical timeline, newest first. Fetches this invoice's contract events from the Soroban RPC (`getEvents` via `lib/invoiceEvents.ts` + `hooks/useInvoiceEvents.ts`) and renders one row per lifecycle event: colored dot + icon by category, human-readable label with the raw event type chip, timestamp, ledger number, and a truncated tx hash linked to Stellar Expert. Fails soft (loading skeletons / quiet empty + error states) and returns null when no contracts are configured.
+
 ### `app/invoices/[id]/print/InvoicePrintView.tsx`
 
 Client-only print view for an individual invoice. Fetches the invoice and financing offers, renders a clean print-optimised layout, and automatically opens the browser print dialog once the data is ready.
@@ -180,7 +195,7 @@ Print route wrapper for the invoice. Uses a client-only dynamic import with SSR 
 
 ### `app/invoices/[id]/page.tsx`
 
-The invoice detail page. Adds a **Print / Export PDF** action that opens the dedicated print view in a new browser tab.
+The invoice detail page. Adds a **Print / Export PDF** action that opens the dedicated print view in a new browser tab, and renders the on-chain activity timeline (see `components/invoices/EventTimeline.tsx`) below the financing offers.
 
 ### `globals.css`
 

--- a/invofi/apps/frontend/e2e/fixtures.ts
+++ b/invofi/apps/frontend/e2e/fixtures.ts
@@ -298,6 +298,17 @@ export async function mockUserProfile(page: Page, walletAddress: string | null):
 
 // ── Soroban RPC mock (on-chain invoice read) ────────────────────────────────
 
+/** Fixture lifecycle events for SMOKE_INVOICE (event timeline, issue: on-chain activity). */
+export const SMOKE_EVENTS = [
+  { name: 'inv_reg', ledger: 4_999_000 },
+  { name: 'off_new', ledger: 4_999_100 },
+  { name: 'inv_rep', ledger: 4_999_200 },
+] as const;
+
+function smokeTxHash(index: number): string {
+  return `${'f0'.repeat(30)}${String(index).padStart(4, '0')}`;
+}
+
 /**
  * Builds the ScVal for an invoice exactly as the live contract returns it
  * (verified against testnet): a map of symbol-keyed fields with amount=i128,
@@ -359,6 +370,47 @@ export async function mockInvoiceRead(page: Page, invoice: OnChainInvoice): Prom
 }
 
 /**
+ * Stubs the RPC `getEvents` call the invoice-detail event timeline makes, so
+ * the timeline renders deterministic fixture entries instead of scanning live
+ * testnet. Non-getEvents requests fall through (to `mockInvoiceRead` or real
+ * testnet).
+ */
+export async function mockInvoiceEvents(page: Page): Promise<void> {
+  await page.route(`**${RPC_URL}/**`, async (route) => {
+    let method: unknown;
+    try {
+      method = (route.request().postDataJSON() as { method?: unknown } | null)?.method;
+    } catch {
+      return route.fallback();
+    }
+    if (method !== 'getEvents') return route.fallback();
+
+    const events = SMOKE_EVENTS.map((evt, i) => ({
+      id: `evt-smoke-${i}`,
+      type: 'contract',
+      ledger: evt.ledger,
+      ledgerClosedAt: `2026-08-1${i + 1}T12:00:00Z`,
+      contractId: 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7',
+      topic: [
+        nativeToScVal(evt.name, { type: 'symbol' }).toXDR('base64'),
+        nativeToScVal(SMOKE_INVOICE.id, { type: 'symbol' }).toXDR('base64'),
+      ],
+      value: nativeToScVal('').toXDR('base64'),
+      inSuccessfulContractCall: true,
+      txHash: smokeTxHash(i),
+    }));
+
+    return route.fulfill({
+      json: {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { events, latestLedger: 5_000_000, cursor: '' },
+      },
+    });
+  });
+}
+
+/**
  * One-call setup for the authenticated smoke flows: a signed-in Supabase
  * session plus the mirror and (optionally) on-chain mocks.
  */
@@ -370,5 +422,6 @@ export async function authenticate(
   await mockSupabaseMirror(page, options);
   if (options.invoice) {
     await mockInvoiceRead(page, options.invoice);
+    await mockInvoiceEvents(page);
   }
 }

--- a/invofi/apps/frontend/e2e/invoice-detail.spec.ts
+++ b/invofi/apps/frontend/e2e/invoice-detail.spec.ts
@@ -24,4 +24,22 @@ test.describe('invoice detail', () => {
       page.getByRole('heading', { name: /Financing Offers/ }),
     ).toBeVisible();
   });
+
+  test('renders the on-chain event timeline newest-first', async ({ page }) => {
+    await authenticate(page, { invoice: SMOKE_INVOICE });
+
+    await page.goto(`/invoices/${SMOKE_INVOICE.id}`);
+
+    await expect(
+      page.getByRole('heading', { name: /On-chain Activity/ }),
+    ).toBeVisible();
+
+    // Fixture entries (SMOKE_EVENTS) — labels + raw type chips + explorer links.
+    await expect(page.getByText('Invoice registered')).toBeVisible();
+    await expect(page.getByText('Offer created')).toBeVisible();
+    await expect(page.getByText('Repayment made')).toBeVisible();
+
+    const expertLinks = page.locator('a[href*="stellar.expert/explorer/testnet/tx/"]');
+    await expect(expertLinks).toHaveCount(3);
+  });
 });

--- a/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
@@ -11,6 +11,7 @@ import { AuthGuard } from '@/components/auth/AuthGuard';
 import { useWallet } from '@/components/auth/WalletProvider';
 import { OfferList } from '@/components/invoices/OfferList';
 import { MessagingPanel } from '@/components/invoices/MessagingPanel';
+import { EventTimeline } from '@/components/invoices/EventTimeline';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { getInvoice, cancelInvoice } from '@/lib/contract';
 import { supabase } from '@/lib/supabase';
@@ -186,6 +187,9 @@ export default function InvoiceDetailPage() {
 
             {/* Financing offers */}
             <OfferList invoiceId={id} invoice={invoice} onUpdate={setInvoice} />
+
+            {/* On-chain lifecycle events (audit trail, reverse-chronological) */}
+            <EventTimeline invoiceId={id} />
 
             {/* Private messaging — only shown when both parties are known */}
             {publicKey && counterpartyAddress && (

--- a/invofi/apps/frontend/src/components/invoices/EventTimeline.tsx
+++ b/invofi/apps/frontend/src/components/invoices/EventTimeline.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import {
+  AlertOctagon,
+  Award,
+  Banknote,
+  Ban,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  FileText,
+  Flag,
+  MinusCircle,
+  PencilLine,
+  PlusCircle,
+  RefreshCw,
+  Scale,
+  Shield,
+  ShieldOff,
+  Star,
+  LifeBuoy,
+  XCircle,
+  type LucideIcon,
+} from 'lucide-react';
+import { format } from 'date-fns';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useInvoiceEvents } from '@/hooks/useInvoiceEvents';
+import { invoiceEventsEnabled, type InvoiceTimelineEntry } from '@/lib/invoiceEvents';
+import { explorerTxUrl } from '@/lib/constants';
+import { formatAddress } from '@/lib/utils';
+
+const EVENT_ICONS: Record<string, LucideIcon> = {
+  inv_reg: FileText,
+  inv_amt: PencilLine,
+  inv_sts: RefreshCw,
+  inv_cxl: XCircle,
+  inv_ovd: Clock,
+  inv_def: AlertOctagon,
+  inv_dsp: Flag,
+  inv_rsl: Scale,
+  off_new: PlusCircle,
+  off_wdr: MinusCircle,
+  off_acc: CheckCircle2,
+  off_rej: Ban,
+  off_def: AlertOctagon,
+  pos_mint: Award,
+  inv_rep: Banknote,
+  pool_stk: Shield,
+  pool_un: ShieldOff,
+  pool_pay: LifeBuoy,
+  reputn: Star,
+};
+
+/**
+ * Per-event dot + icon colors. Both class names are written out in full
+ * (never constructed dynamically) so Tailwind's JIT scanner picks them up.
+ */
+const EVENT_STYLES: Record<string, { dot: string; icon: string }> = {
+  inv_reg: { dot: 'bg-blue-500', icon: 'text-blue-600' },
+  inv_amt: { dot: 'bg-blue-500', icon: 'text-blue-600' },
+  inv_sts: { dot: 'bg-blue-500', icon: 'text-blue-600' },
+  inv_cxl: { dot: 'bg-gray-400', icon: 'text-gray-500' },
+  inv_ovd: { dot: 'bg-amber-500', icon: 'text-amber-600' },
+  inv_def: { dot: 'bg-red-600', icon: 'text-red-600' },
+  inv_dsp: { dot: 'bg-amber-600', icon: 'text-amber-600' },
+  inv_rsl: { dot: 'bg-teal-600', icon: 'text-teal-600' },
+  off_new: { dot: 'bg-purple-600', icon: 'text-purple-600' },
+  off_wdr: { dot: 'bg-purple-400', icon: 'text-purple-500' },
+  off_acc: { dot: 'bg-green-600', icon: 'text-green-600' },
+  off_rej: { dot: 'bg-gray-400', icon: 'text-gray-500' },
+  off_def: { dot: 'bg-red-600', icon: 'text-red-600' },
+  pos_mint: { dot: 'bg-green-600', icon: 'text-green-600' },
+  inv_rep: { dot: 'bg-emerald-600', icon: 'text-emerald-600' },
+  pool_stk: { dot: 'bg-sky-600', icon: 'text-sky-600' },
+  pool_un: { dot: 'bg-sky-400', icon: 'text-sky-500' },
+  pool_pay: { dot: 'bg-emerald-600', icon: 'text-emerald-600' },
+  reputn: { dot: 'bg-indigo-500', icon: 'text-indigo-600' },
+};
+
+const FALLBACK_STYLE = { dot: 'bg-gray-400', icon: 'text-gray-500' };
+
+function EventRow({ entry }: { entry: InvoiceTimelineEntry }) {
+  const Icon = EVENT_ICONS[entry.type] ?? FileText;
+  const accent = EVENT_STYLES[entry.type] ?? FALLBACK_STYLE;
+
+  return (
+    <li className="relative pl-8 pb-5 last:pb-0">
+      <span
+        className={`absolute left-[-5px] top-1 flex h-2.5 w-2.5 items-center justify-center rounded-full ${accent.dot}`}
+        aria-hidden="true"
+      />
+      <div className="flex items-center gap-2">
+        <Icon className={`h-4 w-4 shrink-0 ${accent.icon}`} aria-hidden="true" />
+        <p className="text-sm font-medium text-gray-900">{entry.label}</p>
+        <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-gray-500">
+          {entry.type}
+        </span>
+      </div>
+      <p className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-500">
+        <span>{entry.occurredAt ? format(new Date(entry.occurredAt), 'MMM d, yyyy h:mm a') : '—'}</span>
+        <span aria-hidden="true">·</span>
+        <span>Ledger #{entry.ledger}</span>
+        {entry.txHash && (
+          <>
+            <span aria-hidden="true">·</span>
+            <a
+              href={explorerTxUrl(entry.txHash)}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 font-mono text-blue-600 hover:underline"
+              title={entry.txHash}
+            >
+              {formatAddress(entry.txHash)} <ExternalLink className="h-3 w-3" />
+            </a>
+          </>
+        )}
+      </p>
+    </li>
+  );
+}
+
+export function EventTimeline({ invoiceId }: { invoiceId: string }) {
+  const enabled = invoiceEventsEnabled();
+  const { entries, loading, error } = useInvoiceEvents(enabled ? invoiceId : undefined);
+
+  if (!enabled) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">On-chain Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading && (
+          <div className="space-y-4" data-testid="event-timeline-loading">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="flex items-start gap-3">
+                <div className="mt-1 h-2.5 w-2.5 animate-pulse rounded-full bg-gray-200" />
+                <div className="flex-1 space-y-1.5">
+                  <div className="h-3.5 w-40 animate-pulse rounded bg-gray-200" />
+                  <div className="h-3 w-64 max-w-full animate-pulse rounded bg-gray-100" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!loading && error && (
+          <p className="text-sm text-gray-500">Couldn&apos;t load on-chain activity right now.</p>
+        )}
+
+        {!loading && !error && entries.length === 0 && (
+          <div className="text-sm text-gray-500">
+            <p>No recent on-chain activity found for this invoice.</p>
+            <p className="mt-1 text-xs text-gray-400">
+              The Soroban RPC keeps only a few days of event history, so older invoices may show nothing here.
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && entries.length > 0 && (
+          <ol className="relative ml-[5px] border-l border-gray-200">
+            {entries.map((entry, i) => (
+              <EventRow key={`${entry.txHash}:${entry.type}:${entry.ledger}:${i}`} entry={entry} />
+            ))}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/invofi/apps/frontend/src/hooks/useInvoiceEvents.ts
+++ b/invofi/apps/frontend/src/hooks/useInvoiceEvents.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  fetchInvoiceEvents,
+  invoiceEventsEnabled,
+  type InvoiceTimelineEntry,
+} from '@/lib/invoiceEvents';
+
+interface UseInvoiceEventsReturn {
+  entries: InvoiceTimelineEntry[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Loads the on-chain lifecycle events of one invoice for the detail-page
+ * timeline. Fails soft: errors surface as a flag, entries stay empty.
+ */
+export function useInvoiceEvents(invoiceId: string | undefined): UseInvoiceEventsReturn {
+  const [entries, setEntries] = useState<InvoiceTimelineEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!invoiceId || !invoiceEventsEnabled()) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchInvoiceEvents(invoiceId)
+      .then(result => {
+        if (!cancelled) setEntries(result);
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [invoiceId]);
+
+  return { entries, loading, error };
+}

--- a/invofi/apps/frontend/src/lib/invoiceEvents.test.ts
+++ b/invofi/apps/frontend/src/lib/invoiceEvents.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import { nativeToScVal, rpc as SorobanRpc } from '@stellar/stellar-sdk';
+import type { ProtocolEventName } from '@invofi/sdk';
+import {
+  EVENT_LABELS,
+  invoiceIdScVal,
+  parseRetentionStart,
+  toTimelineEntries,
+} from './invoiceEvents';
+
+// TS checks this array against the ProtocolEventName union: an unknown or
+// renamed literal here is a compile error, keeping the label map honest.
+const ALL_EVENT_NAMES: ProtocolEventName[] = [
+  'inv_reg',
+  'inv_amt',
+  'inv_sts',
+  'inv_cxl',
+  'inv_ovd',
+  'inv_def',
+  'inv_dsp',
+  'inv_rsl',
+  'off_new',
+  'off_wdr',
+  'off_acc',
+  'off_rej',
+  'off_def',
+  'pos_mint',
+  'inv_rep',
+  'pool_stk',
+  'pool_un',
+  'pool_pay',
+  'reputn',
+];
+
+interface RawEventOptions {
+  name: string;
+  /** topic[1] — the event's subject id. */
+  subject?: string;
+  /** Decoded-native payload (re-encoded via nativeToScVal). */
+  value?: unknown;
+  ledger?: number;
+  txHash?: string;
+  /** RPC per-event id; null simulates its absence. */
+  id?: string | null;
+  occurredAt?: string;
+}
+
+function rawEvent(opts: RawEventOptions): SorobanRpc.Api.EventResponse {
+  const topic = [nativeToScVal(opts.name, { type: 'symbol' })];
+  if (opts.subject !== undefined) {
+    topic.push(nativeToScVal(opts.subject, { type: 'symbol' }));
+  }
+  return {
+    id: opts.id === undefined ? `evt-${opts.name}-${opts.ledger ?? 1}` : opts.id,
+    type: 'contract',
+    ledger: opts.ledger ?? 100,
+    ledgerClosedAt: opts.occurredAt ?? null,
+    contractId: 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7',
+    topic,
+    value: opts.value !== undefined ? nativeToScVal(opts.value) : nativeToScVal(''),
+    inSuccessfulContractCall: true,
+    txHash: opts.txHash ?? 'ab'.repeat(64),
+  } as unknown as SorobanRpc.Api.EventResponse;
+}
+
+describe('EVENT_LABELS', () => {
+  it('covers every protocol event name exactly once', () => {
+    expect(Object.keys(EVENT_LABELS).sort()).toEqual([...ALL_EVENT_NAMES].sort());
+  });
+
+  it('maps every label to a non-empty string', () => {
+    for (const name of ALL_EVENT_NAMES) {
+      expect(EVENT_LABELS[name], name).toBeTruthy();
+    }
+  });
+});
+
+describe('parseRetentionStart', () => {
+  it('extracts the oldest retained ledger from the RPC range error', () => {
+    expect(
+      parseRetentionStart(
+        'startLedger must be within the ledger range: 502341 - 601234',
+      ),
+    ).toBe(502341);
+  });
+
+  it('returns undefined for unrelated errors', () => {
+    expect(parseRetentionStart('connection refused')).toBeUndefined();
+    expect(parseRetentionStart('')).toBeUndefined();
+  });
+});
+
+describe('toTimelineEntries', () => {
+  it('keeps events whose subject id matches and maps label + fields', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({
+          name: 'inv_reg',
+          subject: 'inv_1',
+          ledger: 500,
+          occurredAt: '2026-08-01T00:00:00Z',
+          txHash: 'cd'.repeat(32),
+        }),
+      ],
+      'inv_1',
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      type: 'inv_reg',
+      label: 'Invoice registered',
+      ledger: 500,
+      occurredAt: '2026-08-01T00:00:00Z',
+      txHash: 'cd'.repeat(32),
+    });
+  });
+
+  it('matches map payloads carrying invoice_id when the subject is the offer id', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({
+          name: 'off_new',
+          subject: 'off_9',
+          value: { invoice_id: 'inv_1', lender: 'GA'.repeat(16), amount: 1000 },
+        }),
+      ],
+      'inv_1',
+    );
+    expect(entries.map(e => e.type)).toEqual(['off_new']);
+  });
+
+  it('matches array payloads whose first element is the invoice id', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({
+          name: 'off_acc',
+          subject: 'off_9',
+          value: ['inv_1', 'GA'.repeat(16), 1000],
+        }),
+      ],
+      'inv_1',
+    );
+    expect(entries.map(e => e.type)).toEqual(['off_acc']);
+  });
+
+  it('never treats inv_rep array payloads as invoice-scoped (first element is an offer id)', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({
+          name: 'inv_rep',
+          subject: 'off_9',
+          value: ['inv_1', 500, true],
+        }),
+      ],
+      'inv_1',
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  it('drops events belonging to other invoices and unknown event names', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({ name: 'inv_rep', subject: 'inv_other' }),
+        rawEvent({ name: 'mystery_evt', subject: 'inv_1' }),
+        rawEvent({ name: 'pool_stk', subject: 'GA'.repeat(16) }),
+      ],
+      'inv_1',
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  it('sorts newest-first regardless of input order', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({ name: 'inv_reg', subject: 'inv_1', ledger: 100 }),
+        rawEvent({ name: 'inv_rep', subject: 'inv_1', ledger: 300 }),
+        rawEvent({ name: 'off_acc', subject: 'inv_1', ledger: 200 }),
+      ],
+      'inv_1',
+    );
+    expect(entries.map(e => e.ledger)).toEqual([300, 200, 100]);
+    expect(entries.map(e => e.type)).toEqual(['inv_rep', 'off_acc', 'inv_reg']);
+  });
+
+  it('deduplicates identical RPC event ids but keeps distinct same-tx events', () => {
+    const entries = toTimelineEntries(
+      [
+        rawEvent({ name: 'inv_rep', subject: 'inv_1', ledger: 300, id: 'evt-a' }),
+        rawEvent({ name: 'inv_rep', subject: 'inv_1', ledger: 300, id: 'evt-a' }),
+        rawEvent({ name: 'inv_rep', subject: 'inv_1', ledger: 300, id: 'evt-b' }),
+        // No id available → composite fallback keys keep both rows.
+        rawEvent({ name: 'off_new', subject: 'inv_1', ledger: 150, id: null, txHash: 'tx1' }),
+        rawEvent({ name: 'off_rej', subject: 'inv_1', ledger: 150, id: null, txHash: 'tx1' }),
+      ],
+      'inv_1',
+    );
+    expect(entries).toHaveLength(4);
+  });
+
+  it('tolerates malformed topics and values without throwing', () => {
+    const broken = {
+      id: 'evt-x',
+      type: 'contract',
+      ledger: 400,
+      contractId: 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7',
+      topic: [],
+      value: {} as never,
+      txHash: 'ef'.repeat(32),
+    } as unknown as SorobanRpc.Api.EventResponse;
+
+    expect(() => toTimelineEntries([broken, rawEvent({ name: 'inv_ovd', subject: 'inv_1', value: 42 })], 'inv_1')).not.toThrow();
+    expect(toTimelineEntries([broken, rawEvent({ name: 'inv_ovd', subject: 'inv_1', value: 42 })], 'inv_1').map(e => e.type)).toEqual(['inv_ovd']);
+  });
+
+  it('defaults occurredAt to null when the RPC omits it', () => {
+    const entries = toTimelineEntries([rawEvent({ name: 'inv_cxl', subject: 'inv_1' })], 'inv_1');
+    expect(entries[0]?.occurredAt).toBeNull();
+  });
+});
+
+describe('invoiceIdScVal', () => {
+  it('round-trips an invoice id through the symbol ScVal used in topics', async () => {
+    const { scValToNative } = await import('@stellar/stellar-sdk');
+    expect(scValToNative(invoiceIdScVal('inv_smoke_demo'))).toBe('inv_smoke_demo');
+  });
+});

--- a/invofi/apps/frontend/src/lib/invoiceEvents.ts
+++ b/invofi/apps/frontend/src/lib/invoiceEvents.ts
@@ -1,0 +1,231 @@
+// ── Invoice on-chain event timeline (data layer) ─────────────────────────────
+// Fetches the lifecycle events of ONE invoice from the Soroban RPC
+// (`getEvents`) and shapes them for the detail-page timeline component.
+//
+// Source note: the RPC only retains ~5 days of event history, so older
+// invoices legitimately show an empty timeline. When the indexer exposes a
+// per-event table (issue #95), swap the internals of `fetchInvoiceEvents` for
+// a Supabase query returning the same `InvoiceTimelineEntry[]` shape — the
+// hook and component stay untouched.
+
+import {
+  nativeToScVal,
+  rpc as SorobanRpc,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+import type { ProtocolEventName } from '@invofi/sdk';
+import { isMockMode } from './mock-mode';
+import {
+  FINANCING_CONTRACT_ID,
+  REGISTRY_CONTRACT_ID,
+  REPAYMENT_CONTRACT_ID,
+  RPC_URL,
+} from './constants';
+
+/** One decoded, display-ready lifecycle event for an invoice. */
+export interface InvoiceTimelineEntry {
+  /** Raw protocol event name, e.g. `inv_rep`. */
+  type: ProtocolEventName;
+  /** Human-readable label, e.g. "Repayment made". */
+  label: string;
+  /** Ledger (block) sequence the event was emitted in. */
+  ledger: number;
+  /** ISO timestamp of the ledger close, when the RPC reports it. */
+  occurredAt: string | null;
+  /** Hash of the transaction that emitted the event. */
+  txHash: string;
+}
+
+// ── Human labels ─────────────────────────────────────────────────────────────
+
+export const EVENT_LABELS: Record<ProtocolEventName, string> = {
+  inv_reg: 'Invoice registered',
+  inv_amt: 'Invoice amount updated',
+  inv_sts: 'Invoice status updated',
+  inv_cxl: 'Invoice cancelled',
+  inv_ovd: 'Marked overdue',
+  inv_def: 'Invoice defaulted',
+  inv_dsp: 'Dispute raised',
+  inv_rsl: 'Dispute resolved',
+  off_new: 'Offer created',
+  off_wdr: 'Offer withdrawn',
+  off_acc: 'Offer accepted',
+  off_rej: 'Offer rejected',
+  off_def: 'Position defaulted (reclaimed)',
+  pos_mint: 'Position token minted',
+  inv_rep: 'Repayment made',
+  pool_stk: 'Insurance pool staked',
+  pool_un: 'Insurance pool unstaked',
+  pool_pay: 'Insurance payout',
+  reputn: 'Reputation recorded',
+};
+
+// ── Config guard ─────────────────────────────────────────────────────────────
+
+const TIMELINE_CONTRACT_IDS = [REGISTRY_CONTRACT_ID, FINANCING_CONTRACT_ID, REPAYMENT_CONTRACT_ID].filter(Boolean);
+
+/**
+ * True when the timeline can query real chain data — false in offline demo
+ * mode or when no contract IDs are configured (alpha mode).
+ */
+export function invoiceEventsEnabled(): boolean {
+  return !isMockMode() && TIMELINE_CONTRACT_IDS.length > 0;
+}
+
+// ── Ledger-range clamp (mirrors apps/indexer/src/chain.ts) ────────────────────
+
+const RANGE_RE = /startLedger must be within the ledger range: (\d+) - (\d+)/;
+
+/**
+ * Parse the RPC's out-of-range error to find its oldest retained ledger.
+ * Returns undefined when the message doesn't match.
+ */
+export function parseRetentionStart(errorMessage: string): number | undefined {
+  const m = RANGE_RE.exec(errorMessage);
+  return m ? Number(m[1]) : undefined;
+}
+
+// ── Decode + filter + sort (pure, unit-testable) ─────────────────────────────
+
+// Event types whose array payload starts with the invoice id (see the
+// Protocol Events table in @invofi/sdk events.ts). inv_rep's first element is
+// an OFFER id, so it must NOT appear here.
+const ARRAY_INVOICE_ID_FIRST = new Set<string>(['off_new', 'off_acc', 'off_rej', 'off_def', 'inv_def']);
+
+function decodeTopicString(topic: xdr.ScVal | undefined): string | null {
+  if (!topic) return null;
+  try {
+    const decoded = scValToNative(topic);
+    return typeof decoded === 'string' ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert raw RPC events into timeline entries scoped to one invoice.
+ *
+ * An event belongs to the invoice when either:
+ *  - topic[1] (the subject id) equals the invoice id, or
+ *  - the decoded payload carries the invoice id equal to it (offer-scoped
+ *    events may use the offer id as their subject). Payloads arrive either as
+ *    maps (`invoice_id` key) or as arrays whose first element is the invoice
+ *    id — only for event types where the contract documents that layout.
+ *
+ * Output is reverse-chronological (newest first) and deduplicated.
+ */
+export function toTimelineEntries(
+  rawEvents: SorobanRpc.Api.EventResponse[],
+  invoiceId: string,
+): InvoiceTimelineEntry[] {
+  const entries: InvoiceTimelineEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of rawEvents) {
+    const type = decodeTopicString(raw.topic?.[0]);
+    const subjectId = decodeTopicString(raw.topic?.[1]);
+    if (!type || !(type in EVENT_LABELS)) continue;
+
+    let payloadInvoiceId: string | null = null;
+    try {
+      const decoded = scValToNative(raw.value);
+      if (decoded && typeof decoded === 'object' && !Array.isArray(decoded)) {
+        const map = decoded as Record<string, unknown>;
+        const candidate = map['invoice_id'] ?? map['invoiceId'];
+        if (typeof candidate === 'string') payloadInvoiceId = candidate;
+      } else if (Array.isArray(decoded) && ARRAY_INVOICE_ID_FIRST.has(type)) {
+        const candidate = decoded[0];
+        if (typeof candidate === 'string') payloadInvoiceId = candidate;
+      }
+    } catch {
+      // Undecodable payload — subject match below still applies.
+    }
+
+    if (subjectId !== invoiceId && payloadInvoiceId !== invoiceId) continue;
+
+    // raw.id is the RPC's unique per-event id; fall back to a composite key
+    // so two identical-type events inside one tx are not collapsed.
+    const dedupeKey = raw.id ?? `${raw.txHash}:${type}:${subjectId ?? ''}:${entries.length}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    entries.push({
+      type: type as ProtocolEventName,
+      label: EVENT_LABELS[type as ProtocolEventName],
+      ledger: typeof raw.ledger === 'number' ? raw.ledger : parseInt(String(raw.ledger ?? '0'), 10),
+      occurredAt: raw.ledgerClosedAt ?? null,
+      txHash: raw.txHash ?? '',
+    });
+  }
+
+  return entries.sort((a, b) => b.ledger - a.ledger);
+}
+
+// ── RPC orchestration ────────────────────────────────────────────────────────
+
+// ~5 days of ledgers at ~5s each — matches typical getEvents retention; the
+// request is clamped server-side anyway via parseRetentionStart when out of range.
+const LEDGER_WINDOW = 86_400;
+const PAGE_LIMIT = 100;
+const MAX_PAGES = 20;
+
+const EVENT_FILTER = [{ type: 'contract' as const, contractIds: TIMELINE_CONTRACT_IDS }];
+
+interface PageParams {
+  startLedger?: number;
+  cursor?: string;
+}
+
+async function fetchPage({ startLedger, cursor }: PageParams): Promise<SorobanRpc.Api.GetEventsResponse> {
+  const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
+  // The SDK's GetEventsRequest union requires filters inside each variant and
+  // forbids combining startLedger with a cursor.
+  const request: SorobanRpc.Api.GetEventsRequest = cursor
+    ? { cursor, filters: EVENT_FILTER, limit: PAGE_LIMIT }
+    : { startLedger: startLedger ?? 1, filters: EVENT_FILTER, limit: PAGE_LIMIT };
+  return server.getEvents(request);
+}
+
+/**
+ * Fetch the recent on-chain lifecycle events of one invoice, newest first.
+ * Fails soft by design — callers treat any thrown error as "no activity".
+ */
+export async function fetchInvoiceEvents(invoiceId: string): Promise<InvoiceTimelineEntry[]> {
+  if (!invoiceId || !invoiceEventsEnabled()) return [];
+
+  const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
+  let startLedger = Math.max(1, (await server.getLatestLedger()).sequence - LEDGER_WINDOW);
+
+  const collected: SorobanRpc.Api.EventResponse[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    let response: SorobanRpc.Api.GetEventsResponse;
+    try {
+      response = await fetchPage(
+        cursor ? { cursor } : { startLedger },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const retentionStart = parseRetentionStart(message);
+      if (retentionStart !== undefined && !cursor) {
+        // Request predated retention — retry clamped to what the node keeps.
+        startLedger = retentionStart + 10;
+        continue;
+      }
+      throw err;
+    }
+
+    collected.push(...response.events);
+    cursor = response.cursor || undefined;
+    if (!cursor) break;
+  }
+
+  return toTimelineEntries(collected, invoiceId);
+}
+
+/** Build the symbol ScVal for an invoice id — exported for tests/fixtures. */
+export function invoiceIdScVal(invoiceId: string) {
+  return nativeToScVal(invoiceId, { type: 'symbol' });
+}


### PR DESCRIPTION

## Summary

Adds an on-chain event timeline to the invoice detail page: the invoice's full lifecycle audit trail (registered, offers created/accepted/rejected, repayments, marked overdue, disputes, defaults) is listed newest-first, sourced live from Soroban RPC contract events scoped to one invoice id.


## Related issue

Closes #121

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation update
- [x] Test addition
- [ ] Dependency update

## Changes made

- **`src/lib/invoiceEvents.ts`** (new) — data layer for one invoice's lifecycle events:
  - Fetches contract events via Soroban RPC `getEvents` across registry/financing/repayment contracts, paginated by cursor with retention-window clamping (same regex-clamp pattern as `apps/indexer/src/chain.ts`)
  - Scopes events to the invoice by subject id (`topic[1]`) or payload `invoice_id` (map and array payloads), covering both topic conventions used by offer-scoped events; `inv_rep` array payloads are explicitly excluded from invoice matching since their first element is an offer id
  - Exports `EVENT_LABELS` (human-readable labels for all 19 protocol event names) and an `InvoiceTimelineEntry[]` shape designed as a drop-in seam to re-source from the indexer events table later (#95)
- **`src/hooks/useInvoiceEvents.ts`** (new) — thin fetch hook; fails soft (error flag + empty entries)
- **`src/components/invoices/EventTimeline.tsx`** (new) — simple vertical timeline card ("On-chain Activity"): colored dot + icon per event category, human label with raw event type chip, timestamp, ledger number, truncated tx hash deep-linked to Stellar Expert (network-aware via `explorerTxUrl`). Loading skeletons / quiet empty state (explains the ~5-day RPC retention window) / error text. Returns null when no contracts are configured or in mock mode, so alpha mode stays clean
- **`src/app/invoices/[id]/page.tsx`** — renders `<EventTimeline>` below the financing offers
- **E2E** — deterministic `getEvents` RPC stub in `e2e/fixtures.ts` + new spec asserting timeline heading, entry labels, and Stellar Expert links (`invoice-detail.spec.ts`)
- **Unit tests** — `src/lib/invoiceEvents.test.ts`: 14 tests (label-map completeness vs the SDK's `ProtocolEventName` union, scoping rules, newest-first sort, dedupe, retention-clamp parser, malformed-input tolerance)
- **Docs** — `docs/04-frontend.md` (Invoice Detail section, component + page entries), `README.md` project structure, `CHANGELOG.md`


## Testing

<!-- Describe how you tested this. -->

- [x] `npm run type-check` passes (if frontend or SDK changed)
- [x] `npm run lint` passes (if frontend changed)
- [ ] Manually tested on Stellar testnet against the deployed contracts
- [ ] Manually tested in browser with Freighter or Lobstr wallet (for frontend changes)
- [x] Unit tests pass — `npx vitest run src/lib/invoiceEvents.test.ts` (14/14)

Note: this PR merges `origin/main` for a clean base; the SDK `batch()` type fixes that landed there (44ce3afa) resolved the pre-existing `tsc` errors unrelated to this work.


## Screenshots (if UI changed)

Nil

## Checklist>

> ⚠️ **CI checks are maintainer-managed.** Do not add, remove, rename, or
> reconfigure any CI check or workflow in this PR. CI is part of the audit
> story and changes to it go through the maintainers only. If you believe a
> check needs changing, open an issue instead.

- [x] My branch is up to date with `main`
- [x] I followed the commit message format in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I added tests for new behavior
- [x] I updated the relevant documentation
- [x] I have not introduced any hardcoded secrets or keys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-chain activity timeline to invoice detail pages.
  * Displays invoice lifecycle events with timestamps, ledger numbers, event details, and Stellar Expert transaction links.
  * Handles loading, empty, unavailable, and error states gracefully.

* **Documentation**
  * Updated project and frontend documentation to describe the invoice activity timeline and its behavior.

* **Tests**
  * Added coverage for event parsing, filtering, ordering, deduplication, and timeline display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->