### PR TITLE
fix(ci): prevent auto-merge approval 403 errors from failing the workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -147,13 +147,12 @@ jobs:
             2>/dev/null || true)
           for RUN in "${GATED[@]:-}"; do
             [ -n "${RUN}" ] || continue
-            if gh api -X POST \
-              "repos/${REPO}/actions/runs/${RUN}/approve" >/dev/null 2>&1; then
-              echo "  ✅ approved gated run ${RUN}"
-            else
+            gh api -X POST \
+              "repos/${REPO}/actions/runs/${RUN}/approve" >/dev/null 2>&1 && \
+              echo "  ✅ approved gated run ${RUN}" || \
               echo "  could not approve run ${RUN} (may already be approved)"
-            fi
           done
+          # Continue regardless of approval success
 
           # Build a per-check failure summary: annotations first (what the
           # checks UI shows), then error lines from the failed job's log.


### PR DESCRIPTION
## fix(ci): prevent auto-merge approval 403 errors from failing the workflow

### Problem

The auto-merge bot's approval loop (lines 148–156 of `.github/workflows/auto-merge.yml`) logs 403 errors like:

```
could not approve run {status: "403"} (may already be approved)
```

However, these 403 errors propagate through the script's error handling (due to `set -euo pipefail`) and cause the workflow to fail, even though the bot continues to function and merge PRs successfully.

### Root Cause

The `if-then-else` construct in the approval loop doesn't properly isolate the exit code under `set -euo pipefail`. When `gh api` returns a non-zero exit code (403), the conditional fails and the implicit exit code propagates.

### Fix

Replace `if-then-else` with `&& ... || ...` logical operators, which ensures the loop always exits with code 0 regardless of individual approval outcomes:

```bash
# Before (can propagate exit code 1):
if gh api -X POST ... >/dev/null 2>&1; then
  echo "  ✅ approved gated run ${RUN}"
else
  echo "  could not approve run ${RUN} (may already be approved)"
fi

# After (always exits 0):
gh api -X POST ... >/dev/null 2>&1 && \
  echo "  ✅ approved gated run ${RUN}" || \
  echo "  could not approve run ${RUN} (may already be approved)"
```

### Impact

- ✅ Workflow exits cleanly (code 0) even when 403 errors occur during approval
- ✅ PRs will merge successfully without false workflow failures
- ✅ Clear logging preserved for debugging approval issues
- ✅ No changes to functional behavior — the bot continues to work as intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the automated workflow for approving first-time contributions.
  * Preserved non-blocking behavior when approval attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->