### PR TITLE
fix: rate-limit auth endpoints against abuse

### DIFF
--- a/docs/05-authentication.md
+++ b/docs/05-authentication.md
@@ -168,6 +168,40 @@ export default function DashboardPage() {
 
 ---
 
+## Rate Limiting (roadmap v0.4)
+
+Auth and wallet-sign endpoints are rate-limited at the **Vercel middleware layer**
+(`src/middleware.ts`) using an in-memory, fixed-window token bucket per client IP
+(`src/lib/rate-limit.ts`). This throttles abuse *before* it reaches a Route Handler
+or the Supabase auth backend.
+
+**Throttled paths** (each gets its own independent per-IP bucket):
+
+| Path | Purpose |
+| --- | --- |
+| `POST /api/auth/sep10/challenge` | SEP-10 challenge issuance (wallet sign-in) |
+| `POST /api/auth/sep10/verify` | SEP-10 challenge verification (wallet sign-in) |
+| `/auth/login` | Email/password login page |
+| `/auth/register` | Email/password registration page |
+
+**Config** — the limits are defined as constants at the top of `src/middleware.ts`:
+
+| Constant | Default | Meaning |
+| --- | --- | --- |
+| `AUTH_RATE_LIMIT` | `10` | Max requests per IP per window |
+| `AUTH_RATE_LIMIT_WINDOW_MS` | `60_000` | Window size in ms (1 minute) |
+
+When a client exceeds the limit, the middleware returns `429 Too Many Requests`
+with a `Retry-After` header; the request never reaches the auth handler. The
+limiter is in-memory and per-instance, so on a multi-instance Vercel deployment
+the *effective* limit scales with instance count — an accepted tradeoff that still
+stops a single client from hammering an endpoint (see the note in `lib/rate-limit.ts`).
+
+Legitimate flows are unaffected: a normal login/registration or SEP-10 sign-in
+makes only a handful of requests per minute, well under the limit.
+
+---
+
 ## Security Notes
 
 - Supabase session tokens are managed by the `@supabase/ssr` client via cookies (`sameSite: 'lax'`, `httpOnly: false`) — readable by client-side JS, not `HttpOnly`. The browser client needs that access to track and refresh the session itself; this is Supabase's standard SSR cookie mechanism, not something this app opts out of.

--- a/invofi/apps/frontend/src/middleware.test.ts
+++ b/invofi/apps/frontend/src/middleware.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { __resetRateLimitsForTests } from '@/lib/rate-limit';
+
+// Mock the Supabase session refresh so the middleware test only exercises the
+// rate-limiting layer, not the Supabase client.
+vi.mock('@/utils/supabase/middleware', () => ({
+  updateSession: vi.fn(async (request: NextRequest) => NextResponse.next({ request })),
+}));
+
+import { middleware } from './middleware';
+import { updateSession } from '@/utils/supabase/middleware';
+
+const mockedUpdateSession = vi.mocked(updateSession);
+
+function makeRequest(path: string, ip = '203.0.113.5'): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip },
+  });
+}
+
+describe('middleware rate limiting', () => {
+  beforeEach(() => {
+    mockedUpdateSession.mockClear();
+  });
+
+  afterEach(() => {
+    __resetRateLimitsForTests();
+  });
+
+  it('allows legitimate auth requests through to the session refresh', async () => {
+    const request = makeRequest('/api/auth/sep10/challenge');
+    const response = await middleware(request);
+    expect(response.status).toBe(200);
+    expect(mockedUpdateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles a burst of requests to an auth endpoint with 429', async () => {
+    const request = makeRequest('/api/auth/sep10/challenge');
+    // 10 allowed, 11th blocked.
+    for (let i = 0; i < 10; i++) {
+      const res = await middleware(request);
+      expect(res.status).toBe(200);
+    }
+    const blocked = await middleware(request);
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+    // The blocked request never reached the session refresh.
+    expect(mockedUpdateSession).toHaveBeenCalledTimes(10);
+  });
+
+  it('throttles the login page path', async () => {
+    const request = makeRequest('/auth/login');
+    for (let i = 0; i < 10; i++) {
+      await middleware(request);
+    }
+    const blocked = await middleware(request);
+    expect(blocked.status).toBe(429);
+  });
+
+  it('throttles the register page path', async () => {
+    const request = makeRequest('/auth/register');
+    for (let i = 0; i < 10; i++) {
+      await middleware(request);
+    }
+    const blocked = await middleware(request);
+    expect(blocked.status).toBe(429);
+  });
+
+  it('tracks different IPs independently', async () => {
+    const requestA = makeRequest('/api/auth/sep10/verify', '203.0.113.5');
+    const requestB = makeRequest('/api/auth/sep10/verify', '198.51.100.7');
+    for (let i = 0; i < 10; i++) {
+      await middleware(requestA);
+      await middleware(requestB);
+    }
+    // Both are at the limit; the next from either is blocked.
+    expect((await middleware(requestA)).status).toBe(429);
+    expect((await middleware(requestB)).status).toBe(429);
+  });
+
+  it('does not rate-limit non-auth paths', async () => {
+    const request = makeRequest('/dashboard');
+    for (let i = 0; i < 25; i++) {
+      const res = await middleware(request);
+      expect(res.status).toBe(200);
+    }
+    expect(mockedUpdateSession).toHaveBeenCalledTimes(25);
+  });
+});

--- a/invofi/apps/frontend/src/middleware.test.ts
+++ b/invofi/apps/frontend/src/middleware.test.ts
@@ -5,7 +5,7 @@ import { __resetRateLimitsForTests } from '@/lib/rate-limit';
 // Mock the Supabase session refresh so the middleware test only exercises the
 // rate-limiting layer, not the Supabase client.
 vi.mock('@/utils/supabase/middleware', () => ({
-  updateSession: vi.fn(async (request: NextRequest) => NextResponse.next({ request })),
+  updateSession: vi.fn(async () => NextResponse.next()),
 }));
 
 import { middleware } from './middleware';

--- a/invofi/apps/frontend/src/middleware.ts
+++ b/invofi/apps/frontend/src/middleware.ts
@@ -1,7 +1,58 @@
-import { type NextRequest } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 import { updateSession } from '@/utils/supabase/middleware';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+
+/**
+ * Rate-limit config for auth and wallet-sign endpoints (roadmap v0.4).
+ *
+ * Applied at the Vercel middleware layer so abuse is throttled *before* it
+ * reaches a Route Handler or the Supabase auth backend. Uses the in-memory
+ * token-bucket limiter from `lib/rate-limit.ts` (fixed-window, per-IP).
+ *
+ * Tune via the constants below — there is intentionally no env-var indirection
+ * so the limits are visible and reviewable in one place.
+ */
+const AUTH_RATE_LIMIT = 10;
+const AUTH_RATE_LIMIT_WINDOW_MS = 60_000;
+
+/**
+ * Paths that are throttled. These cover both the SEP-10 wallet-sign endpoints
+ * (`/api/auth/sep10/*`) and the email/password auth pages (`/auth/login`,
+ * `/auth/register`) — the two surfaces where a burst of requests could be
+ * abused (credential stuffing, challenge spam, etc.).
+ */
+const RATE_LIMITED_PATHS = [
+  '/api/auth/sep10/challenge',
+  '/api/auth/sep10/verify',
+  '/auth/login',
+  '/auth/register',
+];
+
+function isRateLimitedPath(pathname: string): boolean {
+  return RATE_LIMITED_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
 
 export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (isRateLimitedPath(pathname)) {
+    const clientIp = getClientIp(request);
+    const rateLimit = checkRateLimit(`middleware:${pathname}:${clientIp}`, {
+      limit: AUTH_RATE_LIMIT,
+      windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
+    });
+    if (!rateLimit.allowed) {
+      console.warn(`Rate limit exceeded for ${pathname} from IP ${clientIp}`);
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(Math.ceil((rateLimit.resetAt - Date.now()) / 1000)) },
+        },
+      );
+    }
+  }
+
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary
Added rate limiting at the Vercel middleware layer for auth and wallet-sign endpoints (roadmap v0.4, issue #87).

Changes:
1. `invofi/apps/frontend/src/middleware.ts` — Added per-IP, in-memory fixed-window rate limiting (reusing the existing `checkRateLimit`/`getClientIp` from `lib/rate-limit.ts`) for the auth and wallet-sign paths: `/api/auth/sep10/challenge`, `/api/auth/sep10/verify`, `/auth/login`, `/auth/register`. Each path gets its own independent per-IP bucket (10 req/min). When throttled, the middleware returns `429 Too Many Requests` with a `Retry-After` header *before* the request reaches the Supabase session refresh or any Route Handler. Non-auth paths are unaffected.

2. `invofi/apps/frontend/src/middleware.test.ts` — New Vitest test (mocking the Supabase session refresh) verifying: legitimate auth requests pass through, bursts are throttled with 429, login/register pages are throttled, different IPs are tracked independently, and non-auth paths are not rate-limited.

3. `docs/05-authentication.md` — Added a "Rate Limiting (roadmap v0.4)" section documenting the throttled paths, the config constants (`AUTH_RATE_LIMIT`, `AUTH_RATE_LIMIT_WINDOW_MS`), the 429/Retry-After behavior, and the per-instance tradeoff.

## Changed files
- `docs/05-authentication.md`
- `invofi/apps/frontend/src/middleware.test.ts`
- `invofi/apps/frontend/src/middleware.ts`

## Test plan
Run the frontend unit tests: `cd invofi/apps/frontend && npm test` (or `npx vitest run`). This will execute the new `src/middleware.test.ts` plus the existing `src/lib/rate-limit.test.ts`. Also run lint/typecheck (`npm run lint`, `npm run typecheck`) to confirm the middleware and test compile cleanly.

This PR was created as a draft by the GrantFox issue solver. It will remain a
draft until repository CI passes.

Closes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate limiting for authentication, wallet sign-in, login, and registration requests.
  - Requests exceeding 10 per minute receive a `429 Too Many Requests` response with retry timing information.
  - Rate limits are applied independently per IP address.

- **Documentation**
  - Documented authentication and wallet sign-in rate-limiting behavior, including deployment considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->