### PR TITLE
feat(frontend): add CSV export of offers received (Closes #168)

### DIFF
--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Plus } from 'lucide-react';
+import { Loader2, Plus, Download } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -15,7 +15,8 @@ import { useWallet } from '@/components/auth/WalletProvider';
 import { createOffer, acceptOffer, rejectOffer, repayInvoice, markOverdue, reclaimInvoice } from '@/lib/contract';
 import { supabase } from '@/lib/supabase';
 import { formatAmount, interestRateLabel, durationLabel, generateOfferId, amountToStroops, toStroopsBigInt, OFFER_STATUS_COLORS } from '@/lib/utils';
-import { GRACE_PERIOD_SECS } from '@/lib/constants';
+import { toCsv, downloadCsv } from '@/lib/csv';
+import { GRACE_PERIOD_SECS, STROOPS_PER_XLM } from '@/lib/constants';
 import { useToast } from '@/components/ui/use-toast';
 import type { Currency, FinancingOffer, Invoice } from '@/types';
 
@@ -216,11 +217,43 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
     invoice.status === 'Overdue' && (offer.status === 'Accepted' || offer.status === 'Financed') && publicKey === offer.lender &&
     nowSecs >= invoice.due_date + GRACE_PERIOD_SECS;
 
+  const exportOffersCsv = () => {
+    if (offers.length === 0) return;
+    const rows = offers.map(o => ({
+      id: o.id,
+      lender: o.lender,
+      amount: `${Number(o.amount) / STROOPS_PER_XLM} ${o.currency}`,
+      interest_rate: o.interest_rate,
+      term_days: Math.round(o.duration / 86_400),
+      status: o.status,
+      created_at: (o as unknown as { created_at?: string }).created_at ?? '',
+    }));
+    const csv = toCsv(rows, [
+      { key: 'id', header: 'Offer ID' },
+      { key: 'lender', header: 'Lender' },
+      { key: 'amount', header: 'Amount' },
+      { key: 'interest_rate', header: 'Interest (bps)' },
+      { key: 'term_days', header: 'Term (days)' },
+      { key: 'status', header: 'Status' },
+      { key: 'created_at', header: 'Created Date' },
+    ]);
+    downloadCsv(`invofi-offers-${invoiceId}-${new Date().toISOString().slice(0, 10)}.csv`, csv);
+  };
+
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle className="text-base">Financing Offers ({offers.length})</CardTitle>
         <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={exportOffersCsv}
+            disabled={offers.length === 0}
+            title={offers.length === 0 ? 'No offers to export' : 'Export offers as CSV'}
+          >
+            <Download className="h-3 w-3 mr-1" /> Export
+          </Button>
           {canMarkOverdue && (
             <Button
               size="sm"


### PR DESCRIPTION
## Summary

Adds a CSV export of offers received on the invoice detail page, complementing the existing invoice CSV export (#98). Originators can analyse financing offers offline.

## Changes

- Added an **Export** button to the `OfferList` card header (invoice detail page)
- Reuses the existing `toCsv` / `downloadCsv` helpers in `apps/frontend/src/lib/csv.ts`
- Exports columns: **offer id, lender, amount, interest (bps), term (days), status, created date**
- Filename includes the invoice id and date: `invofi-offers-<invoiceId>-<yyyy-mm-dd>.csv`
- Button is **disabled** when the offer list is empty (no header-only file exported)

## Acceptance criteria

- [x] Export produces a valid CSV with the specified columns
- [x] Filename includes the invoice id and date
- [x] Empty offer lists show a disabled/empty state rather than exporting a header-only file

Closes #168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export for financing offers.
  * Exported files include column headers, formatted offer details, and a date-based filename.
  * The Export button is disabled when no offers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->