### PR TITLE
feat(frontend): wallet address copy + explorer link in navbar (Closes #162)

### DIFF
--- a/invofi/apps/frontend/src/components/auth/WalletButton.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletButton.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Loader2, Wallet, LogOut, Copy, Check, AlertTriangle } from 'lucide-react';
+import { Loader2, Wallet, LogOut, Copy, Check, ExternalLink, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useWallet } from './WalletProvider';
 import { WalletSelectDialog } from './WalletSelectDialog';
 import { formatAddress } from '@/lib/utils';
 import { useToast } from '@/components/ui/use-toast';
 import { getXlmBalance } from '@/lib/horizon';
+import { explorerAccountUrl } from '@/lib/constants';
 
 interface WalletButtonProps {
   onConnected?: (publicKey: string) => void;
@@ -52,9 +53,17 @@ export function WalletButton({ onConnected }: WalletButtonProps) {
     try {
       await navigator.clipboard.writeText(publicKey);
       setCopied(true);
+      toast({
+        title: 'Address copied',
+        description: 'Wallet address copied to clipboard.',
+      });
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // clipboard not available
+      toast({
+        title: 'Copy failed',
+        description: 'Could not copy wallet address to clipboard.',
+        variant: 'destructive',
+      });
     }
   };
 
@@ -68,25 +77,36 @@ export function WalletButton({ onConnected }: WalletButtonProps) {
           </div>
         )}
         <div className="flex items-center gap-2">
-          <button
-            onClick={handleCopy}
-            title={copied ? 'Copied!' : 'Click to copy full address'}
-            className="flex items-center gap-2 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg px-3 py-1.5 text-sm transition-colors hover:bg-green-100 dark:hover:bg-green-900"
-          >
-            <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
-            <span className="font-mono text-green-800 dark:text-green-200">
-              {formatAddress(publicKey)}
-            </span>
+          <div className="flex items-center gap-0 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg overflow-hidden">
+            <a
+              href={explorerAccountUrl(publicKey)}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="View on Stellar Expert"
+              className="flex items-center gap-2 px-3 py-1.5 text-sm transition-colors hover:bg-green-100 dark:hover:bg-green-900"
+            >
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+              <span className="font-mono text-green-800 dark:text-green-200">
+                {formatAddress(publicKey)}
+              </span>
+              <ExternalLink className="h-3 w-3 text-green-500 opacity-60 shrink-0" />
+            </a>
             {xlmBalance !== null && (
-              <span className="text-xs text-green-700 dark:text-green-300 font-medium border-l border-green-200 dark:border-green-800 pl-2 ml-0.5">
+              <span className="text-xs text-green-700 dark:text-green-300 font-medium border-l border-green-200 dark:border-green-800 px-2 py-1.5">
                 {xlmBalance} XLM
               </span>
             )}
-            {copied
-              ? <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
-              : <Copy className="h-3.5 w-3.5 text-green-500 opacity-60" />
-            }
-          </button>
+            <button
+              onClick={handleCopy}
+              title={copied ? 'Copied!' : 'Copy full address'}
+              className="px-2 py-1.5 text-sm transition-colors border-l border-green-200 dark:border-green-800 hover:bg-green-100 dark:hover:bg-green-900"
+            >
+              {copied
+                ? <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+                : <Copy className="h-3.5 w-3.5 text-green-500 opacity-60" />
+              }
+            </button>
+          </div>
 
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary

Adds wallet address copy + explorer link to the navbar wallet button per #162.

## Changes

In `invofi/apps/frontend/src/components/auth/WalletButton.tsx`:

- **Stellar Expert link** — the truncated address is now an anchor (`<a>`) that opens the account on [Stellar Expert](https://stellar.expert) on the correct network (testnet/mainnet via the existing `explorerAccountUrl` helper in `constants.ts`), with an external-link icon and `title` tooltip.
- **Separated copy control** — copy-to-clipboard moved to its own icon button next to the address, so clicking the address navigates while the copy button still copies the full address.
- **Toast confirmation** — copying now shows a success toast ("Address copied"), and clipboard failures show a destructive error toast instead of failing silently.
- Preserved existing behavior: truncated `GABC…WXYZ` rendering, XLM balance pill, network-mismatch warning, and disconnect button.

## Acceptance criteria

- [x] Address renders truncated (e.g. `GABC…WXYZ`) with a copy icon
- [x] Copy shows a toast confirmation
- [x] Clicking the address opens the account on Stellar Expert on the correct network

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct link from the connected wallet address to Stellar Expert.
  * Added toast notifications confirming successful address copies or reporting copy failures.
  * Improved the wallet control layout with clearer balance, explorer-link, and copy actions.
  * Updated copy-button styling and tooltip text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->