### PR TITLE
feat(sdk): event replay and catch-up from a specific ledger (#214)

### DIFF
--- a/invofi/apps/sdk/src/events.ts
+++ b/invofi/apps/sdk/src/events.ts
@@ -327,6 +327,111 @@ export interface ListenToEventsOptions {
  */
 export type StopListening = () => void;
 
+// ── replayEvents options ───────────────────────────────────────────────────
+
+/**
+ * Options for {@link replayEvents}.
+ *
+ * @example
+ * ```ts
+ * import { replayEvents, Networks } from '@invofi/sdk';
+ *
+ * const events = await replayEvents({
+ *   rpcUrl:      'https://soroban-testnet.stellar.org',
+ *   contractIds: [registryId, financingId],
+ *   from:        1000,
+ *   to:          2000,
+ *   eventTypes:  ['inv_reg', 'off_acc'],
+ *   onEvent(event) {
+ *     console.log('Replayed event:', event.type, event.subjectId);
+ *   },
+ * });
+ * ```
+ */
+export interface ReplayEventsOptions {
+  /**
+   * Soroban RPC URL, e.g. `'https://soroban-testnet.stellar.org'`.
+   * Defaults to `'https://soroban-testnet.stellar.org'` if omitted.
+   */
+  rpcUrl?: string;
+
+  /**
+   * Stellar network passphrase. Use `Networks.TESTNET` or `Networks.PUBLIC`.
+   */
+  networkPassphrase?: string;
+
+  /**
+   * Starting ledger sequence (inclusive).
+   */
+  from?: number;
+
+  /**
+   * Alias for `from`. Starting ledger sequence (inclusive).
+   */
+  fromLedger?: number;
+
+  /**
+   * Alias for `from`. Starting ledger sequence (inclusive).
+   */
+  startLedger?: number;
+
+  /**
+   * Ending ledger sequence (inclusive). When omitted, queries up to the current
+   * latest ledger on the network.
+   */
+  to?: number;
+
+  /**
+   * Alias for `to`. Ending ledger sequence (inclusive).
+   */
+  toLedger?: number;
+
+  /**
+   * Alias for `to`. Ending ledger sequence (inclusive).
+   */
+  endLedger?: number;
+
+  /**
+   * One or more contract IDs to filter on.
+   */
+  contractIds?: string[];
+
+  /**
+   * Convenience single contract ID filter.
+   */
+  contractId?: string;
+
+  /**
+   * Subset of event types to receive. When omitted, all protocol events are returned.
+   */
+  eventTypes?: ProtocolEventName[];
+
+  /**
+   * Convenience single event type filter.
+   */
+  eventType?: ProtocolEventName;
+
+  /**
+   * Maximum ledger window size per batch RPC request. Defaults to `1000` (Soroban RPC window limit).
+   */
+  batchSizeLedgers?: number;
+
+  /**
+   * Maximum number of raw events per RPC page request. Defaults to `200`.
+   */
+  limitPerPage?: number;
+
+  /**
+   * Optional callback called for every decoded matching event in chronological order.
+   */
+  onEvent?: (event: ProtocolEvent) => void;
+
+  /**
+   * Optional callback on RPC error during replay.
+   */
+  onError?: (error: Error, context: { from: number; to: number; attempt: number }) => void;
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /** Extract a string value from a decoded ScVal. */
@@ -723,3 +828,230 @@ export function listenToEvents(options: ListenToEventsOptions): StopListening {
     }
   };
 }
+
+// ── replayEvents ───────────────────────────────────────────────────────────
+
+/**
+ * Replay and catch up historical InvoFi protocol events across a specified ledger range.
+ *
+ * Paginates through Soroban RPC event pages and handles ledger ranges larger than
+ * the 1000-ledger RPC window limit by dividing into sequential ledger batches.
+ * Returns fully decoded, strongly-typed {@link ProtocolEvent} objects in strict
+ * chronological order.
+ *
+ * @example
+ * ```ts
+ * import { replayEvents, Networks } from '@invofi/sdk';
+ *
+ * // Object-style:
+ * const events = await replayEvents({
+ *   rpcUrl:      'https://soroban-testnet.stellar.org',
+ *   contractIds: [registryId, financingId],
+ *   from:        1000,
+ *   to:          2500,
+ *   eventTypes:  ['inv_reg', 'off_acc'],
+ *   onEvent(event) {
+ *     console.log('Replayed event:', event.type, event.subjectId);
+ *   },
+ * });
+ *
+ * // Positional-style:
+ * const events = await replayEvents(1000, 2000, (event) => {
+ *   console.log('Got event:', event.type);
+ * });
+ * ```
+ *
+ * @see {@link ReplayEventsOptions} for options.
+ */
+export async function replayEvents(options: ReplayEventsOptions): Promise<ProtocolEvent[]>;
+export async function replayEvents(
+  fromLedger: number,
+  toLedger?: number,
+  callback?: (event: ProtocolEvent) => void,
+  options?: Partial<ReplayEventsOptions>,
+): Promise<ProtocolEvent[]>;
+export async function replayEvents(
+  optionsOrFrom: ReplayEventsOptions | number,
+  toLedgerParam?: number,
+  callbackParam?: (event: ProtocolEvent) => void,
+  extraOptions?: Partial<ReplayEventsOptions>,
+): Promise<ProtocolEvent[]> {
+  let opts: ReplayEventsOptions;
+
+  if (typeof optionsOrFrom === 'number') {
+    opts = {
+      ...extraOptions,
+      from: optionsOrFrom,
+      to: toLedgerParam ?? extraOptions?.to ?? extraOptions?.toLedger ?? extraOptions?.endLedger,
+      onEvent: callbackParam ?? extraOptions?.onEvent,
+    };
+  } else {
+    opts = optionsOrFrom ?? {};
+  }
+
+  const rpcUrl = opts.rpcUrl ?? 'https://soroban-testnet.stellar.org';
+  if (opts.rpcUrl !== undefined && !opts.rpcUrl) {
+    throw new Error('replayEvents: rpcUrl must not be empty');
+  }
+
+  const from = opts.from ?? opts.fromLedger ?? opts.startLedger;
+  if (from === undefined) {
+    throw new Error('replayEvents: valid starting ledger (from) is required');
+  }
+  if (typeof from !== 'number' || isNaN(from) || from < 0 || !Number.isInteger(from)) {
+    throw new Error('replayEvents: from must be a non-negative integer');
+  }
+
+  const to = opts.to ?? opts.toLedger ?? opts.endLedger;
+  if (to !== undefined) {
+    if (typeof to !== 'number' || isNaN(to) || to < 0 || !Number.isInteger(to)) {
+      throw new Error('replayEvents: to must be a non-negative integer');
+    }
+    if (to < from) {
+      throw new Error('replayEvents: to must be greater than or equal to from');
+    }
+  }
+
+  const contractIds = opts.contractIds ?? (opts.contractId ? [opts.contractId] : undefined);
+  const eventTypes = opts.eventTypes ?? (opts.eventType ? [opts.eventType] : undefined);
+  const allowedTypes = eventTypes ? new Set<string>(eventTypes) : null;
+  const onEvent = opts.onEvent;
+  const batchSizeLedgers = Math.max(1, opts.batchSizeLedgers ?? 1000);
+  const limitPerPage = opts.limitPerPage ?? 200;
+
+  const rpcServer = new SorobanRpc.Server(rpcUrl, { allowHttp: rpcUrl.startsWith('http://') });
+
+  let targetTo = to;
+  if (targetTo === undefined) {
+    const latestLedgerRes = await rpcServer.getLatestLedger();
+    targetTo = latestLedgerRes.sequence;
+    if (targetTo < from) {
+      return [];
+    }
+  }
+
+  let currentWindowStart = from;
+  const allEvents: ProtocolEvent[] = [];
+  const seenPagingTokens = new Set<string>();
+
+  while (currentWindowStart <= targetTo) {
+    const currentWindowEnd = Math.min(currentWindowStart + batchSizeLedgers - 1, targetTo);
+    let cursor: string | undefined = undefined;
+    let hasMorePagesInWindow = true;
+    const pageStartLedger = currentWindowStart;
+
+    while (hasMorePagesInWindow) {
+      const filters: SorobanRpc.Api.EventFilter[] = [];
+      if (contractIds && contractIds.length > 0) {
+        filters.push({ type: 'contract', contractIds });
+      } else {
+        filters.push({ type: 'contract' });
+      }
+
+      const requestParams: Record<string, unknown> = {
+        startLedger: pageStartLedger,
+        filters,
+        limit: limitPerPage,
+      };
+      if (cursor) {
+        requestParams.cursor = cursor;
+        requestParams.pagination = { cursor, limit: limitPerPage };
+      }
+
+      let res: SorobanRpc.Api.GetEventsResponse;
+      try {
+        res = await rpcServer.getEvents(requestParams as unknown as SorobanRpc.Server.GetEventsRequest);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        if (opts.onError) {
+          try {
+            opts.onError(error, { from: currentWindowStart, to: currentWindowEnd, attempt: 1 });
+          } catch {
+            // suppress onError exception
+          }
+        }
+        throw error;
+      }
+
+      const rawEvents = res?.events ?? [];
+      if (rawEvents.length === 0) {
+        break;
+      }
+
+      let newEventsInBatch = 0;
+      for (const rawEvent of rawEvents) {
+        const rawLedger = typeof rawEvent.ledger === 'number'
+          ? rawEvent.ledger
+          : parseInt(String(rawEvent.ledger ?? '0'), 10);
+
+        if (rawLedger > targetTo) {
+          hasMorePagesInWindow = false;
+          break;
+        }
+        if (rawLedger > currentWindowEnd) {
+          hasMorePagesInWindow = false;
+          break;
+        }
+        if (rawLedger < from) {
+          continue;
+        }
+
+        const eventKey = rawEvent.id || (rawEvent as { pagingToken?: string }).pagingToken || `${rawLedger}-${rawEvent.txHash}-${rawEvent.contractId}`;
+        if (seenPagingTokens.has(eventKey)) {
+          continue;
+        }
+        seenPagingTokens.add(eventKey);
+        newEventsInBatch++;
+
+        const decoded = decodeEvent(rawEvent);
+        if (decoded === null) continue;
+
+        if (contractIds && contractIds.length > 0 && !contractIds.includes(decoded.contractId)) {
+          continue;
+        }
+
+        if (allowedTypes && !allowedTypes.has(decoded.type)) {
+          continue;
+        }
+
+        if (!KNOWN_EVENT_NAMES.has(decoded.type as ProtocolEventName)) {
+          continue;
+        }
+
+        allEvents.push(decoded);
+        if (onEvent) {
+          try {
+            onEvent(decoded);
+          } catch {
+            // onEvent errors must not abort replay iteration
+          }
+        }
+      }
+
+      const lastRawEvent = rawEvents[rawEvents.length - 1];
+      const lastRawLedger = typeof lastRawEvent.ledger === 'number'
+        ? lastRawEvent.ledger
+        : parseInt(String(lastRawEvent.ledger ?? '0'), 10);
+
+      const nextCursor = (res as { cursor?: string }).cursor || (lastRawEvent as { pagingToken?: string }).pagingToken;
+
+      if (
+        lastRawLedger <= currentWindowEnd &&
+        nextCursor &&
+        nextCursor !== cursor &&
+        newEventsInBatch > 0 &&
+        rawEvents.length >= limitPerPage
+      ) {
+        cursor = nextCursor;
+      } else {
+        hasMorePagesInWindow = false;
+      }
+    }
+
+    currentWindowStart = currentWindowEnd + 1;
+  }
+
+  allEvents.sort((a, b) => a.ledger - b.ledger);
+  return allEvents;
+}
+

--- a/invofi/apps/sdk/src/index.ts
+++ b/invofi/apps/sdk/src/index.ts
@@ -131,11 +131,12 @@ export { Contract, Networks, xdr, nativeToScVal, scValToNative } from '@stellar/
 // // Stop polling when done:
 // stop();
 // ```
-export { listenToEvents } from './events';
+export { listenToEvents, replayEvents } from './events';
 export type {
   ProtocolEventName,
   ProtocolEvent,
   ListenToEventsOptions,
+  ReplayEventsOptions,
   StopListening,
   // Per-event payload types
   InvoiceRegisteredData,

--- a/invofi/apps/sdk/tests/events.test.ts
+++ b/invofi/apps/sdk/tests/events.test.ts
@@ -38,8 +38,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach, type MockedFunction } from 'vitest';
 import { nativeToScVal, rpc as SorobanRpc } from '@stellar/stellar-sdk';
-import { listenToEvents } from '../src/events';
-import type { ProtocolEvent, ListenToEventsOptions } from '../src/events';
+import { listenToEvents, replayEvents } from '../src/events';
+import type { ProtocolEvent, ListenToEventsOptions, ReplayEventsOptions } from '../src/events';
 
 // ── Mock SorobanRpc.Server ────────────────────────────────────────────────────
 // vi.mock hoists to the top so the import in events.ts picks up the mock.
@@ -74,13 +74,14 @@ function makeRawEvent(
   subjectId: string,
   dataFields: unknown[],
   ledger = 100,
+  contractId: string = CONTRACT_ID,
 ): SorobanRpc.Api.EventResponse {
   return {
     id: `${ledger}-0`,
     type: 'contract' as const,
     ledger,
     ledgerClosedAt: new Date().toISOString(),
-    contractId: CONTRACT_ID,
+    contractId,
     txHash: TX_HASH,
     topic: [
       nativeToScVal(eventName, { type: 'symbol' }),
@@ -721,3 +722,209 @@ describe('listenToEvents — cursor advance', () => {
     expect(mockGetEvents.mock.calls[1][0]).toMatchObject({ startLedger: 101 });
   });
 });
+
+// ── 10. replayEvents ───────────────────────────────────────────────────────────
+
+describe('replayEvents — argument validation', () => {
+  it('throws when from is missing, negative, or not an integer', async () => {
+    await expect(replayEvents({ from: undefined } as unknown as ReplayEventsOptions)).rejects.toThrow('valid starting ledger');
+    await expect(replayEvents({ from: -1 })).rejects.toThrow('non-negative integer');
+    await expect(replayEvents({ from: 10.5 })).rejects.toThrow('non-negative integer');
+  });
+
+  it('throws when to is less than from', async () => {
+    await expect(replayEvents({ from: 2000, to: 1000 })).rejects.toThrow('greater than or equal to');
+  });
+
+  it('throws when rpcUrl is explicitly empty', async () => {
+    await expect(replayEvents({ rpcUrl: '', from: 1000, to: 2000 })).rejects.toThrow('rpcUrl must not be empty');
+  });
+});
+
+describe('replayEvents — basic range replay', () => {
+  it('fetches events in range and delivers them in chronological order', async () => {
+    const raw1 = makeRawEvent(
+      'inv_reg', 'inv_1001',
+      ['GBUSINESS1234567890123456789012345678901234567890123456', 50_000n, 1_700_000_000n],
+      1050,
+    );
+    const raw2 = makeRawEvent(
+      'off_acc', 'off_2002',
+      ['inv_1001', 'GLENDER123456789012345678901234567890123456789012345678', 50_000n],
+      1100,
+    );
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [raw1, raw2],
+      latestLedger: 1200,
+    });
+
+    const received: ProtocolEvent[] = [];
+    const result = await replayEvents({
+      rpcUrl: RPC_URL,
+      contractIds: [CONTRACT_ID],
+      from: 1000,
+      to: 1200,
+      onEvent: (e) => received.push(e),
+    });
+
+    expect(result).toHaveLength(2);
+    expect(received).toHaveLength(2);
+    expect(result[0].type).toBe('inv_reg');
+    expect(result[0].ledger).toBe(1050);
+    expect(result[1].type).toBe('off_acc');
+    expect(result[1].ledger).toBe(1100);
+
+    expect(mockGetEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startLedger: 1000,
+        filters: [{ type: 'contract', contractIds: [CONTRACT_ID] }],
+      }),
+    );
+  });
+
+  it('supports positional calling style replayEvents(from, to, callback, options)', async () => {
+    const raw = makeRawEvent('inv_cxl', 'inv_cxl_1', ['GBUSINESS123'], 1050);
+    mockGetEvents.mockResolvedValueOnce({
+      events: [raw],
+      latestLedger: 1100,
+    });
+
+    const callbackEvents: ProtocolEvent[] = [];
+    const events = await replayEvents(1000, 1100, (e) => callbackEvents.push(e), {
+      rpcUrl: RPC_URL,
+      contractIds: [CONTRACT_ID],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('inv_cxl');
+    expect(callbackEvents).toHaveLength(1);
+  });
+
+  it('defaults to current latest ledger when to is omitted', async () => {
+    mockGetLatestLedger.mockResolvedValueOnce({ sequence: 500 });
+    mockGetEvents.mockResolvedValueOnce({
+      events: [],
+      latestLedger: 500,
+    });
+
+    const events = await replayEvents({
+      rpcUrl: RPC_URL,
+      contractIds: [CONTRACT_ID],
+      from: 400,
+    });
+
+    expect(mockGetLatestLedger).toHaveBeenCalled();
+    expect(events).toEqual([]);
+    expect(mockGetEvents).toHaveBeenCalledWith(expect.objectContaining({ startLedger: 400 }));
+  });
+});
+
+describe('replayEvents — pagination across large ranges (>1000 ledgers)', () => {
+  it('automatically splits ranges larger than 1000 ledgers into sequential window batches', async () => {
+    const rawWindow1 = makeRawEvent('inv_reg', 'inv_w1', ['G1', 1000n, 12345n], 1500);
+    const rawWindow2 = makeRawEvent('off_new', 'off_w2', ['inv_w1', 'G2', 1000n, 500], 2500);
+    const rawWindow3 = makeRawEvent('inv_rep', 'inv_w3', ['off_w2', 1000n, true], 3200);
+
+    // Range 1000..3500 (2501 ledgers) -> 3 windows: [1000..1999], [2000..2999], [3000..3500]
+    mockGetEvents
+      .mockResolvedValueOnce({ events: [rawWindow1], latestLedger: 3500 })
+      .mockResolvedValueOnce({ events: [rawWindow2], latestLedger: 3500 })
+      .mockResolvedValueOnce({ events: [rawWindow3], latestLedger: 3500 });
+
+    const result = await replayEvents({
+      rpcUrl: RPC_URL,
+      contractIds: [CONTRACT_ID],
+      from: 1000,
+      to: 3500,
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result[0].subjectId).toBe('inv_w1');
+    expect(result[1].subjectId).toBe('off_w2');
+    expect(result[2].subjectId).toBe('inv_w3');
+
+    expect(mockGetEvents).toHaveBeenCalledTimes(3);
+    expect(mockGetEvents.mock.calls[0][0]).toMatchObject({ startLedger: 1000 });
+    expect(mockGetEvents.mock.calls[1][0]).toMatchObject({ startLedger: 2000 });
+    expect(mockGetEvents.mock.calls[2][0]).toMatchObject({ startLedger: 3000 });
+  });
+
+  it('paginates multiple pages within a single window using cursor', async () => {
+    const rawPage1_1 = makeRawEvent('inv_reg', 'inv_p1_1', ['G1', 1000n, 12345n], 1020);
+    const rawPage1_2 = makeRawEvent('inv_reg', 'inv_p1_2', ['G2', 2000n, 12345n], 1050);
+    const rawPage2_1 = makeRawEvent('off_acc', 'off_p2_1', ['inv_p1_1', 'GL', 1000n], 1080);
+
+    // Window 1000..1100 with limitPerPage=2
+    mockGetEvents
+      .mockResolvedValueOnce({
+        events: [rawPage1_1, rawPage1_2],
+        latestLedger: 1100,
+        cursor: 'cursor-page-2',
+      } as unknown as GetEventsResult)
+      .mockResolvedValueOnce({
+        events: [rawPage2_1],
+        latestLedger: 1100,
+      });
+
+    const result = await replayEvents({
+      rpcUrl: RPC_URL,
+      contractIds: [CONTRACT_ID],
+      from: 1000,
+      to: 1100,
+      limitPerPage: 2,
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.subjectId)).toEqual(['inv_p1_1', 'inv_p1_2', 'off_p2_1']);
+    expect(mockGetEvents).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('replayEvents — filtering & type safety', () => {
+  it('filters events by contractId and eventTypes', async () => {
+    const otherContractId = 'CBOTHERCONTRACT123456789012345678901234567890123456789012';
+    const matching1 = makeRawEvent('inv_reg', 'inv_match', ['G1', 100n, 200n], 1010);
+    const matching2 = makeRawEvent('off_acc', 'off_match', ['inv_match', 'G2', 100n], 1020);
+    const wrongType = makeRawEvent('pool_stk', 'pool_1', ['G3', 500n], 1030);
+    const wrongContract = makeRawEvent('inv_reg', 'inv_wrong_contract', ['G4', 100n, 200n], 1040, otherContractId);
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [matching1, matching2, wrongType, wrongContract],
+      latestLedger: 1100,
+    });
+
+    const result = await replayEvents({
+      rpcUrl: RPC_URL,
+      contractIds: [CONTRACT_ID],
+      eventTypes: ['inv_reg', 'off_acc'],
+      from: 1000,
+      to: 1100,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.type)).toEqual(['inv_reg', 'off_acc']);
+    expect(result.map((e) => e.subjectId)).toEqual(['inv_match', 'off_match']);
+  });
+
+  it('correctly handles chronological sorting across replayed events', async () => {
+    const rawLater = makeRawEvent('inv_rep', 'rep_2', ['off_1', 1000n, true], 1500);
+    const rawEarlier = makeRawEvent('inv_reg', 'reg_1', ['G1', 1000n, 12345n], 1200);
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [rawLater, rawEarlier], // RPC returned unsorted
+      latestLedger: 1600,
+    });
+
+    const result = await replayEvents({
+      rpcUrl: RPC_URL,
+      from: 1000,
+      to: 1600,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].ledger).toBe(1200);
+    expect(result[1].ledger).toBe(1500);
+  });
+});
+


### PR DESCRIPTION
## Summary

- Implemented `replayEvents` in `@invofi/sdk` to fetch and replay historical protocol events across specified ledger ranges.
- Supports automatic multi-batch pagination across ranges exceeding the Soroban RPC 1000-ledger window limit.
- Supports intra-window cursor pagination with configurable page limits (`limitPerPage`).
- Added filtering by contract ID (`contractId` / `contractIds`) and event type (`eventType` / `eventTypes`).
- Guarantees strict chronological ordering of replayed events.
- Supports both object options (`replayEvents({ from, to, ... })`) and positional parameters (`replayEvents(fromLedger, toLedger, callback, options)`).
- Re-exported `replayEvents` and `ReplayEventsOptions` from the SDK entrypoint (`invofi/apps/sdk/src/index.ts`).

## Why

Previously, `listenToEvents` only streamed new events occurring after polling began. If a client service was offline, crashed, or restarted, missed historical events could not be fetched or recovered. `replayEvents` provides an event catch-up mechanism to sync missed state changes without requiring external indexing infrastructure.

## Implementation

1. **`invofi/apps/sdk/src/events.ts`**:
   - Added `ReplayEventsOptions` interface with support for `from`/`fromLedger`/`startLedger`, `to`/`toLedger`/`endLedger`, `contractIds`, `eventTypes`, `batchSizeLedgers`, `limitPerPage`, `onEvent`, and `onError`.
   - Added `replayEvents` function overloads for object options and positional signatures.
   - Implemented chunked sequential ledger window iteration (batching across 1000-ledger RPC boundaries) and cursor-based intra-window pagination.
   - Integrated event deduplication via unique event keys (`pagingToken`/`id`) and client-side sorting by ledger sequence to guarantee strict chronological ordering.

2. **`invofi/apps/sdk/src/index.ts`**:
   - Exported `replayEvents` function and `ReplayEventsOptions` interface alongside `listenToEvents`.

3. **`invofi/apps/sdk/tests/events.test.ts`**:
   - Added 10 unit test cases covering argument validation, basic range replay, positional calling style, omission of `to` (resolving `latestLedger`), large multi-window pagination (>1000 ledgers), cursor pagination, filtering by contract IDs and event types, and chronological sort guarantees.

## Testing

Executed automated test suite in `invofi/apps/sdk`:
- `npm run type-check` (`tsc --noEmit` — 0 errors)
- `npm test` (`vitest run` — all 8 test files passed, 355/355 unit tests passed)

```text
Test Files  8 passed (8)
     Tests  355 passed (355)
  Duration  3.25s
Scope / Risk
Affected files:
invofi/apps/sdk/src/events.ts
invofi/apps/sdk/src/index.ts
invofi/apps/sdk/tests/events.test.ts
Breaking changes: None. listenToEvents and existing SDK methods remain completely unchanged and backward-compatible.
Issue
closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event replay functionality for retrieving historical protocol events across a ledger range.
  * Supports pagination, filtering by contract and event type, alias resolution, and chronological sorting.
  * Added callback support for processing events as they are replayed.
  * Exported the replay API and its configuration type through the SDK.

* **Bug Fixes**
  * Added validation and error reporting for invalid replay parameters and RPC failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->