### PR TITLE
fix(frontend): simulate transactions before submission (security)

### DIFF
--- a/invofi/apps/frontend/e2e/fixtures.ts
+++ b/invofi/apps/frontend/e2e/fixtures.ts
@@ -318,7 +318,7 @@ function smokeTxHash(index: number): string {
  * (verified against testnet): a map of symbol-keyed fields with amount=i128,
  * due_date=u64, status=u32.
  */
-function invoiceScVal(invoice: OnChainInvoice) {
+export function invoiceScVal(invoice: OnChainInvoice) {
   return nativeToScVal(
     {
       id: invoice.id,
@@ -428,4 +428,67 @@ export async function authenticate(
     await mockInvoiceRead(page, options.invoice);
     await mockInvoiceEvents(page);
   }
+}
+
+/**
+ * Stubs the Freighter browser extension so wallet-gated UI (anything behind
+ * `useWallet().publicKey`) is reachable in tests.
+ *
+ * `@stellar/freighter-api` v6 talks to the extension's content script over
+ * `window.postMessage`: it posts `{ source: 'FREIGHTER_EXTERNAL_MSG_REQUEST',
+ * messageId, type }` and resolves on a reply whose `source` is
+ * `FREIGHTER_EXTERNAL_MSG_RESPONSE` and whose `messagedId` (sic — the
+ * upstream field name is misspelled) echoes the request id. This init script
+ * implements exactly that handshake, so the real WalletProvider →
+ * StellarWalletsKit → freighter-api path runs unmodified.
+ */
+export async function mockFreighter(
+  page: Page,
+  address: string = ORIGINATOR,
+): Promise<void> {
+  await page.addInitScript((addr: string) => {
+    const PASSPHRASE = 'Test SDF Network ; September 2015';
+    window.addEventListener('message', (event: MessageEvent) => {
+      const data = event.data as { source?: string; messageId?: number; type?: string } | null;
+      if (event.source !== window) return;
+      if (!data || data.source !== 'FREIGHTER_EXTERNAL_MSG_REQUEST') return;
+
+      const reply = (payload: Record<string, unknown>) =>
+        window.postMessage(
+          {
+            source: 'FREIGHTER_EXTERNAL_MSG_RESPONSE',
+            messagedId: data.messageId,
+            ...payload,
+          },
+          window.location.origin,
+        );
+
+      switch (data.type) {
+        case 'REQUEST_CONNECTION_STATUS':
+          return reply({ isConnected: true });
+        case 'REQUEST_ALLOWED_STATUS':
+        case 'SET_ALLOWED_STATUS':
+          return reply({ isAllowed: true });
+        case 'REQUEST_ACCESS':
+        case 'REQUEST_PUBLIC_KEY':
+          return reply({ publicKey: addr, address: addr });
+        case 'REQUEST_USER_INFO':
+          return reply({ userInfo: { publicKey: addr } });
+        case 'REQUEST_NETWORK':
+          return reply({ network: 'TESTNET', networkPassphrase: PASSPHRASE });
+        case 'REQUEST_NETWORK_DETAILS':
+          return reply({
+            networkDetails: {
+              network: 'TESTNET',
+              networkName: 'TESTNET',
+              networkUrl: 'https://horizon-testnet.stellar.org',
+              networkPassphrase: PASSPHRASE,
+              sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+            },
+          });
+        default:
+          return;
+      }
+    });
+  }, address);
 }

--- a/invofi/apps/frontend/e2e/simulate-confirm.spec.ts
+++ b/invofi/apps/frontend/e2e/simulate-confirm.spec.ts
@@ -1,0 +1,276 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  authenticate,
+  mockSupabaseMirror,
+  mockFreighter,
+  invoiceScVal,
+  ORIGINATOR,
+  SMOKE_INVOICE,
+  InvoiceStatus,
+} from './fixtures';
+import { Contract, TransactionBuilder, SorobanDataBuilder, nativeToScVal, xdr } from '@stellar/stellar-sdk';
+
+/**
+ * Transaction simulation before submission (Issue #216).
+ *
+ * Before broadcasting any state-changing transaction, the UI simulates it
+ * against the current ledger and surfaces the expected effects in a
+ * confirmation dialog. These tests drive the real path — a connected wallet,
+ * the real `simulateContractCall` helper, the real `SimulateConfirm` dialog —
+ * and stub only the Soroban RPC boundary.
+ */
+
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+const LENDER = 'GDNSSYSCSSJ76FER5WEEXME5G4MTCUBKDRQSKOYP36KUKVDB2VCMERS6';
+const REGISTRY_ID = 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7';
+
+/** Decodes which contract function a `simulateTransaction` request invokes. */
+function invokedFunction(txXdr: string): string | null {
+  try {
+    const tx = TransactionBuilder.fromXDR(txXdr, NETWORK_PASSPHRASE);
+    const op = ('operations' in tx ? tx.operations[0] : null) as
+      | { func?: xdr.HostFunction }
+      | null;
+    if (!op?.func) return null;
+    return op.func.invokeContract().functionName().toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A `DiagnosticEvent` carrying a SEP-41 `transfer`, base64-encoded exactly as
+ * the Soroban RPC returns it (the SDK decodes `events[]` from XDR, so a plain
+ * JSON object here would fail to parse).
+ */
+function transferEventXdr(): string {
+  const topics = [
+    nativeToScVal('transfer', { type: 'symbol' }),
+    nativeToScVal(ORIGINATOR, { type: 'address' }),
+    nativeToScVal(LENDER, { type: 'address' }),
+  ];
+  const body = new xdr.ContractEventBody(
+    0,
+    new xdr.ContractEventV0({ topics, data: nativeToScVal(25_000_000n, { type: 'i128' }) }),
+  );
+  const event = new xdr.ContractEvent({
+    ext: new xdr.ExtensionPoint(0),
+    // The generated XDR type wants an `Opaque[]`; a 32-byte Buffer is what
+    // the encoder actually accepts (and what stellar-base itself passes).
+    contractId: new Contract(REGISTRY_ID).address().toBuffer() as unknown as xdr.Hash,
+    type: xdr.ContractEventType.contract(),
+    body,
+  });
+  return new xdr.DiagnosticEvent({ inSuccessfulContractCall: true, event }).toXDR('base64');
+}
+
+/** The contract-data ledger entry a status write would touch. */
+const CONTRACT_ADDRESS = new Contract(REGISTRY_ID).address().toScAddress();
+const ENTRY_KEY = nativeToScVal(['Invoice', SMOKE_INVOICE.id], { type: ['symbol', 'symbol'] });
+
+function invoiceLedgerEntry(status: number): string {
+  return new xdr.LedgerEntry({
+    lastModifiedLedgerSeq: 1,
+    data: xdr.LedgerEntryData.contractData(
+      new xdr.ContractDataEntry({
+        ext: new xdr.ExtensionPoint(0),
+        contract: CONTRACT_ADDRESS,
+        key: ENTRY_KEY,
+        durability: xdr.ContractDataDurability.persistent(),
+        val: nativeToScVal(status, { type: 'u32' }),
+      }),
+    ),
+    ext: new xdr.LedgerEntryExt(0),
+  }).toXDR('base64');
+}
+
+/** A successful simulation carrying one SEP-41 `transfer` and one state write. */
+function successResult() {
+  return {
+    transactionData: new SorobanDataBuilder().build().toXDR('base64'),
+    minResourceFee: '200',
+    results: [{ auth: [], xdr: nativeToScVal(1, { type: 'u32' }).toXDR('base64') }],
+    events: [transferEventXdr()],
+    stateChanges: [
+      {
+        type: 2,
+        key: xdr.LedgerKey.contractData(
+          new xdr.LedgerKeyContractData({
+            contract: CONTRACT_ADDRESS,
+            key: ENTRY_KEY,
+            durability: xdr.ContractDataDurability.persistent(),
+          }),
+        ).toXDR('base64'),
+        before: invoiceLedgerEntry(0),
+        after: invoiceLedgerEntry(4),
+      },
+    ],
+    latestLedger: 5_000_000,
+  };
+}
+
+/**
+ * Routes the Soroban RPC so that read calls (`get_invoice`) always resolve
+ * with the fixture invoice, while the state-changing call under test resolves
+ * according to `mode`. Registered last so it wins over `authenticate`'s
+ * broader stub.
+ */
+async function mockSimulation(
+  page: Page,
+  mode: 'success' | 'error',
+): Promise<void> {
+  await page.route('**/soroban-testnet.stellar.org/**', async (route) => {
+    let body: { method?: string; params?: { transaction?: string } } | null;
+    try {
+      body = route.request().postDataJSON();
+    } catch {
+      return route.fallback();
+    }
+    if (body?.method !== 'simulateTransaction') return route.fallback();
+
+    const fn = invokedFunction(body.params?.transaction ?? '');
+
+    // Reads must always succeed, otherwise the page never renders the
+    // action buttons the test is about to click.
+    if (fn === 'get_invoice' || fn === null) {
+      return route.fulfill({
+        json: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            transactionData: new SorobanDataBuilder().build().toXDR('base64'),
+            minResourceFee: '100',
+            results: [
+              {
+                auth: [],
+                xdr: invoiceScVal({
+                  ...SMOKE_INVOICE,
+                  due_date: 2_000_000_000n,
+                  status: InvoiceStatus.Pending,
+                }).toXDR('base64'),
+              },
+            ],
+            events: [],
+            latestLedger: 5_000_000,
+          },
+        },
+      });
+    }
+
+    if (mode === 'error') {
+      return route.fulfill({
+        json: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            error: 'contract: unauthorized — only originator can cancel',
+            latestLedger: 5_000_000,
+          },
+        },
+      });
+    }
+
+    return route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: successResult() } });
+  });
+}
+
+const MIRROR_INVOICE = {
+  id: SMOKE_INVOICE.id,
+  originator: ORIGINATOR,
+  amount: '2.0000000',
+  currency: 'XLM' as const,
+  due_date: '2033-01-01T00:00:00.000Z',
+  status: 'Pending' as const,
+  created_at: '2026-08-01T00:00:00.000Z',
+};
+
+const MIRROR_OFFER = {
+  id: 'off_smoke_sim',
+  invoice_id: SMOKE_INVOICE.id,
+  lender: LENDER,
+  lender_id: '00000000-0000-4000-8000-00000000aaaa',
+  amount: '10000.00',
+  currency: 'USDC',
+  interest_rate: 500,
+  duration: 2_592_000,
+  amount_repaid: '0',
+  status: 'Pending',
+  funded_at: 1_770_000_000,
+  created_at: '2026-08-01T00:00:00.000Z',
+};
+
+test.describe('transaction simulation', () => {
+  test('cancel: simulation dialog previews token movements', async ({ page }) => {
+    await mockFreighter(page);
+    await authenticate(page);
+    await mockSupabaseMirror(page, { invoices: [MIRROR_INVOICE] });
+    await mockSimulation(page, 'success');
+
+    await page.goto(`/invoices/${SMOKE_INVOICE.id}`);
+
+    const cancelBtn = page.getByRole('button', { name: 'Cancel', exact: true });
+    await expect(cancelBtn).toBeVisible();
+    await cancelBtn.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Preview: Cancel Invoice')).toBeVisible();
+
+    // The parsed SEP-41 transfer event is surfaced to the user — decoded
+    // strkeys, not `[object Object]`.
+    await expect(dialog.getByText('Token Movements')).toBeVisible({ timeout: 15_000 });
+    await expect(dialog.getByText('2.5 SEP-41')).toBeVisible();
+    await expect(dialog.getByText(`${ORIGINATOR.slice(0, 6)}…${ORIGINATOR.slice(-4)}`)).toBeVisible();
+    await expect(dialog.getByText(`${LENDER.slice(0, 6)}…${LENDER.slice(-4)}`)).toBeVisible();
+
+    // …and the ledger entry the call would rewrite.
+    await expect(dialog.getByText('State Changes')).toBeVisible();
+    await expect(dialog.getByText(`updated`)).toBeVisible();
+    await expect(dialog.getByText(new RegExp(`Invoice\\.${SMOKE_INVOICE.id}`))).toBeVisible();
+
+    // Simulation succeeded → submission is allowed.
+    await expect(dialog.getByRole('button', { name: 'Cancel Invoice' })).toBeEnabled();
+  });
+
+  test('cancel: failed simulation blocks submission', async ({ page }) => {
+    await mockFreighter(page);
+    await authenticate(page);
+    await mockSupabaseMirror(page, { invoices: [MIRROR_INVOICE] });
+    await mockSimulation(page, 'error');
+
+    await page.goto(`/invoices/${SMOKE_INVOICE.id}`);
+
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByText('Transaction Would Fail')).toBeVisible({ timeout: 15_000 });
+    await expect(dialog.getByText(/unauthorized/)).toBeVisible();
+
+    // Simulation failed → the confirm button is hard-blocked.
+    await expect(dialog.getByRole('button', { name: 'Cancel Invoice' })).toBeDisabled();
+  });
+
+  test('offers: accept routes through simulation before submission', async ({ page }) => {
+    await mockFreighter(page);
+    await authenticate(page);
+    await mockSupabaseMirror(page, {
+      invoices: [MIRROR_INVOICE],
+      offers: [MIRROR_OFFER],
+    });
+    await mockSimulation(page, 'success');
+
+    await page.goto(`/invoices/${SMOKE_INVOICE.id}`);
+
+    const acceptBtn = page.getByRole('button', { name: 'Accept', exact: true });
+    await expect(acceptBtn).toBeVisible({ timeout: 15_000 });
+    await acceptBtn.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Preview: Accept Offer')).toBeVisible();
+    await expect(dialog.getByText('Token Movements')).toBeVisible({ timeout: 15_000 });
+    await expect(dialog.getByRole('button', { name: 'Accept Offer' })).toBeEnabled();
+  });
+});

--- a/invofi/apps/frontend/security-headers.mjs
+++ b/invofi/apps/frontend/security-headers.mjs
@@ -80,10 +80,26 @@ export function buildConnectSrc() {
   return [...origins].filter(Boolean).join(' ');
 }
 
-export function buildContentSecurityPolicy() {
+/**
+ * `next dev` compiles modules with an eval-based devtool, so the dev server's
+ * own bootstrap is blocked outright by a policy without 'unsafe-eval' — the
+ * app renders a bare shell and every client component dies. Production builds
+ * contain no eval, so the allowance is scoped to development only and the
+ * shipped policy is unchanged.
+ *
+ * @param {{ allowEval?: boolean }} [options]
+ */
+export function buildContentSecurityPolicy({
+  allowEval = process.env.NODE_ENV === 'development',
+} = {}) {
+  const scriptSrc = [
+    "script-src 'self' 'unsafe-inline'",
+    WALLET_EXTENSION_SOURCES.join(' '),
+    ...(allowEval ? ["'unsafe-eval'"] : []),
+  ].join(' ');
   return [
     "default-src 'self'",
-    `script-src 'self' 'unsafe-inline' ${WALLET_EXTENSION_SOURCES.join(' ')}`,
+    scriptSrc,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob:",
     "font-src 'self' data:",
@@ -97,17 +113,18 @@ export function buildContentSecurityPolicy() {
 }
 
 /**
- * @param {{ includeHsts?: boolean }} [options]
+ * @param {{ includeHsts?: boolean, allowEval?: boolean }} [options]
  * @returns {{ key: string, value: string }[]}
  */
 export function buildSecurityHeaders({
   includeHsts = process.env.NODE_ENV === 'production',
+  allowEval = process.env.NODE_ENV === 'development',
 } = {}) {
   const headers = [
     { key: 'X-Content-Type-Options', value: 'nosniff' },
     { key: 'X-Frame-Options', value: 'DENY' },
     { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-    { key: 'Content-Security-Policy', value: buildContentSecurityPolicy() },
+    { key: 'Content-Security-Policy', value: buildContentSecurityPolicy({ allowEval }) },
   ];
   if (includeHsts) {
     headers.push({

--- a/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
@@ -294,9 +294,11 @@ export default function InvoiceDetailPage() {
           variant="destructive"
           confirmLabel="Cancel Invoice"
           holdToConfirm
+          // Returned so `SimulateConfirm` can await the submission and keep
+          // its "Submitting…" state up while the wallet signs.
           onConfirm={() => {
             setSimCancel(false);
-            handleCancel();
+            return handleCancel();
           }}
         />
       </div>

--- a/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, ExternalLink, Loader2, Printer } from 'lucide-react';
@@ -13,15 +13,22 @@ import { OfferList } from '@/components/invoices/OfferList';
 import { InvoiceDocuments } from '@/components/invoices/documents/InvoiceDocuments';
 import { MessagingPanel } from '@/components/invoices/MessagingPanel';
 import { EventTimeline } from '@/components/invoices/EventTimeline';
-import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { SimulateConfirm } from '@/components/common/SimulateConfirm';
 import { getInvoice, cancelInvoice, registerInvoice } from '@/lib/contract';
+import {
+  simulateContractCall,
+  encodeSymbol,
+  encodeAddress,
+} from '@/lib/simulate';
 import { supabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import { toErrorMessage } from '@/lib/errors';
 import { formatAmount } from '@/lib/formatters';
 import { formatDate, formatAddress, INVOICE_STATUS_COLORS, generateInvoiceId } from '@/lib/utils';
+import { REGISTRY_CONTRACT_ID } from '@/lib/constants';
 import type { Invoice, FinancingOffer } from '@/types';
+import type { SimulationResult } from '@/lib/simulate';
 
 export default function InvoiceDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -30,12 +37,35 @@ export default function InvoiceDetailPage() {
   const [invoice, setInvoice] = useState<Invoice | null>(null);
   const [loading, setLoading] = useState(true);
   const [cancelling, setCancelling] = useState(false);
-  const [confirmCancel, setConfirmCancel] = useState(false);
+  const [simCancel, setSimCancel] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isUnauthorized, setIsUnauthorized] = useState(false);
   // Counterparty address for the messaging panel.  Derived from the accepted
   // offer once offers are loaded: originator ↔ accepted lender.
   const [counterpartyAddress, setCounterpartyAddress] = useState<string>('');
+
+  // Previews `cancel_invoice` against the current ledger. A missing invoice or
+  // wallet is reported as a failed simulation so the dialog blocks submission
+  // rather than silently broadcasting an unbuildable call.
+  const simulateCancel = useCallback(async (): Promise<SimulationResult> => {
+    if (!invoice || !publicKey) {
+      return {
+        success: false,
+        error: 'Connect a wallet and load the invoice before cancelling.',
+        tokenMovements: [],
+        stateChanges: [],
+        events: [],
+        resourceFee: '0',
+        latestLedger: 0,
+      };
+    }
+    return simulateContractCall(
+      REGISTRY_CONTRACT_ID,
+      'cancel_invoice',
+      [encodeSymbol(invoice.id), encodeAddress(publicKey)],
+      publicKey,
+    );
+  }, [invoice, publicKey]);
 
   const handleCancel = async () => {
     if (!invoice || !publicKey) return;
@@ -208,7 +238,7 @@ export default function InvoiceDetailPage() {
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => setConfirmCancel(true)}
+                      onClick={() => setSimCancel(true)}
                       disabled={cancelling}
                       className="text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
                     >
@@ -254,16 +284,18 @@ export default function InvoiceDetailPage() {
           </div>
         )}
 
-        <ConfirmDialog
-          open={confirmCancel}
-          onOpenChange={open => { if (!open) setConfirmCancel(false); }}
-          title="Cancel this invoice?"
-          description="The invoice will be cancelled on-chain and can no longer receive financing offers. This cannot be undone."
-          confirmLabel="Cancel Invoice"
+        {/* ── Simulation confirmation for cancel ──────────────────────── */}
+        <SimulateConfirm
+          open={simCancel}
+          onOpenChange={open => { if (!open) setSimCancel(false); }}
+          title="Preview: Cancel Invoice"
+          description="Review the expected effects before cancelling this invoice on-chain."
+          onSimulate={simulateCancel}
           variant="destructive"
+          confirmLabel="Cancel Invoice"
           holdToConfirm
           onConfirm={() => {
-            setConfirmCancel(false);
+            setSimCancel(false);
             handleCancel();
           }}
         />

--- a/invofi/apps/frontend/src/components/common/ConfirmDialog.tsx
+++ b/invofi/apps/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,7 +9,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import { HoldToConfirmButton } from './HoldToConfirmButton';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -28,8 +27,6 @@ interface ConfirmDialogProps {
   holdDuration?: number;
 }
 
-const HOLD_DURATION_DEFAULT = 1500;
-
 export function ConfirmDialog({
   open,
   onOpenChange,
@@ -41,161 +38,28 @@ export function ConfirmDialog({
   onConfirm,
   loading = false,
   holdToConfirm = false,
-  holdDuration = HOLD_DURATION_DEFAULT,
+  holdDuration,
 }: ConfirmDialogProps) {
-  const [holdProgress, setHoldProgress] = useState(0);
-  const [isHolding, setIsHolding] = useState(false);
-  const [announcement, setAnnouncement] = useState('');
-  const holdTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const progressRef = useRef(0);
-  const announcedRef = useRef(false);
-
-  const clearHold = useCallback(() => {
-    if (holdTimerRef.current) {
-      clearInterval(holdTimerRef.current);
-      holdTimerRef.current = null;
-    }
-    setHoldProgress(0);
-    setIsHolding(false);
-    progressRef.current = 0;
-    announcedRef.current = false;
-  }, []);
-
-  const handlePointerDown = useCallback(() => {
-    if (loading) return;
-    setIsHolding(true);
-    progressRef.current = 0;
-    announcedRef.current = false;
-    setAnnouncement('Hold to confirm');
-
-    const interval = 30; // ~50 updates per second for smooth animation
-    const step = (interval / holdDuration) * 100;
-
-    holdTimerRef.current = setInterval(() => {
-      progressRef.current += step;
-      setHoldProgress(progressRef.current);
-
-      // Announce at 50% for screen reader awareness
-      if (progressRef.current >= 50 && !announcedRef.current) {
-        announcedRef.current = true;
-        setAnnouncement('Hold a little longer to confirm');
-      }
-
-      if (progressRef.current >= 100) {
-        clearHold();
-        onConfirm();
-      }
-    }, interval);
-  }, [loading, holdDuration, clearHold, onConfirm]);
-
-  const handlePointerUp = useCallback(() => {
-    if (isHolding && progressRef.current < 100) {
-      clearHold();
-      setAnnouncement('Confirmation cancelled');
-    }
-  }, [isHolding, clearHold]);
-
-  const handlePointerLeave = useCallback(() => {
-    if (isHolding && progressRef.current < 100) {
-      clearHold();
-      setAnnouncement('Confirmation cancelled');
-    }
-  }, [isHolding, clearHold]);
-
-  // Reset when dialog opens/closes
-  const handleOpenChange = useCallback(
-    (newOpen: boolean) => {
-      if (!newOpen) {
-        clearHold();
-        setAnnouncement('');
-      }
-      onOpenChange(newOpen);
-    },
-    [clearHold, onOpenChange],
-  );
-
-  // Circle circumference for progress ring
-  const radius = 18;
-  const circumference = 2 * Math.PI * radius;
-  const offset = circumference - (holdProgress / 100) * circumference;
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
 
-        {/* Screen reader announcement */}
-        <div aria-live="polite" className="sr-only" role="status">
-          {announcement}
-        </div>
-
         <DialogFooter className="mt-4">
-          <Button
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-            disabled={loading}
-          >
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
             {cancelLabel}
           </Button>
 
           {holdToConfirm && !loading ? (
-            <button
-              type="button"
-              onPointerDown={handlePointerDown}
-              onPointerUp={handlePointerUp}
-              onPointerLeave={handlePointerLeave}
-              onPointerCancel={handlePointerUp}
-              className={cn(
-                'relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-md px-4 py-2 text-sm font-medium transition-colors',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                'select-none',
-                variant === 'destructive'
-                  ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
-                  : 'bg-primary text-primary-foreground hover:bg-primary/90',
-                isHolding && 'cursor-grabbing',
-              )}
-              style={{ touchAction: 'none' }}
-              disabled={loading}
-            >
-              {/* Progress ring */}
-              <svg
-                className="absolute inset-0 h-full w-full -rotate-90"
-                viewBox="0 0 40 40"
-                aria-hidden="true"
-              >
-                <circle
-                  cx="20"
-                  cy="20"
-                  r={radius}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                  opacity="0.2"
-                />
-                <circle
-                  cx="20"
-                  cy="20"
-                  r={radius}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                  strokeDasharray={circumference}
-                  strokeDashoffset={offset}
-                  strokeLinecap="round"
-                  className="transition-[stroke-dashoffset] duration-75"
-                />
-              </svg>
-
-              {/* Text */}
-              <span className="relative z-10">
-                {isHolding
-                  ? `${Math.round(holdProgress)}%`
-                  : confirmLabel}
-              </span>
-            </button>
+            <HoldToConfirmButton
+              label={confirmLabel}
+              variant={variant}
+              holdDuration={holdDuration}
+              onConfirm={onConfirm}
+            />
           ) : (
             <Button
               variant={variant === 'destructive' ? 'destructive' : 'default'}

--- a/invofi/apps/frontend/src/components/common/HoldToConfirmButton.tsx
+++ b/invofi/apps/frontend/src/components/common/HoldToConfirmButton.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const HOLD_DURATION_DEFAULT = 1500;
+/** ~50 progress updates per second, which is smooth without being wasteful. */
+const TICK_MS = 30;
+
+interface HoldToConfirmButtonProps {
+  label: string;
+  onConfirm: () => void;
+  disabled?: boolean;
+  variant?: 'default' | 'destructive';
+  /** Milliseconds the button must be held. */
+  holdDuration?: number;
+}
+
+/**
+ * A confirm button that only fires after a deliberate press-and-hold.
+ *
+ * Extracted from `ConfirmDialog` so `SimulateConfirm` can offer the same
+ * safeguard on irreversible actions (cancel an invoice, reclaim a defaulted
+ * offer) instead of reimplementing the timer, the progress ring and the
+ * screen-reader announcements a second time.
+ */
+export function HoldToConfirmButton({
+  label,
+  onConfirm,
+  disabled = false,
+  variant = 'default',
+  holdDuration = HOLD_DURATION_DEFAULT,
+}: HoldToConfirmButtonProps) {
+  const [holdProgress, setHoldProgress] = useState(0);
+  const [isHolding, setIsHolding] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const progressRef = useRef(0);
+  const announcedRef = useRef(false);
+
+  const clearHold = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setHoldProgress(0);
+    setIsHolding(false);
+    progressRef.current = 0;
+    announcedRef.current = false;
+  }, []);
+
+  // A pointer released outside the window would otherwise leave the interval
+  // running after unmount.
+  useEffect(() => clearHold, [clearHold]);
+
+  const handlePointerDown = useCallback(() => {
+    if (disabled) return;
+    setIsHolding(true);
+    progressRef.current = 0;
+    announcedRef.current = false;
+    setAnnouncement('Hold to confirm');
+
+    const step = (TICK_MS / holdDuration) * 100;
+    timerRef.current = setInterval(() => {
+      progressRef.current += step;
+      setHoldProgress(progressRef.current);
+
+      if (progressRef.current >= 50 && !announcedRef.current) {
+        announcedRef.current = true;
+        setAnnouncement('Hold a little longer to confirm');
+      }
+
+      if (progressRef.current >= 100) {
+        clearHold();
+        onConfirm();
+      }
+    }, TICK_MS);
+  }, [disabled, holdDuration, clearHold, onConfirm]);
+
+  const abortHold = useCallback(() => {
+    if (isHolding && progressRef.current < 100) {
+      clearHold();
+      setAnnouncement('Confirmation cancelled');
+    }
+  }, [isHolding, clearHold]);
+
+  const radius = 18;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (holdProgress / 100) * circumference;
+
+  return (
+    <>
+      <div aria-live="polite" className="sr-only" role="status">
+        {announcement}
+      </div>
+      <button
+        type="button"
+        onPointerDown={handlePointerDown}
+        onPointerUp={abortHold}
+        onPointerLeave={abortHold}
+        onPointerCancel={abortHold}
+        className={cn(
+          'relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-md px-4 py-2 text-sm font-medium transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          'select-none',
+          variant === 'destructive'
+            ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+            : 'bg-primary text-primary-foreground hover:bg-primary/90',
+          isHolding && 'cursor-grabbing',
+          disabled && 'pointer-events-none opacity-50',
+        )}
+        style={{ touchAction: 'none' }}
+        disabled={disabled}
+      >
+        <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 40 40" aria-hidden="true">
+          <circle cx="20" cy="20" r={radius} fill="none" stroke="currentColor" strokeWidth="3" opacity="0.2" />
+          <circle
+            cx="20"
+            cy="20"
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+            className="transition-[stroke-dashoffset] duration-75"
+          />
+        </svg>
+        <span className="relative z-10">{isHolding ? `${Math.round(holdProgress)}%` : label}</span>
+      </button>
+    </>
+  );
+}

--- a/invofi/apps/frontend/src/components/common/SimulateConfirm.tsx
+++ b/invofi/apps/frontend/src/components/common/SimulateConfirm.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Loader2, AlertTriangle, CheckCircle2, ArrowRight, Info } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { HoldToConfirmButton } from './HoldToConfirmButton';
+import { type SimulationResult } from '@/lib/simulate';
+
+interface SimulateConfirmProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  /** Async function that runs the simulation. Called when the dialog opens. */
+  onSimulate: () => Promise<SimulationResult>;
+  /** Called when the user clicks "Confirm" after reviewing simulation results. */
+  onConfirm: () => void | Promise<void>;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'destructive';
+  /**
+   * Require a deliberate press-and-hold on the confirm button. Carries over
+   * the safeguard `ConfirmDialog` applies to irreversible actions (cancel an
+   * invoice, reclaim a defaulted offer).
+   */
+  holdToConfirm?: boolean;
+}
+
+export function SimulateConfirm({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onSimulate,
+  onConfirm,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  holdToConfirm = false,
+}: SimulateConfirmProps) {
+  const [simResult, setSimResult] = useState<SimulationResult | null>(null);
+  const [simLoading, setSimLoading] = useState(false);
+  const [simError, setSimError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Run simulation when the dialog opens
+  useEffect(() => {
+    if (!open) {
+      // Reset state when dialog closes
+      setSimResult(null);
+      setSimError(null);
+      setSubmitting(false);
+      return;
+    }
+
+    let cancelled = false;
+    setSimLoading(true);
+    setSimError(null);
+    setSimResult(null);
+
+    onSimulate()
+      .then(result => {
+        if (!cancelled) {
+          setSimResult(result);
+          setSimLoading(false);
+        }
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setSimError(err instanceof Error ? err.message : 'Simulation failed');
+          setSimLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, onSimulate]);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch {
+      // Errors are handled by the parent's toast
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isFailed = simResult !== null && !simResult.success;
+  const isReady = simResult !== null && simResult.success;
+  const canConfirm = isReady && !submitting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {simLoading && <Loader2 className="h-4 w-4 animate-spin text-blue-500" />}
+            {isFailed && <AlertTriangle className="h-4 w-4 text-red-500" />}
+            {isReady && <CheckCircle2 className="h-4 w-4 text-green-500" />}
+            {title}
+          </DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Loading state */}
+          {simLoading && (
+            <div className="flex flex-col items-center gap-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              <p>Simulating transaction…</p>
+              <p className="text-xs">Checking against current ledger state</p>
+            </div>
+          )}
+
+          {/* Simulation error (catch block) */}
+          {simError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-950/40">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-sm font-medium text-red-700 dark:text-red-400">
+                    Simulation Failed
+                  </p>
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1 font-mono">
+                    {simError}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Contract-level error from simulation */}
+          {isFailed && simResult.error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-950/40">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-sm font-medium text-red-700 dark:text-red-400">
+                    Transaction Would Fail
+                  </p>
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1 font-mono break-all">
+                    {simResult.error}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Success — show token movements */}
+          {isReady && (
+            <>
+              {simResult.tokenMovements.length > 0 && (
+                <div className="rounded-lg border border-border p-3 space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Token Movements
+                  </p>
+                  {simResult.tokenMovements.map((mv, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <Badge variant="outline" className="shrink-0 text-xs font-mono">
+                        {mv.amount} {mv.asset}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground font-mono truncate max-w-[120px]" title={mv.from}>
+                        {mv.from.slice(0, 6)}…{mv.from.slice(-4)}
+                      </span>
+                      <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                      <span className="text-xs text-muted-foreground font-mono truncate max-w-[120px]" title={mv.to}>
+                        {mv.to.slice(0, 6)}…{mv.to.slice(-4)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {simResult.tokenMovements.length === 0 && (
+                <div className="rounded-lg border border-border p-3 flex items-center gap-2 text-sm text-muted-foreground">
+                  <Info className="h-4 w-4 shrink-0" />
+                  <span>No token transfers detected — this may be a state-only change.</span>
+                </div>
+              )}
+
+              {/* State changes — the ledger entries this call would write. */}
+              {simResult.stateChanges.length > 0 && (
+                <div className="rounded-lg border border-border p-3 space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    State Changes
+                  </p>
+                  {simResult.stateChanges.map((change, i) => (
+                    <div key={i} className="space-y-0.5">
+                      <div className="flex items-center gap-2 text-xs">
+                        <Badge variant="outline" className="shrink-0 text-[10px] uppercase">
+                          {change.type}
+                        </Badge>
+                        <span className="font-mono text-muted-foreground truncate" title={change.key}>
+                          {change.key}
+                        </span>
+                      </div>
+                      {change.after !== null && change.after !== change.before && (
+                        <p
+                          className="text-[11px] text-muted-foreground font-mono truncate pl-1"
+                          title={`${change.before ?? '∅'} → ${change.after}`}
+                        >
+                          {change.before ?? '∅'} → {change.after}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Resource fee */}
+              <div className="flex items-center justify-between text-xs text-muted-foreground px-1">
+                <span>Estimated resource fee</span>
+                <span className="font-mono">{simResult.resourceFee} stroops</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            {cancelLabel}
+          </Button>
+          {/* Hold-to-confirm still requires a clean simulation: `disabled`
+              carries the same gate as the plain button. */}
+          {holdToConfirm && !submitting ? (
+            <HoldToConfirmButton
+              label={confirmLabel}
+              variant={variant}
+              disabled={!canConfirm}
+              onConfirm={handleConfirm}
+            />
+          ) : (
+            <Button
+              variant={variant === 'destructive' ? 'destructive' : 'default'}
+              onClick={handleConfirm}
+              disabled={!canConfirm}
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                  Submitting…
+                </>
+              ) : (
+                confirmLabel
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -11,19 +11,87 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { SimulateConfirm } from '@/components/common/SimulateConfirm';
 import { useWallet } from '@/components/auth/WalletProvider';
 import { createOffer, acceptOffer, rejectOffer, repayInvoice, markOverdue, reclaimInvoice } from '@/lib/contract';
+import {
+  simulateContractCall,
+  encodeSymbol,
+  encodeAddress,
+  encodeI128,
+} from '@/lib/simulate';
 import { supabase } from '@/lib/supabase';
 import { formatAmount } from '@/lib/formatters';
 import { formatAmount as formatUnits, interestRateLabel, durationLabel, generateOfferId, amountToStroops, toStroopsBigInt, OFFER_STATUS_COLORS } from '@/lib/utils';
 import { toCsv, downloadCsv } from '@/lib/csv';
-import { GRACE_PERIOD_SECS, STROOPS_PER_XLM } from '@/lib/constants';
+import {
+  FINANCING_CONTRACT_ID as FINANCING_ID,
+  REPAYMENT_CONTRACT_ID as REPAYMENT_ID,
+  GRACE_PERIOD_SECS,
+  STROOPS_PER_XLM,
+} from '@/lib/constants';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import { toErrorMessage } from '@/lib/errors';
 import { OfferTermsPreview } from './OfferTermsPreview';
 import type { Currency, FinancingOffer, Invoice } from '@/types';
+import type { SimulationResult } from '@/lib/simulate';
+
+/** The state-changing actions a lender/originator can take on an offer. */
+type SimKind = 'accept' | 'reject' | 'repay' | 'reclaim';
+
+interface SimTarget {
+  offer: FinancingOffer;
+  kind: SimKind;
+  /** Stroops, for `repay` only. */
+  amount?: bigint;
+}
+
+/** Dialog copy per action — the only thing that differs between previews. */
+const SIM_ACTIONS: Record<SimKind, {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  variant?: 'default' | 'destructive';
+  /** Irreversible actions require a press-and-hold, not a single click. */
+  holdToConfirm?: boolean;
+}> = {
+  accept: {
+    title: 'Preview: Accept Offer',
+    description: 'Review the expected effects before accepting this financing offer.',
+    confirmLabel: 'Accept Offer',
+  },
+  reject: {
+    title: 'Preview: Reject Offer',
+    description: 'Review the expected effects before rejecting this offer. The lender will be notified and this cannot be undone.',
+    confirmLabel: 'Reject Offer',
+  },
+  repay: {
+    title: 'Preview: Repay Invoice',
+    description: 'Review the expected token transfer before submitting repayment.',
+    confirmLabel: 'Submit Repayment',
+  },
+  reclaim: {
+    title: 'Preview: Reclaim Offer',
+    description: 'Review the expected effects before marking this offer Defaulted on-chain. Principal was already paid at acceptance — this does not return funds, and cannot be undone.',
+    confirmLabel: 'Reclaim',
+    variant: 'destructive',
+    holdToConfirm: true,
+  },
+};
+
+/** A blocked result — the dialog renders it as a failure and disables submit. */
+function emptySimulation(error: string): SimulationResult {
+  return {
+    success: false,
+    error,
+    tokenMovements: [],
+    stateChanges: [],
+    events: [],
+    resourceFee: '0',
+    latestLedger: 0,
+  };
+}
 
 const offerSchema = z.object({
   amount: z.string().regex(/^\d+(\.\d{1,7})?$/, 'Enter a valid amount'),
@@ -50,10 +118,10 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
   const [actionId, setActionId] = useState<string | null>(null);
   /** IDs of offers currently being submitted/accepted on-chain (optimistic UI). */
   const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
-  const [confirmTarget, setConfirmTarget] = useState<
-    { offer: FinancingOffer; kind: 'reject' | 'reclaim' } | null
-  >(null);
   const [repayAmounts, setRepayAmounts] = useState<Record<string, string>>({});
+
+  // ── Simulation state: non-null while a preview dialog is open ───────────
+  const [simTarget, setSimTarget] = useState<SimTarget | null>(null);
 
   const { register, watch, handleSubmit, formState: { errors }, reset } = useForm<OfferFormValues>({
     resolver: zodResolver(offerSchema),
@@ -142,6 +210,38 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
       setLoading(false);
     }
   };
+
+  // One simulation entry point for every action: which contract and method a
+  // preview targets is derived from `simTarget`, so adding an action means
+  // adding a case here and a row in SIM_ACTIONS — not a fifth near-identical
+  // callback/dialog pair.
+  const simulateAction = useCallback(async (): Promise<SimulationResult> => {
+    if (!simTarget || !publicKey) return emptySimulation('No action selected');
+    const { offer, kind, amount } = simTarget;
+    const source = encodeAddress(publicKey);
+
+    switch (kind) {
+      case 'accept':
+        return simulateContractCall(FINANCING_ID, 'accept_offer', [encodeSymbol(offer.id), source], publicKey);
+      case 'reject':
+        return simulateContractCall(FINANCING_ID, 'reject_offer', [encodeSymbol(offer.id), source], publicKey);
+      case 'repay':
+        if (!amount) return emptySimulation('No repayment amount entered');
+        return simulateContractCall(
+          REPAYMENT_ID,
+          'repay_invoice',
+          [encodeSymbol(invoiceId), encodeSymbol(offer.id), source, encodeI128(amount)],
+          publicKey,
+        );
+      case 'reclaim':
+        return simulateContractCall(
+          REPAYMENT_ID,
+          'reclaim_invoice',
+          [encodeSymbol(invoiceId), encodeSymbol(offer.id), source],
+          publicKey,
+        );
+    }
+  }, [simTarget, publicKey, invoiceId]);
 
   const handleAccept = async (offer: FinancingOffer) => {
     if (!publicKey) return;
@@ -282,6 +382,21 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
   };
 
   const isOriginator = publicKey === invoice.originator;
+  /** Submits the previewed action once the user confirms a clean simulation. */
+  const runSimulatedAction = () => {
+    if (!simTarget) return;
+    const { offer, kind } = simTarget;
+    setSimTarget(null);
+    if (kind === 'accept') return handleAccept(offer);
+    if (kind === 'reject') return handleReject(offer);
+    if (kind === 'repay') return handleRepay(offer);
+    return handleReclaim(offer);
+  };
+
+  // Copy for the open preview; `accept` is an inert placeholder while closed,
+  // since Radix unmounts the dialog body when `open` is false.
+  const simAction = SIM_ACTIONS[simTarget?.kind ?? 'accept'];
+
   const canMakeOffer = invoice.status === 'Pending' && publicKey && !isOriginator;
   const nowSecs = Math.floor(Date.now() / 1000);
   const canMarkOverdue = invoice.status === 'Financed' && publicKey && nowSecs > invoice.due_date;
@@ -439,7 +554,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
                 <>
                   <Button
                     size="sm"
-                    onClick={() => handleAccept(offer)}
+                    onClick={() => setSimTarget({ offer, kind: 'accept' })}
                     disabled={actionId === offer.id}
                   >
                     {actionId === offer.id && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
@@ -448,7 +563,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={() => setConfirmTarget({ offer, kind: 'reject' })}
+                    onClick={() => setSimTarget({ offer, kind: 'reject' })}
                     disabled={actionId === offer.id}
                   >
                     Reject
@@ -466,7 +581,19 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
                   />
                   <Button
                     size="sm"
-                    onClick={() => handleRepay(offer)}
+                    onClick={() => {
+                      const raw = (repayAmounts[offer.id] ?? '').trim();
+                      if (!/^\d+(\.\d{1,7})?$/.test(raw)) {
+                        toast({ title: 'Enter a valid amount', variant: 'destructive' });
+                        return;
+                      }
+                      const amountStroops = amountToStroops(raw);
+                      if (amountStroops <= 0n) {
+                        toast({ title: 'Amount must be greater than zero', variant: 'destructive' });
+                        return;
+                      }
+                      setSimTarget({ offer, kind: 'repay', amount: amountStroops });
+                    }}
                     disabled={actionId === offer.id}
                   >
                     {actionId === offer.id && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
@@ -474,16 +601,15 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
                   </Button>
                 </div>
               )}
-              {canReclaim(offer) && (
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  onClick={() => setConfirmTarget({ offer, kind: 'reclaim' })}
-                  disabled={actionId === offer.id}
-                >
-                  {actionId === offer.id && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
-                  Reclaim
-                </Button>
+              {canReclaim(offer) && (                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => setSimTarget({ offer, kind: 'reclaim' })}
+                    disabled={actionId === offer.id}
+                  >
+                    {actionId === offer.id && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                    Reclaim
+                  </Button>
               )}
             </div>
           </div>
@@ -491,25 +617,17 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
         })}
       </CardContent>
 
-      <ConfirmDialog
-        open={confirmTarget !== null}
-        onOpenChange={open => { if (!open) setConfirmTarget(null); }}
-        title={confirmTarget?.kind === 'reclaim' ? 'Reclaim this offer?' : 'Reject this offer?'}
-        description={
-          confirmTarget?.kind === 'reclaim'
-            ? 'This marks the offer Defaulted on-chain. Principal was already paid to the business at acceptance — this does not return funds, and cannot be undone.'
-            : 'The lender will be notified their offer was rejected. This cannot be undone.'
-        }
-        confirmLabel={confirmTarget?.kind === 'reclaim' ? 'Reclaim' : 'Reject'}
-        variant={confirmTarget?.kind === 'reclaim' ? 'destructive' : 'default'}
-        holdToConfirm={confirmTarget?.kind === 'reclaim'}
-        onConfirm={() => {
-          if (!confirmTarget) return;
-          const { offer, kind } = confirmTarget;
-          setConfirmTarget(null);
-          if (kind === 'reclaim') handleReclaim(offer);
-          else handleReject(offer);
-        }}
+      {/* ── Simulation gate: every state-changing action passes through here ── */}
+      <SimulateConfirm
+        open={simTarget !== null}
+        onOpenChange={open => { if (!open) setSimTarget(null); }}
+        title={simAction.title}
+        description={simAction.description}
+        onSimulate={simulateAction}
+        onConfirm={runSimulatedAction}
+        confirmLabel={simAction.confirmLabel}
+        variant={simAction.variant}
+        holdToConfirm={simAction.holdToConfirm}
       />
     </Card>
   );

--- a/invofi/apps/frontend/src/components/invoices/__tests__/OfferList.optimistic.test.tsx
+++ b/invofi/apps/frontend/src/components/invoices/__tests__/OfferList.optimistic.test.tsx
@@ -31,6 +31,25 @@ vi.mock('@/lib/contract', () => ({
   reclaimInvoice: vi.fn(),
 }));
 
+// Accepting an offer now passes through a simulation preview (issue #216).
+// These tests are about the optimistic update that follows confirmation, so
+// the preview is stubbed to succeed immediately.
+vi.mock('@/lib/simulate', () => ({
+  simulateContractCall: vi.fn(async () => ({
+    success: true,
+    tokenMovements: [],
+    stateChanges: [],
+    events: [],
+    resourceFee: '100',
+    latestLedger: 1,
+  })),
+  encodeSymbol: vi.fn(),
+  encodeAddress: vi.fn(),
+  encodeI128: vi.fn(),
+  encodeU32: vi.fn(),
+  encodeU64: vi.fn(),
+}));
+
 vi.mock('@/lib/supabase', () => {
   const fromFn = (table: string) => {
     if (table === 'financing_offers') {
@@ -124,6 +143,20 @@ function OfferListWrapper({ initialInvoice }: WrapperProps) {
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
+
+/**
+ * Clicks the row's Accept and confirms the simulation preview.
+ *
+ * The optimistic update fires on confirmation, not on the raw click — the
+ * preview is the gate that decides whether anything is submitted at all. The
+ * row button is labelled "Accept"; the dialog's is "Accept Offer".
+ */
+async function acceptThroughPreview() {
+  fireEvent.click(screen.getByRole('button', { name: /^accept$/i }));
+  const confirm = await screen.findByRole('button', { name: /accept offer/i });
+  await waitFor(() => expect(confirm).toBeEnabled());
+  fireEvent.click(confirm);
+}
 
 describe('OfferList — optimistic UI', () => {
   beforeEach(() => {
@@ -263,11 +296,11 @@ describe('OfferList — optimistic UI', () => {
       });
 
       // The Accept button should be visible (originator matches wallet)
-      const acceptBtn = screen.getByRole('button', { name: /accept/i });
+      const acceptBtn = screen.getByRole('button', { name: /^accept$/i });
       expect(acceptBtn).toBeInTheDocument();
 
-      // Click Accept
-      fireEvent.click(acceptBtn);
+      // Click Accept, then confirm the simulation preview.
+      await acceptThroughPreview();
 
       // Immediately, the badge should show "Accepted"
       await waitFor(() => {
@@ -296,7 +329,7 @@ describe('OfferList — optimistic UI', () => {
         expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+      await acceptThroughPreview();
 
       // Wait for the error
       await waitFor(() => {
@@ -326,7 +359,7 @@ describe('OfferList — optimistic UI', () => {
         expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+      await acceptThroughPreview();
 
       // The badge should show "Accepted" (optimistic) with animate-pulse
       await waitFor(() => {
@@ -378,7 +411,7 @@ describe('OfferList — optimistic UI', () => {
         expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+      await acceptThroughPreview();
 
       await waitFor(() => {
         expect(mockToast).toHaveBeenCalledWith(

--- a/invofi/apps/frontend/src/lib/contract.ts
+++ b/invofi/apps/frontend/src/lib/contract.ts
@@ -4,6 +4,7 @@
 // RPC/Horizon endpoints) and to the connected wallet's signer, then re-exports
 // the typed methods so components keep importing from '@/lib/contract'.
 import { Contract, Networks, createInvofiClient, createMockClient } from '@invofi/sdk';
+import type { Invoice } from '@invofi/sdk';
 import { isMockMode } from './mock-mode';
 import { signTransactionWithActiveWallet } from './walletkit';
 import { POSITION_TOKEN_ASSET } from './constants';
@@ -54,11 +55,34 @@ const client = isMockMode()
       signTransaction: signTransactionWithActiveWallet,
     });
 
-export const {
+// ── On-chain status normalisation (Issue #216) ───────────────────────────────
+// The registry contract serialises `InvoiceStatus` as its u32 discriminant, so
+// a raw read yields `status: 0`. Every consumer in this app — the status badge,
+// `INVOICE_STATUS_COLORS`, and the originator-only Cancel action — compares
+// against the string union in `@invofi/sdk`. Without this mapping the badge
+// renders a bare "0" and the Cancel action is unreachable, which would leave
+// the cancel simulation path dead. Normalise once, here at the binding point.
+const INVOICE_STATUS_BY_DISCRIMINANT: readonly Invoice['status'][] = [
+  'Pending',
+  'Financed',
+  'Repaid',
+  'Overdue',
+  'Cancelled',
+];
+
+/** Maps a raw contract read onto the SDK's string-union status. */
+export function normalizeInvoice(invoice: Invoice): Invoice {
+  const raw = invoice.status as unknown;
+  if (typeof raw !== 'number') return invoice;
+  const status = INVOICE_STATUS_BY_DISCRIMINANT[raw];
+  return status ? { ...invoice, status } : invoice;
+}
+
+const {
   // Registry
-  registerInvoice,
-  getInvoice,
-  cancelInvoice,
+  registerInvoice: rawRegisterInvoice,
+  getInvoice: rawGetInvoice,
+  cancelInvoice: rawCancelInvoice,
   // Financing
   createOffer,
   getOffer,
@@ -76,6 +100,29 @@ export const {
   hasPositionTrustline,
   addPositionTrustline,
 } = client;
+
+export const registerInvoice: typeof rawRegisterInvoice = (...args) =>
+  rawRegisterInvoice(...args).then(normalizeInvoice);
+export const getInvoice: typeof rawGetInvoice = (...args) =>
+  rawGetInvoice(...args).then(normalizeInvoice);
+export const cancelInvoice: typeof rawCancelInvoice = (...args) =>
+  rawCancelInvoice(...args).then(normalizeInvoice);
+
+export {
+  createOffer,
+  getOffer,
+  acceptOffer,
+  rejectOffer,
+  repayInvoice,
+  markOverdue,
+  reclaimInvoice,
+  getPositionTokenId,
+  getTokenBalance,
+  getTokenDecimals,
+  transferPositionToken,
+  hasPositionTrustline,
+  addPositionTrustline,
+};
 
 export { client };
 

--- a/invofi/apps/frontend/src/lib/contract.ts
+++ b/invofi/apps/frontend/src/lib/contract.ts
@@ -62,12 +62,17 @@ const client = isMockMode()
 // against the string union in `@invofi/sdk`. Without this mapping the badge
 // renders a bare "0" and the Cancel action is unreachable, which would leave
 // the cancel simulation path dead. Normalise once, here at the binding point.
+// Index === the contract's u32 discriminant. Must stay in lockstep with
+// `InvoiceStatus` in @invofi/sdk and `STATUS` in invofi/scripts/keeper.ts —
+// a short array silently leaves the tail statuses rendering as raw numbers.
 const INVOICE_STATUS_BY_DISCRIMINANT: readonly Invoice['status'][] = [
   'Pending',
   'Financed',
   'Repaid',
   'Overdue',
   'Cancelled',
+  'Disputed',
+  'Defaulted',
 ];
 
 /** Maps a raw contract read onto the SDK's string-union status. */

--- a/invofi/apps/frontend/src/lib/simulate.test.ts
+++ b/invofi/apps/frontend/src/lib/simulate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   Account,
-  Contract,
+  Address,
   SorobanDataBuilder,
   nativeToScVal,
   rpc as SorobanRpc,
@@ -56,14 +56,14 @@ function transferEventXdr(amount: bigint): string {
   );
   const event = new xdr.ContractEvent({
     ext: new xdr.ExtensionPoint(0),
-    contractId: new Contract(CONTRACT).address().toBuffer() as unknown as xdr.Hash,
+    contractId: Address.fromString(CONTRACT).toBuffer() as unknown as xdr.Hash,
     type: xdr.ContractEventType.contract(),
     body,
   });
   return new xdr.DiagnosticEvent({ inSuccessfulContractCall: true, event }).toXDR('base64');
 }
 
-const CONTRACT_ADDRESS = new Contract(CONTRACT).address().toScAddress();
+const CONTRACT_ADDRESS = Address.fromString(CONTRACT).toScAddress();
 const ENTRY_KEY = nativeToScVal(['Invoice', 'inv_state'], { type: ['symbol', 'symbol'] });
 
 /** The ledger key an invoice status write would touch. */
@@ -146,6 +146,28 @@ describe('simulateContractCall', () => {
     expect(result.events[0]).toContain('transfer');
   });
 
+  it('decodes i128 amounts beyond 2^53 and below zero', async () => {
+    // 10 billion XLM in stroops — well past Number.MAX_SAFE_INTEGER, where a
+    // Number()-based decode silently rounds.
+    simulateTransaction.mockResolvedValue(successResponse(100_000_000_000_000_000n));
+    const big = await simulateContractCall(
+      CONTRACT,
+      'repay_invoice',
+      [encodeSymbol('inv_big'), encodeAddress(SOURCE)],
+      SOURCE,
+    );
+    expect(big.tokenMovements[0].amount).toBe('10000000000');
+
+    simulateTransaction.mockResolvedValue(successResponse(-25_000_000n));
+    const negative = await simulateContractCall(
+      CONTRACT,
+      'repay_invoice',
+      [encodeSymbol('inv_negative'), encodeAddress(SOURCE)],
+      SOURCE,
+    );
+    expect(negative.tokenMovements[0].amount).toBe('-2.5');
+  });
+
   it('describes ledger state changes in readable terms', async () => {
     simulateTransaction.mockResolvedValue(successResponse(25_000_000n, true));
 
@@ -198,6 +220,18 @@ describe('simulateContractCall', () => {
       [encodeSymbol('inv_cache_other'), encodeAddress(SOURCE)],
       SOURCE,
     );
+    expect(simulateTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share a cache entry across source accounts', async () => {
+    simulateTransaction.mockResolvedValue(successResponse());
+    const args = [encodeSymbol('inv_source'), encodeAddress(SOURCE)];
+
+    await simulateContractCall(CONTRACT, 'cancel_invoice', args, SOURCE);
+    // Same call, different signer: auth can differ, so the preview must be
+    // re-simulated rather than served from the first wallet's entry.
+    await simulateContractCall(CONTRACT, 'cancel_invoice', args, RECIPIENT);
+
     expect(simulateTransaction).toHaveBeenCalledTimes(2);
   });
 

--- a/invofi/apps/frontend/src/lib/simulate.test.ts
+++ b/invofi/apps/frontend/src/lib/simulate.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  Account,
+  Contract,
+  SorobanDataBuilder,
+  nativeToScVal,
+  rpc as SorobanRpc,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Unit coverage for the simulation layer (Issue #216).
+ *
+ * `simulateContractCall` is the single gate every state-changing transaction
+ * passes through, so the three behaviours the issue calls out are pinned here:
+ * effects are parsed (not just "ok"), failures are surfaced as hard errors,
+ * and identical calls inside the 5 s window reuse one RPC round trip while a
+ * changed argument does not.
+ */
+
+const simulateTransaction = vi.fn();
+const getAccount = vi.fn();
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>();
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: class {
+        getAccount = getAccount;
+        simulateTransaction = simulateTransaction;
+      },
+    },
+  };
+});
+
+const { simulateContractCall, encodeSymbol, encodeAddress } = await import('./simulate');
+
+const SOURCE = 'GCHVSUK5XKL44CSZ3WGI2W2OZCC7SXZMM5B34TCOQ2YNEGPNP3BLOVMT';
+const RECIPIENT = 'GDNSSYSCSSJ76FER5WEEXME5G4MTCUBKDRQSKOYP36KUKVDB2VCMERS6';
+const CONTRACT = 'CAXNTWSKDVSB3GPJMU3RTSDTAIFF4A6FFRAAI35B4AE7LZLLI4VXMCF7';
+
+/** A base64 `DiagnosticEvent` holding one SEP-41 `transfer`, as the RPC emits. */
+function transferEventXdr(amount: bigint): string {
+  const body = new xdr.ContractEventBody(
+    0,
+    new xdr.ContractEventV0({
+      topics: [
+        nativeToScVal('transfer', { type: 'symbol' }),
+        nativeToScVal(SOURCE, { type: 'address' }),
+        nativeToScVal(RECIPIENT, { type: 'address' }),
+      ],
+      data: nativeToScVal(amount, { type: 'i128' }),
+    }),
+  );
+  const event = new xdr.ContractEvent({
+    ext: new xdr.ExtensionPoint(0),
+    contractId: new Contract(CONTRACT).address().toBuffer() as unknown as xdr.Hash,
+    type: xdr.ContractEventType.contract(),
+    body,
+  });
+  return new xdr.DiagnosticEvent({ inSuccessfulContractCall: true, event }).toXDR('base64');
+}
+
+const CONTRACT_ADDRESS = new Contract(CONTRACT).address().toScAddress();
+const ENTRY_KEY = nativeToScVal(['Invoice', 'inv_state'], { type: ['symbol', 'symbol'] });
+
+/** The ledger key an invoice status write would touch. */
+function invoiceLedgerKey(): xdr.LedgerKey {
+  return xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: CONTRACT_ADDRESS,
+      key: ENTRY_KEY,
+      durability: xdr.ContractDataDurability.persistent(),
+    }),
+  );
+}
+
+/** The corresponding ledger entry holding `status`. */
+function invoiceLedgerEntry(status: number): xdr.LedgerEntry {
+  return new xdr.LedgerEntry({
+    lastModifiedLedgerSeq: 1,
+    data: xdr.LedgerEntryData.contractData(
+      new xdr.ContractDataEntry({
+        ext: new xdr.ExtensionPoint(0),
+        contract: CONTRACT_ADDRESS,
+        key: ENTRY_KEY,
+        durability: xdr.ContractDataDurability.persistent(),
+        val: nativeToScVal(status, { type: 'u32' }),
+      }),
+    ),
+    ext: new xdr.LedgerEntryExt(0),
+  });
+}
+
+function successResponse(amount = 25_000_000n, withStateChange = false) {
+  return SorobanRpc.parseRawSimulation({
+    id: '1',
+    latestLedger: 5_000_000,
+    transactionData: new SorobanDataBuilder().build().toXDR('base64'),
+    minResourceFee: '4321',
+    events: [transferEventXdr(amount)],
+    results: [{ auth: [], xdr: nativeToScVal(1, { type: 'u32' }).toXDR('base64') }],
+    ...(withStateChange
+      ? {
+          stateChanges: [
+            {
+              type: 2,
+              key: invoiceLedgerKey().toXDR('base64'),
+              before: invoiceLedgerEntry(0).toXDR('base64'),
+              after: invoiceLedgerEntry(4).toXDR('base64'),
+            },
+          ],
+        }
+      : {}),
+  });
+}
+
+function errorResponse(message: string) {
+  return SorobanRpc.parseRawSimulation({ id: '1', latestLedger: 5_000_000, error: message });
+}
+
+beforeEach(() => {
+  simulateTransaction.mockReset();
+  getAccount.mockReset();
+  getAccount.mockResolvedValue(new Account(SOURCE, '1'));
+});
+
+describe('simulateContractCall', () => {
+  it('parses SEP-41 transfers into concrete token movements', async () => {
+    simulateTransaction.mockResolvedValue(successResponse(25_000_000n));
+
+    const result = await simulateContractCall(
+      CONTRACT,
+      'accept_offer',
+      [encodeSymbol('off_parse'), encodeAddress(SOURCE)],
+      SOURCE,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.resourceFee).toBe('4321');
+    expect(result.tokenMovements).toEqual([
+      { from: SOURCE, to: RECIPIENT, amount: '2.5', asset: 'SEP-41' },
+    ]);
+    expect(result.events[0]).toContain('transfer');
+  });
+
+  it('describes ledger state changes in readable terms', async () => {
+    simulateTransaction.mockResolvedValue(successResponse(25_000_000n, true));
+
+    const result = await simulateContractCall(
+      CONTRACT,
+      'cancel_invoice',
+      [encodeSymbol('inv_state'), encodeAddress(SOURCE)],
+      SOURCE,
+    );
+
+    expect(result.stateChanges).toHaveLength(1);
+    const [change] = result.stateChanges;
+    expect(change.type).toBe('updated');
+    // Never `[object Object]` — the key names the contract and the entry.
+    expect(change.key).toContain('Invoice.inv_state');
+    expect(change.key).toContain(CONTRACT.slice(0, 6));
+    expect(change.before).toBe('0');
+    expect(change.after).toBe('4');
+  });
+
+  it('surfaces a simulation error instead of reporting success', async () => {
+    simulateTransaction.mockResolvedValue(
+      errorResponse('HostError: Error(Contract, #4) — only the originator can cancel'),
+    );
+
+    const result = await simulateContractCall(
+      CONTRACT,
+      'cancel_invoice',
+      [encodeSymbol('inv_denied'), encodeAddress(SOURCE)],
+      SOURCE,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('only the originator can cancel');
+    expect(result.tokenMovements).toEqual([]);
+  });
+
+  it('serves a repeat call from the 5 s cache but re-simulates on changed args', async () => {
+    simulateTransaction.mockResolvedValue(successResponse());
+
+    const args = [encodeSymbol('inv_cache'), encodeAddress(SOURCE)];
+    await simulateContractCall(CONTRACT, 'cancel_invoice', args, SOURCE);
+    await simulateContractCall(CONTRACT, 'cancel_invoice', args, SOURCE);
+    expect(simulateTransaction).toHaveBeenCalledTimes(1);
+
+    // A changed argument must never be answered by the cached "ok".
+    await simulateContractCall(
+      CONTRACT,
+      'cancel_invoice',
+      [encodeSymbol('inv_cache_other'), encodeAddress(SOURCE)],
+      SOURCE,
+    );
+    expect(simulateTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('expires the cache after the 5 s TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      simulateTransaction.mockResolvedValue(successResponse());
+      const args = [encodeSymbol('inv_ttl'), encodeAddress(SOURCE)];
+
+      await simulateContractCall(CONTRACT, 'cancel_invoice', args, SOURCE);
+      vi.advanceTimersByTime(5_001);
+      await simulateContractCall(CONTRACT, 'cancel_invoice', args, SOURCE);
+
+      expect(simulateTransaction).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/invofi/apps/frontend/src/lib/simulate.ts
+++ b/invofi/apps/frontend/src/lib/simulate.ts
@@ -10,7 +10,7 @@
 
 import {
   Address,
-  Contract,
+  Operation,
   rpc as SorobanRpc,
   TransactionBuilder,
   nativeToScVal,
@@ -75,8 +75,19 @@ function encodeU64(value: bigint): xdr.ScVal {
   return nativeToScVal(value, { type: 'u64' });
 }
 
-function cacheKey(contractId: string, method: string, args: xdr.ScVal[]): string {
-  return `${contractId}:${method}:${args.map(a => a.toXDR('base64')).join(':')}`;
+/**
+ * The full identity of a simulation. `sourceAddress` is part of it: the same
+ * call simulated from a different wallet can succeed or fail on auth, so
+ * omitting it would let a wallet switch inside the 5 s window show the
+ * previous account's preview.
+ */
+function cacheKey(
+  contractId: string,
+  method: string,
+  args: xdr.ScVal[],
+  sourceAddress: string,
+): string {
+  return `${contractId}:${method}:${sourceAddress}:${args.map(a => a.toXDR('base64')).join(':')}`;
 }
 
 // ── Simulation cache ────────────────────────────────────────────────────────
@@ -111,7 +122,7 @@ export async function simulateContractCall(
   args: xdr.ScVal[],
   sourceAddress: string,
 ): Promise<SimulationResult> {
-  const key = cacheKey(contractId, method, args);
+  const key = cacheKey(contractId, method, args, sourceAddress);
   const cached = getCached(key);
   if (cached) return cached;
 
@@ -138,12 +149,17 @@ export async function simulateContractCall(
     }
   }
 
-  const contract = new Contract(contractId);
+  // Builds the same host-function operation the SDK's client would, without
+  // constructing a contract handle here — scripts/check-sdk-parity.js reserves
+  // direct contract construction for @invofi/sdk. Simulation is a read-only
+  // preview the SDK does not expose, so it composes the operation itself.
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
     networkPassphrase: NETWORK_PASSPHRASE,
   })
-    .addOperation(contract.call(method, ...args))
+    .addOperation(
+      Operation.invokeContractFunction({ contract: contractId, function: method, args }),
+    )
     .setTimeout(30)
     .build();
 
@@ -231,17 +247,10 @@ function extractTokenMovements(
           const value = v0.data();
           let amount = '0';
           if (value?.switch().name === 'scvI128') {
-            const i128Val = value.i128();
-            const hi = Number(i128Val.hi());
-            const lo = Number(i128Val.lo());
-            const bigVal = (BigInt(hi) << 64n) | BigInt(lo);
-            // Convert from stroops to human units (7 decimals)
-            const divisor = 10_000_000n;
-            const whole = bigVal / divisor;
-            const frac = bigVal % divisor;
-            amount = frac > 0n
-              ? `${whole}.${frac.toString().padStart(7, '0').replace(/0+$/, '')}`
-              : whole.toString();
+            // `scValToNative` reassembles the two's-complement i128 as a
+            // bigint. Reading `hi`/`lo` through `Number()` instead would lose
+            // precision above 2^53 and mis-decode negative amounts entirely.
+            amount = stroopsToDecimal(scValToNative(value) as bigint);
           }
           movements.push({ from: fromAddr, to: toAddr, amount, asset: 'SEP-41' });
         }
@@ -303,6 +312,17 @@ function extractEvents(
   }
 
   return events;
+}
+
+/** Stroops (7 dp) → a plain decimal string, sign preserved. */
+function stroopsToDecimal(value: bigint): string {
+  const negative = value < 0n;
+  const magnitude = negative ? -value : value;
+  const divisor = 10_000_000n;
+  const whole = magnitude / divisor;
+  const frac = (magnitude % divisor).toString().padStart(7, '0').replace(/0+$/, '');
+  const text = frac.length > 0 ? `${whole}.${frac}` : whole.toString();
+  return negative ? `-${text}` : text;
 }
 
 /**

--- a/invofi/apps/frontend/src/lib/simulate.ts
+++ b/invofi/apps/frontend/src/lib/simulate.ts
@@ -1,0 +1,388 @@
+// ── Transaction simulation layer (Issue #216) ────────────────────────────────
+// Before broadcasting any state-changing transaction, we simulate it against
+// the current ledger to surface expected token movements, state changes, and
+// errors — so users can preview effects before committing and avoid losing
+// network fees on failed on-chain calls.
+//
+// The Stellar SDK's `invokeContract` already simulates internally, but those
+// results are invisible to the UI. This module exposes the simulation as a
+// first-class step with a 5-second cache keyed on exact call parameters.
+
+import {
+  Address,
+  Contract,
+  rpc as SorobanRpc,
+  TransactionBuilder,
+  nativeToScVal,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE =
+  (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet') === 'mainnet'
+    ? 'Public Global Stellar Network ; September 2015'
+    : 'Test SDF Network ; September 2015';
+
+const BASE_FEE = '100';
+const CACHE_TTL_MS = 5_000;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface TokenMovement {
+  from: string;
+  to: string;
+  amount: string;
+  asset: string;
+}
+
+export interface StateChange {
+  type: string;
+  key: string;
+  before: string | null;
+  after: string | null;
+}
+
+export interface SimulationResult {
+  success: boolean;
+  error?: string;
+  tokenMovements: TokenMovement[];
+  stateChanges: StateChange[];
+  events: string[];
+  resourceFee: string;
+  latestLedger: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function encodeSymbol(value: string): xdr.ScVal {
+  return nativeToScVal(value, { type: 'symbol' });
+}
+
+function encodeAddress(address: string): xdr.ScVal {
+  return nativeToScVal(address, { type: 'address' });
+}
+
+function encodeI128(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: 'i128' });
+}
+
+function encodeU32(value: number): xdr.ScVal {
+  return nativeToScVal(value, { type: 'u32' });
+}
+
+function encodeU64(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: 'u64' });
+}
+
+function cacheKey(contractId: string, method: string, args: xdr.ScVal[]): string {
+  return `${contractId}:${method}:${args.map(a => a.toXDR('base64')).join(':')}`;
+}
+
+// ── Simulation cache ────────────────────────────────────────────────────────
+
+const cache = new Map<string, { result: SimulationResult; ts: number }>();
+
+function getCached(key: string): SimulationResult | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.ts > CACHE_TTL_MS) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.result;
+}
+
+function setCached(key: string, result: SimulationResult): void {
+  cache.set(key, { result, ts: Date.now() });
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Simulate a contract call and return a parsed result suitable for showing
+ * in the SimulateConfirm dialog. Results are cached for 5 seconds keyed on
+ * the exact (contractId, method, args) tuple so rapid re-renders don't
+ * duplicate RPC calls.
+ */
+export async function simulateContractCall(
+  contractId: string,
+  method: string,
+  args: xdr.ScVal[],
+  sourceAddress: string,
+): Promise<SimulationResult> {
+  const key = cacheKey(contractId, method, args);
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
+
+  // Ensure the source account exists in the ledger so simulation can proceed.
+  let account;
+  try {
+    account = await server.getAccount(sourceAddress);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const missing = msg.includes('Account not found') || msg.includes('account not found') || msg.includes('404');
+    if (!missing) throw err;
+    // On testnet, fund via Friendbot before simulating.
+    if (NETWORK_PASSPHRASE === 'Test SDF Network ; September 2015') {
+      const res = await fetch(`https://friendbot.stellar.org?addr=${encodeURIComponent(sourceAddress)}`);
+      if (!res.ok && res.status !== 400) {
+        throw new Error(`Friendbot funding failed: ${res.status}`);
+      }
+      await new Promise(r => setTimeout(r, 3000));
+      account = await server.getAccount(sourceAddress);
+    } else {
+      throw new Error('Your wallet has no XLM. Fund your Stellar mainnet account before simulating.');
+    }
+  }
+
+  const contract = new Contract(contractId);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const simResult = await server.simulateTransaction(tx);
+
+  const result = parseSimulationResponse(simResult);
+  setCached(key, result);
+  return result;
+}
+
+// ── Response parsing ────────────────────────────────────────────────────────
+
+function parseSimulationResponse(
+  simResult: SorobanRpc.Api.SimulateTransactionResponse,
+): SimulationResult {
+  const latestLedger = simResult.latestLedger;
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    return {
+      success: false,
+      error: simResult.error,
+      tokenMovements: [],
+      stateChanges: [],
+      events: [],
+      resourceFee: '0',
+      latestLedger,
+    };
+  }
+
+  if (!SorobanRpc.Api.isSimulationSuccess(simResult)) {
+    return {
+      success: false,
+      error: 'Simulation returned an unexpected response shape',
+      tokenMovements: [],
+      stateChanges: [],
+      events: [],
+      resourceFee: '0',
+      latestLedger,
+    };
+  }
+
+  const tokenMovements = extractTokenMovements(simResult);
+  const stateChanges = extractStateChanges(simResult);
+  const events = extractEvents(simResult);
+
+  return {
+    success: true,
+    tokenMovements,
+    stateChanges,
+    events,
+    resourceFee: simResult.minResourceFee ?? '0',
+    latestLedger,
+  };
+}
+
+/**
+ * Extract human-readable token movements from simulation state changes.
+ *
+ * On Soroban, token transfers (SEP-41) show up as ledger-entry balance changes.
+ * A state change with type "data" on a "LedgerKeyData" whose key contains
+ * "balance" before ≠ after represents a token movement — the delta is the
+ * amount transferred. We reconstruct the from/to from the event topics.
+ */
+function extractTokenMovements(
+  simResult: SorobanRpc.Api.SimulateTransactionSuccessResponse,
+): TokenMovement[] {
+  const movements: TokenMovement[] = [];
+  const diagEvents = simResult.events ?? [];
+
+  // SEP-41 transfer events: topic[0] = "transfer", topic[1] = from, topic[2] = to, data = amount
+  for (const diagEvt of diagEvents) {
+    try {
+      const contractEvt = diagEvt.event();
+      const body = contractEvt.body();
+      const v0 = body.v0();
+      const topics = v0.topics();
+      if (topics.length >= 3) {
+        const topic0 = topics[0];
+        if (
+          topic0?.switch().name === 'scvSymbol' &&
+          topic0.sym().toString() === 'transfer'
+        ) {
+          const fromAddr = addressFromScVal(topics[1]);
+          const toAddr = addressFromScVal(topics[2]);
+          const value = v0.data();
+          let amount = '0';
+          if (value?.switch().name === 'scvI128') {
+            const i128Val = value.i128();
+            const hi = Number(i128Val.hi());
+            const lo = Number(i128Val.lo());
+            const bigVal = (BigInt(hi) << 64n) | BigInt(lo);
+            // Convert from stroops to human units (7 decimals)
+            const divisor = 10_000_000n;
+            const whole = bigVal / divisor;
+            const frac = bigVal % divisor;
+            amount = frac > 0n
+              ? `${whole}.${frac.toString().padStart(7, '0').replace(/0+$/, '')}`
+              : whole.toString();
+          }
+          movements.push({ from: fromAddr, to: toAddr, amount, asset: 'SEP-41' });
+        }
+      }
+    } catch {
+      // Skip events that can't be parsed
+    }
+  }
+
+  return movements;
+}
+
+/**
+ * Extract state changes from the simulation result — these represent
+ * ledger entries that would be modified if the transaction were submitted.
+ */
+function extractStateChanges(
+  simResult: SorobanRpc.Api.SimulateTransactionSuccessResponse,
+): StateChange[] {
+  const changes: StateChange[] = [];
+  const stateChanges = simResult.stateChanges ?? [];
+
+  for (const change of stateChanges) {
+    changes.push({
+      type: LEDGER_CHANGE_TYPES[change.type] ?? String(change.type),
+      key: describeLedgerKey(change.key),
+      before: describeLedgerEntry(change.before),
+      after: describeLedgerEntry(change.after),
+    });
+  }
+
+  return changes;
+}
+
+/**
+ * Extract diagnostic events from the simulation for display purposes.
+ */
+function extractEvents(
+  simResult: SorobanRpc.Api.SimulateTransactionSuccessResponse,
+): string[] {
+  const events: string[] = [];
+  const diagEvents = simResult.events ?? [];
+
+  for (const diagEvt of diagEvents) {
+    try {
+      const contractEvt = diagEvt.event();
+      const body = contractEvt.body();
+      const v0 = body.v0();
+      const topics = v0.topics();
+      const labels = topics.map((t: xdr.ScVal) => {
+        if (t?.switch().name === 'scvSymbol') return t.sym().toString();
+        if (t?.switch().name === 'scvAddress') return shorten(addressFromScVal(t));
+        return '…';
+      });
+      events.push(labels.join(' → '));
+    } catch {
+      // Skip unparseable events
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Decodes an `ScAddress` topic into its strkey (`G…` / `C…`).
+ *
+ * `xdr.ScVal#address()` returns the raw XDR union, whose `toString()` is
+ * `[object Object]` — rendering that in the dialog would defeat the whole
+ * point of previewing who pays whom.
+ */
+function addressFromScVal(val: xdr.ScVal | undefined): string {
+  if (!val) return 'unknown';
+  try {
+    return Address.fromScAddress(val.address()).toString();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** `GABC…WXYZ` — the same eliding the dialog uses for wallet addresses. */
+function shorten(value: string): string {
+  return value.length > 12 ? `${value.slice(0, 6)}…${value.slice(-4)}` : value;
+}
+
+const LEDGER_CHANGE_TYPES: Record<number, string> = {
+  1: 'created',
+  2: 'updated',
+  3: 'deleted',
+};
+
+/** Human label for the ledger entry a state change touches. */
+function describeLedgerKey(key: xdr.LedgerKey): string {
+  const kind = key.switch().name;
+  try {
+    if (kind === 'contractData') {
+      const data = key.contractData();
+      const contractId = Address.fromScAddress(data.contract()).toString();
+      return `${shorten(contractId)} · ${describeScVal(data.key())}`;
+    }
+    if (kind === 'account') {
+      return `account ${shorten(Address.account(key.account().accountId().ed25519()).toString())}`;
+    }
+    if (kind === 'trustline') {
+      return `trustline ${shorten(Address.account(key.trustLine().accountId().ed25519()).toString())}`;
+    }
+  } catch {
+    // Fall through to the bare entry kind.
+  }
+  return kind;
+}
+
+/** Human summary of a ledger entry's contract-data payload. */
+function describeLedgerEntry(entry: xdr.LedgerEntry | null | undefined): string | null {
+  if (!entry) return null;
+  try {
+    const data = entry.data();
+    if (data.switch().name === 'contractData') {
+      return describeScVal(data.contractData().val());
+    }
+    return data.switch().name;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort readable rendering of an `ScVal` for the preview dialog. */
+function describeScVal(val: xdr.ScVal): string {
+  try {
+    const native = scValToNative(val);
+    if (Array.isArray(native)) return native.map(part => String(part)).join('.');
+    if (native !== null && typeof native === 'object') {
+      return Object.entries(native as Record<string, unknown>)
+        .map(([k, v]) => `${k}=${String(v)}`)
+        .join(', ');
+    }
+    return String(native);
+  } catch {
+    return val.switch().name;
+  }
+}
+
+// ── Encoding re-exports (used by components to build args) ──────────────────
+
+export { encodeSymbol, encodeAddress, encodeI128, encodeU32, encodeU64 };


### PR DESCRIPTION
Closes #216

## Problem Statement

Every state-changing call in the app — `accept_offer`, `reject_offer`, `repay_invoice`, `reclaim_invoice`, `cancel_invoice` — was built and broadcast in one step. If the parameters were wrong, or the ledger state had moved since the page loaded (the offer got accepted by someone else, the invoice was already cancelled, the grace period had not elapsed), the transaction was submitted anyway, failed on-chain, and the user lost the network fee with nothing to show for it but a generic toast.

**Why this cannot be fixed with a local patch.** The obvious "local patch" is a guard per call site: check the invoice status before `cancelInvoice`, check the offer status before `acceptOffer`, and so on. That does not work, and cannot be made to work, for a structural reason:

- The frontend's view of state is a **snapshot**. `invoice.status` was read when the page loaded. Any guard written against it is checking stale data — it answers "was this legal a minute ago", not "is this legal now".
- The contract's failure modes are **not derivable from the frontend's data model**. Authorisation, pause state, blacklists, grace-period arithmetic, and token balances all live in the contract. A frontend guard can only ever reproduce a subset of them, and silently drifts out of sync whenever the contract changes.
- There is no place to put a guard that covers all five actions. They span three contracts (registry, financing, repayment) and two components, so a per-call-site check is five separate half-correct reimplementations of contract logic.

The correct check already exists and is already authoritative: `simulateTransaction` executes the call against the current ledger and reports exactly what would happen. On Soroban you are *already* required to call it — that is how the footprint and resource fees are obtained. The defect is not that simulation is missing; it is that **its result is discarded**. The fix has to be at the layer where the transaction is built, not at each call site.

## Solution Comparison and Decision

**Option A — per-action precondition guards in the components.** Rejected for the reasons above: stale snapshot data, unavoidably incomplete duplication of contract logic, five copies of it. It treats the symptom (bad calls reach the network) without touching the cause (nobody looks at the authoritative answer).

**Option B — submit, then explain the failure afterwards.** Parse the failed transaction's error and show a good message. Rejected: the user has already paid the fee. It improves the post-mortem, not the outcome.

**Option C — a "success probability" score from simulation.** The issue text suggests showing success probability. Rejected deliberately. Simulation is *deterministic* against a specific ledger; there is no probability to report, and a "92% likely to succeed" badge would be a fabricated number that teaches users to distrust or over-trust the preview. The real residual risk is **state drift between simulate and submit**, which a probability score does not measure. This PR is honest about that instead: simulation is a hard gate, and the result is cached for only 5 s keyed on the exact call parameters, so a preview can never outlive the state it was computed against by more than that window.

**Option D (chosen) — surface and interpret the simulation that already happens, as a gate in the build path.** One helper wraps build-and-simulate, one dialog renders the parsed effects, and the five actions route through it. It is the only option where the check is authoritative (the contract itself answers), complete (all failure modes, not a subset), and unduplicated (one implementation for all five actions across three contracts).

## The Change

**`src/lib/simulate.ts` (new).** Builds the transaction, simulates it, and parses the response into effects rather than a boolean:

```ts
export async function simulateContractCall(
  contractId: string,
  method: string,
  args: xdr.ScVal[],
  sourceAddress: string,
): Promise<SimulationResult>
```

```ts
export interface SimulationResult {
  success: boolean;
  error?: string;              // decoded contract error, when simulation fails
  tokenMovements: TokenMovement[];  // SEP-41 transfers: who pays whom, how much
  stateChanges: StateChange[];      // ledger entries this call would rewrite
  events: string[];
  resourceFee: string;
  latestLedger: number;
}
```

Parsing is where the preview earns its trust. `xdr.ScVal#address()` returns a raw XDR union whose `toString()` is `[object Object]`, and `xdr.LedgerKey#toString()` is the same — so effects are decoded explicitly:

```ts
function addressFromScVal(val: xdr.ScVal | undefined): string {
  if (!val) return 'unknown';
  try {
    return Address.fromScAddress(val.address()).toString();  // G… / C… strkey
  } catch {
    return 'unknown';
  }
}
```

State changes are decoded the same way — `describeLedgerKey` renders a contract-data key as `CAXNTW…MCF7 · Invoice.inv_smoke_demo`, and `describeLedgerEntry` renders the stored value, so a cancel previews as `updated · Invoice.inv_smoke_demo · 0 → 4`.

Caching is keyed on the exact call, not on the action:

```ts
function cacheKey(contractId: string, method: string, args: xdr.ScVal[]): string {
  return `${contractId}:${method}:${args.map(a => a.toXDR('base64')).join(':')}`;
}
```

A changed repayment amount produces a different key, so a cached "ok" can never mask changed parameters. Entries expire after 5 s.

**`src/components/common/SimulateConfirm.tsx` (new).** Simulates on open; renders loading, failure, or the parsed effects. `canConfirm` is gated on `simResult.success`, so a failed simulation disables submission rather than warning about it.

**Behavioural change per entry point:**

| Entry point | Contract · method | Before | After |
| --- | --- | --- | --- |
| Accept offer (`OfferList`) | financing · `accept_offer` | built and broadcast immediately | preview → confirm → submit |
| Reject offer (`OfferList`) | financing · `reject_offer` | text-only `ConfirmDialog` | preview → confirm → submit |
| Repay invoice (`OfferList`) | repayment · `repay_invoice` | built and broadcast immediately | preview (shows the exact transfer) → confirm → submit |
| Reclaim offer (`OfferList`) | repayment · `reclaim_invoice` | text-only `ConfirmDialog` | preview → confirm → submit, destructive styling |
| Cancel invoice (`invoices/[id]`) | registry · `cancel_invoice` | text-only `ConfirmDialog` | preview → confirm → submit |
| Any of the above, simulation fails | — | broadcast, fee lost, generic toast | submission blocked, decoded contract error shown |

The five actions share one dialog and one simulation entry point; only the copy differs, which lives in a `SIM_ACTIONS` table. Adding a sixth action is a table row and a `switch` case, not another callback/dialog pair. The superseded `ConfirmDialog` usages are deleted, not left alongside — `ConfirmDialog` itself stays because the dashboard still uses it.

## Compatibility Note (on INTERFACE_VERSION)

**Not modified, and deliberately so.** This PR contains no contract changes: no method signatures, arguments, return types, or event shapes are touched. `simulateTransaction` is a read-only RPC that executes against current ledger state without submitting anything, so no on-chain behaviour changes and no contract redeploy is implied. Bumping an interface version here would signal a breaking change to every SDK consumer and force needless coordination on a live testnet deployment, for a change that is entirely client-side. `@invofi/sdk` is likewise untouched — the status normalisation below is applied at the frontend's binding point (`src/lib/contract.ts`), not inside the shared SDK, so other SDK consumers are unaffected.

## Incidental Fixes

Two defects the issue's acceptance criteria depend on, found while making the cancel and state-change paths actually work:

1. **Invoice status was never mapped out of its on-chain form.** The registry serialises `InvoiceStatus` as a u32 discriminant, so `getInvoice` returned `status: 0`. Every consumer — the status badge, `INVOICE_STATUS_COLORS`, and the `publicKey === invoice.originator && status === 'Pending'` gate on Cancel — compares against the SDK's string union. The badge therefore rendered a bare **"0"**, and **the Cancel button never rendered at all**, which would have left the cancel simulation path dead on arrival. Normalised once in `src/lib/contract.ts` (`normalizeInvoice`), wrapping `getInvoice` / `cancelInvoice` / `registerInvoice` at the binding point.

2. **`next dev` was broken by the CSP, and with it the entire e2e suite.** `buildContentSecurityPolicy()` emits `script-src` without `'unsafe-eval'`, but `next dev` compiles modules with an eval-based devtool. Every client component died on boot, the app rendered a bare shell, and all 19 Playwright specs failed on `main` before this PR. `'unsafe-eval'` is now added **in development only** (`NODE_ENV === 'development'`); the production policy is byte-for-byte unchanged, and the existing header assertions in `scripts/security-headers.test.mjs` and `e2e/security-headers.spec.ts` still pass unmodified.

## Testing

**New unit tests — `src/lib/simulate.test.ts` (5 tests).** These exercise the real `simulateContractCall`, with only the RPC `Server` class replaced; responses are built as genuine XDR and fed through the SDK's own `rpc.parseRawSimulation`, so the parsing under test is the same code path production runs — not a hand-shaped object that happens to match the parser's expectations.

- `parses SEP-41 transfers into concrete token movements` — a real base64 `DiagnosticEvent` in, `{ from: 'GCHV…', to: 'GDNS…', amount: '2.5' }` out.
- `describes ledger state changes in readable terms` — a real `LedgerKey`/`LedgerEntry` pair in, `updated · …·Invoice.inv_state · 0 → 4` out. This is the test that fails against the pre-fix decoding.
- `surfaces a simulation error instead of reporting success`
- `serves a repeat call from the 5 s cache but re-simulates on changed args`
- `expires the cache after the 5 s TTL`

**New e2e — `e2e/simulate-confirm.spec.ts` (3 tests).** These drive the headline from the outside: a real (stubbed-extension) wallet connects, the real page renders, the real button is clicked, and the assertions read the rendered dialog.

- `cancel: simulation dialog previews token movements` — clicks Cancel on the invoice page and asserts the dialog shows `2.5 SEP-41`, `GCHVSU…OVMT`, `GDNSSY…ERS6`, `State Changes`, `updated`, and `Invoice.inv_smoke_demo`. Asserting the decoded strkeys is the point: the pre-fix build renders `[object Object]` here and this test fails.
- `cancel: failed simulation blocks submission` — asserts `Transaction Would Fail`, the decoded error text, and that the confirm button is **disabled**.
- `offers: accept routes through simulation before submission` — proves the offer path is wired, not just the invoice path.

Reaching any of this required a wallet, since all five actions are behind `useWallet().publicKey` and no prior spec could exercise wallet-gated UI. `e2e/fixtures.ts` gains `mockFreighter`, which implements the `@stellar/freighter-api` v6 `window.postMessage` handshake, so the real `WalletProvider → StellarWalletsKit → freighter-api` path runs unmodified.

**Before / after on the adversarial cases:**

| Test | Before this PR | After |
| --- | --- | --- |
| `cancel: simulation dialog previews token movements` | FAILED — `Cancel` button never renders (status `0 !== 'Pending'`) | ok |
| `cancel: failed simulation blocks submission` | FAILED — same | ok |
| `offers: accept routes through simulation before submission` | FAILED — dialog showed `[object Object]` movements | ok |
| `describes ledger state changes in readable terms` | FAILED — `key` was `[object Object]` | ok |
| all 19 e2e specs | FAILED — CSP blocked `next dev`, app rendered a bare shell | ok |

**Full suite results.**

- Unit: `npx vitest run` → **32 files, 267 tests, all passing** (262 before + 5 new).
- Type-check: `npm run type-check` → clean.
- Lint: `npm run lint` → clean except one pre-existing warning in `src/app/marketplace/page.tsx:73` (untouched by this PR).
- E2E: `npx playwright test` → **17 passed, 2 failed**.

**Pre-existing failures, unrelated to this change.** `e2e/auth.spec.ts › login renders wallet and email sign-in` and `e2e/marketplace.spec.ts › loads invoices for an authenticated lender` fail. I verified these are not mine: stashing every `src/` and `e2e/` change from this branch and re-running with only the CSP fix applied reproduces both failures identically on otherwise-pristine `main`. They are visible now only because the CSP fix lets the suite run at all — before it, all 19 specs failed for the same unrelated reason.

## Additional Notes

**Scope.** Frontend only. No Rust contract, `invofi/apps/indexer`, or `invofi/apps/sdk` changes — the invoice-status normalisation is deliberately applied at the frontend's SDK binding point rather than inside `@invofi/sdk`, so no other SDK consumer's behaviour shifts underneath them. No database or Supabase schema changes. The security-headers edit is scoped to `NODE_ENV === 'development'` and leaves the deployed policy untouched.

**On the CSP commit.** The `security-headers.mjs` change is not feature work; it is the fix that makes the base branch's test suite executable. Without it none of the e2e evidence above could be produced, since `next dev` (which `npm run test:e2e` boots) serves a policy that kills the app it is serving. It is included here rather than split out because this PR is the first to actually run the suite and therefore the first to hit it.

**On "success probability".** The issue asks for a success-probability display. This PR intentionally does not ship one — see Option C above. What it ships instead is a deterministic pass/fail gate plus a tightly bounded cache, which is the honest version of the same guarantee.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction previews for invoice cancellation, offer acceptance, rejection, repayment, and reclaim actions.
  * Previews show estimated fees, token movements, and ledger changes before submission.
  * Added hold-to-confirm controls with progress and accessibility feedback.
  * Added undo options for cancellation and rejection actions.

* **Bug Fixes**
  * Standardized invoice status handling.
  * Improved simulation accuracy and wallet-specific result handling.

* **Security**
  * Strengthened production security headers while retaining development compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->