### PR TITLE
feat: add hold-to-confirm mode for destructive actions (Closes #161)

### DIFF
--- a/invofi/apps/frontend/src/app/dashboard/page.tsx
+++ b/invofi/apps/frontend/src/app/dashboard/page.tsx
@@ -259,6 +259,7 @@ export default function DashboardPage() {
         description={`Invoice ${cancelTarget?.id ?? ''} will be marked as Cancelled. This cannot be undone.`}
         confirmLabel="Yes, cancel"
         variant="destructive"
+        holdToConfirm
         onConfirm={handleCancelInvoice}
         loading={cancelling}
       />

--- a/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
@@ -208,6 +208,7 @@ export default function InvoiceDetailPage() {
           description="The invoice will be cancelled on-chain and can no longer receive financing offers. This cannot be undone."
           confirmLabel="Cancel Invoice"
           variant="destructive"
+          holdToConfirm
           onConfirm={() => {
             setConfirmCancel(false);
             handleCancel();

--- a/invofi/apps/frontend/src/components/common/ConfirmDialog.test.tsx
+++ b/invofi/apps/frontend/src/components/common/ConfirmDialog.test.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConfirmDialog } from './ConfirmDialog';
+
+function TestHarness({
+  holdToConfirm = false,
+  holdDuration = 1500,
+  variant = 'destructive',
+}: {
+  holdToConfirm?: boolean;
+  holdDuration?: number;
+  variant?: 'default' | 'destructive';
+}) {
+  const [open, setOpen] = useState(true);
+  const onConfirm = vi.fn();
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Test Action"
+      description="This action cannot be undone."
+      confirmLabel="Confirm"
+      variant={variant}
+      holdToConfirm={holdToConfirm}
+      holdDuration={holdDuration}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+describe('ConfirmDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('standard mode', () => {
+    it('renders the confirm button as a regular Button', () => {
+      render(<TestHarness holdToConfirm={false} />);
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    });
+
+    it('triggers onConfirm on single click', () => {
+      render(<TestHarness holdToConfirm={false} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    });
+  });
+
+  describe('hold-to-confirm mode', () => {
+    it('renders a custom button with progress ring', () => {
+      render(<TestHarness holdToConfirm />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+      expect(btn).toBeInTheDocument();
+      // Should have an SVG progress ring
+      expect(btn.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('shows progress percentage while holding', () => {
+      render(<TestHarness holdToConfirm holdDuration={1000} />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+
+      fireEvent.pointerDown(btn);
+
+      // Advance 300ms (~30% progress)
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(screen.getByText('30%')).toBeInTheDocument();
+
+      // Advance another 300ms (~60%)
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(screen.getByText('60%')).toBeInTheDocument();
+    });
+
+    it('calls onConfirm after holding for the full duration', () => {
+      const onConfirm = vi.fn();
+      function Test() {
+        const [open, setOpen] = useState(true);
+        return (
+          <ConfirmDialog
+            open={open}
+            onOpenChange={setOpen}
+            title="Test"
+            confirmLabel="Confirm"
+            variant="destructive"
+            holdToConfirm
+            holdDuration={1000}
+            onConfirm={onConfirm}
+          />
+        );
+      }
+      render(<Test />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+
+      fireEvent.pointerDown(btn);
+
+      // Advance past the full duration
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels on pointer up before the full duration', () => {
+      const onConfirm = vi.fn();
+      function Test() {
+        const [open, setOpen] = useState(true);
+        return (
+          <ConfirmDialog
+            open={open}
+            onOpenChange={setOpen}
+            title="Test"
+            confirmLabel="Confirm"
+            variant="destructive"
+            holdToConfirm
+            holdDuration={1000}
+            onConfirm={onConfirm}
+          />
+        );
+      }
+      render(<Test />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+
+      fireEvent.pointerDown(btn);
+
+      // Advance 300ms
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Release early
+      fireEvent.pointerUp(btn);
+
+      // Advance remaining time
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // Should NOT have called onConfirm
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('cancels on pointer leave before the full duration', () => {
+      const onConfirm = vi.fn();
+      function Test() {
+        const [open, setOpen] = useState(true);
+        return (
+          <ConfirmDialog
+            open={open}
+            onOpenChange={setOpen}
+            title="Test"
+            confirmLabel="Confirm"
+            variant="destructive"
+            holdToConfirm
+            holdDuration={1000}
+            onConfirm={onConfirm}
+          />
+        );
+      }
+      render(<Test />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+
+      fireEvent.pointerDown(btn);
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      fireEvent.pointerLeave(btn);
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('resets progress after cancellation', () => {
+      const onConfirm = vi.fn();
+      function Test() {
+        const [open, setOpen] = useState(true);
+        return (
+          <ConfirmDialog
+            open={open}
+            onOpenChange={setOpen}
+            title="Test"
+            confirmLabel="Confirm"
+            variant="destructive"
+            holdToConfirm
+            holdDuration={1000}
+            onConfirm={onConfirm}
+          />
+        );
+      }
+      render(<Test />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+
+      // Start holding
+      fireEvent.pointerDown(btn);
+      act(() => { vi.advanceTimersByTime(300); });
+      expect(screen.getByText('30%')).toBeInTheDocument();
+
+      // Cancel
+      fireEvent.pointerUp(btn);
+
+      // Confirm button should show original label again
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    });
+
+    it('has an aria-live region for screen reader announcements', () => {
+      render(<TestHarness holdToConfirm holdDuration={1000} />);
+      const liveRegion = document.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toBeInTheDocument();
+      expect(liveRegion).toHaveAttribute('role', 'status');
+    });
+
+    it('announces hold start when pointer goes down', () => {
+      render(<TestHarness holdToConfirm holdDuration={1000} />);
+      const btn = screen.getByRole('button', { name: 'Confirm' });
+
+      fireEvent.pointerDown(btn);
+
+      const liveRegion = document.querySelector('[aria-live="polite"]');
+      expect(liveRegion).toHaveTextContent('Hold to confirm');
+    });
+  });
+});

--- a/invofi/apps/frontend/src/components/common/ConfirmDialog.tsx
+++ b/invofi/apps/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -9,6 +10,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -20,7 +22,13 @@ interface ConfirmDialogProps {
   variant?: 'default' | 'destructive';
   onConfirm: () => void;
   loading?: boolean;
+  /** When true, the confirm button requires pressing and holding ~1.5s to trigger onConfirm */
+  holdToConfirm?: boolean;
+  /** Duration in ms that the button must be held (default: 1500) */
+  holdDuration?: number;
 }
+
+const HOLD_DURATION_DEFAULT = 1500;
 
 export function ConfirmDialog({
   open,
@@ -32,29 +40,171 @@ export function ConfirmDialog({
   variant = 'default',
   onConfirm,
   loading = false,
+  holdToConfirm = false,
+  holdDuration = HOLD_DURATION_DEFAULT,
 }: ConfirmDialogProps) {
+  const [holdProgress, setHoldProgress] = useState(0);
+  const [isHolding, setIsHolding] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  const holdTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const progressRef = useRef(0);
+  const announcedRef = useRef(false);
+
+  const clearHold = useCallback(() => {
+    if (holdTimerRef.current) {
+      clearInterval(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    setHoldProgress(0);
+    setIsHolding(false);
+    progressRef.current = 0;
+    announcedRef.current = false;
+  }, []);
+
+  const handlePointerDown = useCallback(() => {
+    if (loading) return;
+    setIsHolding(true);
+    progressRef.current = 0;
+    announcedRef.current = false;
+    setAnnouncement('Hold to confirm');
+
+    const interval = 30; // ~50 updates per second for smooth animation
+    const step = (interval / holdDuration) * 100;
+
+    holdTimerRef.current = setInterval(() => {
+      progressRef.current += step;
+      setHoldProgress(progressRef.current);
+
+      // Announce at 50% for screen reader awareness
+      if (progressRef.current >= 50 && !announcedRef.current) {
+        announcedRef.current = true;
+        setAnnouncement('Hold a little longer to confirm');
+      }
+
+      if (progressRef.current >= 100) {
+        clearHold();
+        onConfirm();
+      }
+    }, interval);
+  }, [loading, holdDuration, clearHold, onConfirm]);
+
+  const handlePointerUp = useCallback(() => {
+    if (isHolding && progressRef.current < 100) {
+      clearHold();
+      setAnnouncement('Confirmation cancelled');
+    }
+  }, [isHolding, clearHold]);
+
+  const handlePointerLeave = useCallback(() => {
+    if (isHolding && progressRef.current < 100) {
+      clearHold();
+      setAnnouncement('Confirmation cancelled');
+    }
+  }, [isHolding, clearHold]);
+
+  // Reset when dialog opens/closes
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      if (!newOpen) {
+        clearHold();
+        setAnnouncement('');
+      }
+      onOpenChange(newOpen);
+    },
+    [clearHold, onOpenChange],
+  );
+
+  // Circle circumference for progress ring
+  const radius = 18;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (holdProgress / 100) * circumference;
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
+
+        {/* Screen reader announcement */}
+        <div aria-live="polite" className="sr-only" role="status">
+          {announcement}
+        </div>
+
         <DialogFooter className="mt-4">
           <Button
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={loading}
           >
             {cancelLabel}
           </Button>
-          <Button
-            variant={variant === 'destructive' ? 'destructive' : 'default'}
-            onClick={onConfirm}
-            disabled={loading}
-          >
-            {loading ? 'Processing...' : confirmLabel}
-          </Button>
+
+          {holdToConfirm && !loading ? (
+            <button
+              type="button"
+              onPointerDown={handlePointerDown}
+              onPointerUp={handlePointerUp}
+              onPointerLeave={handlePointerLeave}
+              onPointerCancel={handlePointerUp}
+              className={cn(
+                'relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-md px-4 py-2 text-sm font-medium transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                'select-none',
+                variant === 'destructive'
+                  ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                  : 'bg-primary text-primary-foreground hover:bg-primary/90',
+                isHolding && 'cursor-grabbing',
+              )}
+              style={{ touchAction: 'none' }}
+              disabled={loading}
+            >
+              {/* Progress ring */}
+              <svg
+                className="absolute inset-0 h-full w-full -rotate-90"
+                viewBox="0 0 40 40"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="20"
+                  cy="20"
+                  r={radius}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  opacity="0.2"
+                />
+                <circle
+                  cx="20"
+                  cy="20"
+                  r={radius}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeDasharray={circumference}
+                  strokeDashoffset={offset}
+                  strokeLinecap="round"
+                  className="transition-[stroke-dashoffset] duration-75"
+                />
+              </svg>
+
+              {/* Text */}
+              <span className="relative z-10">
+                {isHolding
+                  ? `${Math.round(holdProgress)}%`
+                  : confirmLabel}
+              </span>
+            </button>
+          ) : (
+            <Button
+              variant={variant === 'destructive' ? 'destructive' : 'default'}
+              onClick={onConfirm}
+              disabled={loading}
+            >
+              {loading ? 'Processing...' : confirmLabel}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -373,6 +373,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
         }
         confirmLabel={confirmTarget?.kind === 'reclaim' ? 'Reclaim' : 'Reject'}
         variant={confirmTarget?.kind === 'reclaim' ? 'destructive' : 'default'}
+        holdToConfirm={confirmTarget?.kind === 'reclaim'}
         onConfirm={() => {
           if (!confirmTarget) return;
           const { offer, kind } = confirmTarget;


### PR DESCRIPTION
## Summary

Add optional hold-to-confirm mode to ConfirmDialog for high-stakes destructive actions (cancel invoice, reclaim offer). The button requires pressing and holding for ~1.5s to trigger the destructive action, preventing accidental irreversible clicks.

## Changes

- **ConfirmDialog**: New  and  props. When  is true, the confirm button shows a progress ring and percentage counter while being held. Releasing early cancels the confirmation. Screen reader announcements via  region.
- **invoices/[id]/page.tsx**: Added  to Cancel Invoice dialog
- **dashboard/page.tsx**: Added  to Cancel Invoice dialog
- **OfferList.tsx**: Added  to Reclaim Offer dialog (destructive only)

## Acceptance Criteria

- [x] Hold-to-confirm works for the flagged destructive actions
- [x] Releasing early cancels the confirmation
- [x] Screen-reader accessible (the hint is announced via aria-live)

## Tests

Comprehensive test coverage in ConfirmDialog.test.tsx:
- Standard mode renders regular button
- Hold-to-confirm mode shows progress ring
- Progress percentage updates while holding
- onConfirm called after full hold duration
- Pointer up cancels before full duration
- Pointer leave cancels
- Progress resets after cancellation
- aria-live region present and announces hold start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hold-to-confirm protection for invoice cancellation and reclaim actions.
  * Displays confirmation progress while the control is held.
  * Cancels and resets confirmation if the hold is interrupted.
  * Includes accessible status announcements for hold progress and completion.

* **Tests**
  * Added comprehensive coverage for standard and hold-to-confirm dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->