### PR TITLE
feat(settings): add Network & Contracts panel (Closes #163)

### DIFF
--- a/invofi/apps/frontend/src/app/settings/__tests__/page.test.tsx
+++ b/invofi/apps/frontend/src/app/settings/__tests__/page.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ComponentType } from 'react';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const mockRouterPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+const mockSignOut = vi.fn();
+vi.mock('@/utils/supabase/client', () => ({
+  createClient: () => ({ auth: { signOut: mockSignOut } }),
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// constants.ts reads process.env at module scope, so the page and its
+// constants must be re-imported after each env change (vi.resetModules).
+async function renderSettingsPage() {
+  vi.resetModules();
+  const { default: SettingsPage } = await import('../page');
+  const Page = SettingsPage as ComponentType;
+  return render(<Page />);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+describe('SettingsPage — Network & Contracts panel (issue #163)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.NEXT_PUBLIC_RPC_URL;
+    delete process.env.NEXT_PUBLIC_HORIZON_URL;
+    delete process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_FINANCING_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_REPAYMENT_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+    delete process.env.NEXT_PUBLIC_CONTRACT_ID;
+  });
+
+  it('renders the settings page with Profile, Network & Contracts and Account cards', async () => {
+    await renderSettingsPage();
+    expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument();
+    expect(screen.getByText('Network & Contracts')).toBeInTheDocument();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+  });
+
+  it('shows the network, RPC and Horizon endpoints', async () => {
+    await renderSettingsPage();
+
+    // Defaults from constants.ts: testnet network, default RPC/Horizon URLs
+    expect(screen.getByText('Stellar Network')).toBeInTheDocument();
+    expect(screen.getByText('testnet')).toBeInTheDocument();
+    expect(screen.getByText('RPC URL')).toBeInTheDocument();
+    expect(screen.getByText('https://soroban-testnet.stellar.org')).toBeInTheDocument();
+    expect(screen.getByText('Horizon URL')).toBeInTheDocument();
+    expect(screen.getByText('https://horizon-testnet.stellar.org')).toBeInTheDocument();
+  });
+
+  it('renders one contract row per contract and exposes explorer + copy actions', async () => {
+    process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID = 'CA-REGISTRY-FOO';
+    process.env.NEXT_PUBLIC_FINANCING_CONTRACT_ID = 'CA-FINANCING-BAR';
+    process.env.NEXT_PUBLIC_REPAYMENT_CONTRACT_ID = 'CA-REPAYMENT-BAZ';
+
+    await renderSettingsPage();
+
+    expect(screen.getByText('Registry')).toBeInTheDocument();
+    expect(screen.getByText('Financing')).toBeInTheDocument();
+    expect(screen.getByText('Repayment')).toBeInTheDocument();
+
+    expect(screen.getByText('CA-REGISTRY-FOO')).toBeInTheDocument();
+    expect(screen.getByText('CA-FINANCING-BAR')).toBeInTheDocument();
+    expect(screen.getByText('CA-REPAYMENT-BAZ')).toBeInTheDocument();
+
+    // One Explorer link per contract, network-aware
+    const links = screen.getAllByRole('link', { name: /open .* contract/i });
+    expect(links).toHaveLength(3);
+    expect(links[0]).toHaveAttribute('href', 'https://stellar.expert/explorer/testnet/contract/CA-REGISTRY-FOO');
+    expect(links[1]).toHaveAttribute('href', 'https://stellar.expert/explorer/testnet/contract/CA-FINANCING-BAR');
+    expect(links[2]).toHaveAttribute('href', 'https://stellar.expert/explorer/testnet/contract/CA-REPAYMENT-BAZ');
+
+    // One copy button per contract
+    expect(screen.getAllByRole('button', { name: /copy .* contract id/i })).toHaveLength(3);
+  });
+
+  it('copies the contract ID to the clipboard and shows a Copied state', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID = 'CA-COPY-ME';
+
+    await renderSettingsPage();
+
+    const copyButton = screen.getByRole('button', { name: 'Copy Registry contract ID' });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('CA-COPY-ME');
+    });
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
+  });
+
+  it('shows a "not configured" warning for missing contract IDs', async () => {
+    // No contract env vars set → all three rows fall back to the empty legacy contract id
+    await renderSettingsPage();
+
+    expect(screen.getAllByText('— not configured')).toHaveLength(3);
+  });
+
+  it('falls back to the legacy contract id when 3-contract vars are unset', async () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = 'CA-LEGACY-ONLY';
+
+    await renderSettingsPage();
+
+    // Legacy deployment routes all three contracts to one id
+    expect(screen.getAllByText('CA-LEGACY-ONLY')).toHaveLength(3);
+    expect(screen.queryByText('— not configured')).not.toBeInTheDocument();
+  });
+
+  it('uses the mainnet explorer base when the network is mainnet', async () => {
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'mainnet';
+    process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID = 'CA-MAINNET';
+
+    await renderSettingsPage();
+
+    const link = screen.getByRole('link', { name: /open registry contract/i });
+    expect(link).toHaveAttribute('href', 'https://stellar.expert/explorer/public/contract/CA-MAINNET');
+  });
+
+  it('calls supabase signOut and navigates home on sign out', async () => {
+    mockSignOut.mockResolvedValue(undefined);
+    await renderSettingsPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /sign out/i }));
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledOnce();
+    });
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/invofi/apps/frontend/src/app/settings/page.tsx
+++ b/invofi/apps/frontend/src/app/settings/page.tsx
@@ -3,12 +3,109 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { User, ChevronRight } from 'lucide-react';
+import { Check, ChevronRight, Copy, ExternalLink, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useToast } from '@/components/ui/use-toast';
 import { createClient } from '@/utils/supabase/client';
+import {
+  EXPLORER_BASE,
+  FINANCING_CONTRACT_ID,
+  HORIZON_URL,
+  REGISTRY_CONTRACT_ID,
+  REPAYMENT_CONTRACT_ID,
+  RPC_URL,
+  STELLAR_NETWORK,
+} from '@/lib/constants';
+
+interface ContractRowProps {
+  /** Human-readable label for the contract, e.g. "Registry". */
+  label: string;
+  /** Contract ID from env; empty means the deployment omitted it. */
+  contractId: string;
+}
+
+/** One contract row: ID + copy button + Stellar Expert deep link, or a "not
+ *  configured" warning when the env var is missing. */
+function ContractRow({ label, contractId }: ContractRowProps) {
+  const [copied, setCopied] = useState(false);
+  const { toast } = useToast();
+
+  const copyId = async () => {
+    try {
+      await navigator.clipboard.writeText(contractId);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast({ title: 'Copy failed', description: 'Could not access the clipboard.', variant: 'destructive' });
+    }
+  };
+
+  if (!contractId) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+        <span className="font-medium">{label}</span>
+        <span className="text-amber-600">— not configured</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-md border border-gray-100 px-3 py-2">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-700">{label}</p>
+        <p className="text-xs text-gray-500 mt-0.5 font-mono truncate" title={contractId}>
+          {contractId}
+        </p>
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onClick={copyId}
+          className="inline-flex items-center gap-1 text-xs font-medium text-gray-600 hover:text-gray-900 rounded-md px-2 py-1 hover:bg-gray-100 transition-colors"
+          aria-label={`Copy ${label} contract ID`}
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-green-600" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+        <a
+          href={explorerContractUrl(contractId)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs font-medium text-gray-600 hover:text-gray-900 rounded-md px-2 py-1 hover:bg-gray-100 transition-colors"
+          aria-label={`Open ${label} contract on Stellar Expert`}
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          Explorer
+        </a>
+      </div>
+    </div>
+  );
+}
+
+const explorerContractUrl = (contractId: string) => `${EXPLORER_BASE}/contract/${contractId}`;
+
+interface EndpointRowProps {
+  label: string;
+  value: string;
+}
+
+/** Endpoint row: shows the value or an explicit "not configured" warning. */
+function EndpointRow({ label, value }: EndpointRowProps) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <p className="text-sm font-medium text-gray-700">{label}</p>
+      {value ? (
+        <p className="text-xs text-gray-500 mt-0.5 text-right break-all max-w-[70%]" title={value}>
+          {value}
+        </p>
+      ) : (
+        <p className="text-xs text-amber-600 whitespace-nowrap">not configured</p>
+      )}
+    </div>
+  );
+}
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -45,20 +142,32 @@ export default function SettingsPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Network</CardTitle>
+            <CardTitle className="text-base">Network &amp; Contracts</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-gray-700">Stellar Network</p>
-                <p className="text-xs text-gray-500 mt-0.5">
-                  {process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet'}
-                </p>
+                <p className="text-xs text-gray-500 mt-0.5 capitalize">{STELLAR_NETWORK}</p>
               </div>
               <span className="inline-flex items-center gap-1.5 text-xs font-medium text-green-700 bg-green-50 border border-green-200 rounded-full px-3 py-1">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
                 Connected
               </span>
+            </div>
+
+            <div className="space-y-2.5">
+              <EndpointRow label="RPC URL" value={RPC_URL} />
+              <EndpointRow label="Horizon URL" value={HORIZON_URL} />
+            </div>
+
+            <div className="pt-1">
+              <p className="text-sm font-medium text-gray-700 mb-2">Contracts</p>
+              <div className="space-y-2">
+                <ContractRow label="Registry" contractId={REGISTRY_CONTRACT_ID} />
+                <ContractRow label="Financing" contractId={FINANCING_CONTRACT_ID} />
+                <ContractRow label="Repayment" contractId={REPAYMENT_CONTRACT_ID} />
+              </div>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
Adds a "Network & Contracts" panel to the settings page (issue #163).

The previous Network card only showed the Stellar network name. This panel now displays:
- **Active network** (testnet/mainnet) with the Connected badge
- **RPC URL** and **Horizon URL** endpoints
- **All three contract IDs** (Registry, Financing, Repayment) with:
  - Full ID displayed with monospace truncation + hover tooltip
  - A **copy button** per contract ID (with "Copied" feedback)
  - A **Stellar Expert deep link** per contract ID (network-aware)
- Explicit **"not configured"** warning state when an env var is missing

## Scope
- Reuses the existing exported constants from `@/lib/constants` (`STELLAR_NETWORK`, `RPC_URL`, `HORIZON_URL`, `REGISTRY_CONTRACT_ID`, `FINANCING_CONTRACT_ID`, `REPAYMENT_CONTRACT_ID`, `EXPLORER_BASE`)
- Read-only display — no editable settings introduced
- Legacy fallback works: when only `NEXT_PUBLIC_CONTRACT_ID` is set, all three rows route to that single ID

## Files changed
- `apps/frontend/src/app/settings/page.tsx` — added the panel (2 small presentational components: `ContractRow`, `EndpointRow`)
- `apps/frontend/src/app/settings/__tests__/page.test.tsx` — 8 new tests covering rendering, explorer links, copy interaction, not-configured state, legacy fallback, and mainnet explorer base

## Tests
```bash
NODE_ENV=development npx vitest run src/app/settings/__tests__/page.test.tsx
# Test Files  1 passed (1)
# Tests       8 passed (8)
```

Closes #163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Stellar network endpoint and contract details to the Settings page.
  - Added one-click copying for contract IDs.
  - Added links to view contracts in Stellar Expert.
  - Clearly indicates when contract configuration is unavailable.
  - Added network-aware explorer links, including mainnet support.

- **Bug Fixes**
  - Improved sign-out behavior and handling of legacy contract configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->