### PR TITLE
fix(frontend): include /contracts route in sitemap and robots (Closes #135)

### DIFF
--- a/invofi/apps/frontend/src/app/robots.ts
+++ b/invofi/apps/frontend/src/app/robots.ts
@@ -11,7 +11,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
-      allow: ['/', '/marketplace', '/marketplace/positions', '/stats'],
+      allow: ['/', '/marketplace', '/marketplace/positions', '/stats', '/contracts'],
       disallow: [
         '/dashboard/',
         '/invoices/',

--- a/invofi/apps/frontend/src/app/sitemap.ts
+++ b/invofi/apps/frontend/src/app/sitemap.ts
@@ -38,6 +38,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'daily',
       priority: 0.8,
     },
+    {
+      url: `${BASE}/contracts`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
 
     // ── Auth pages ────────────────────────────────────────────────────────
     {


### PR DESCRIPTION
Refreshes `sitemap.ts` and `robots.ts` to include the `/contracts` route among the publicly crawlable pages.

**Changes:**
- `sitemap.ts`: added `/contracts` entry (changeFrequency: weekly, priority: 0.7)
- `robots.ts`: added `/contracts` to the allow list

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **SEO Improvements**
  * Added the public contracts page to the sitemap.
  * Enabled search engines to crawl and index the contracts page.
  * Configured weekly updates and a priority of 0.7 for the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->