### PR TITLE
feat(frontend): add reusable ExplorerLink component (Closes #130)

### DIFF
--- a/invofi/apps/frontend/src/app/portfolio/page.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/page.tsx
@@ -19,6 +19,7 @@ import { stroopsToUsd } from '@/lib/live/prices';
 import { useLivePortfolio } from '@/components/portfolio/LivePortfolioProvider';
 import { ConnectionStatus } from '@/components/portfolio/ConnectionStatus';
 import { RepaymentProgress } from '@/components/portfolio/RepaymentProgress';
+import { ExplorerLink } from '@/components/common/ExplorerLink';
 import type { LivePosition } from '@/lib/live/types';
 
 
@@ -296,14 +297,13 @@ function PositionCard({ offer }: { offer: LivePosition }) {
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <CopyId id={offer.invoice_id} />
-                <a
-                  href={`https://stellar.expert/explorer/${NETWORK}/contract/${offer.invoice_id}`}
-                  target="_blank"
-                  rel="noreferrer noopener"
+                <ExplorerLink
+                  type="contract"
+                  value={offer.invoice_id}
                   className="text-xs text-blue-500 hover:underline"
                 >
                   ↗
-                </a>
+                </ExplorerLink>
               </div>
               <p className="text-xs text-muted-foreground">
                 {interestRateLabel(offer.interest_rate)} · {durationLabel(offer.duration)}

--- a/invofi/apps/frontend/src/components/common/ExplorerLink.test.tsx
+++ b/invofi/apps/frontend/src/components/common/ExplorerLink.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ExplorerLink } from './ExplorerLink';
+
+describe('ExplorerLink', () => {
+  it('renders a contract link with the correct href', () => {
+    render(<ExplorerLink type="contract" value="abc123" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/testnet/contract/abc123',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+
+  it('renders an account link', () => {
+    render(<ExplorerLink type="account" value="GABCDEF123456" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/testnet/account/GABCDEF123456',
+    );
+  });
+
+  it('renders a transaction link', () => {
+    render(<ExplorerLink type="tx" value="txhash" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/testnet/tx/txhash',
+    );
+  });
+
+  it('renders children instead of the raw value', () => {
+    render(<ExplorerLink type="contract" value="abc123">View</ExplorerLink>);
+    expect(screen.getByRole('link')).toHaveTextContent('View');
+  });
+
+  it('applies a custom className', () => {
+    render(<ExplorerLink type="contract" value="abc123" className="font-mono" />);
+    expect(screen.getByRole('link')).toHaveClass('font-mono');
+  });
+
+  it('defaults title to "View on Stellar Expert"', () => {
+    render(<ExplorerLink type="contract" value="abc123" />);
+    expect(screen.getByRole('link')).toHaveAttribute('title', 'View on Stellar Expert');
+  });
+
+  it('accepts a custom title', () => {
+    render(<ExplorerLink type="contract" value="abc123" title="Check it out" />);
+    expect(screen.getByRole('link')).toHaveAttribute('title', 'Check it out');
+  });
+});

--- a/invofi/apps/frontend/src/components/common/ExplorerLink.tsx
+++ b/invofi/apps/frontend/src/components/common/ExplorerLink.tsx
@@ -1,0 +1,41 @@
+import { explorerContractUrl, explorerAccountUrl, explorerTxUrl } from '@/lib/constants';
+
+interface ExplorerLinkProps {
+  type: 'contract' | 'account' | 'tx';
+  value: string;
+  children?: React.ReactNode;
+  className?: string;
+  title?: string;
+}
+
+/**
+ * Reusable Stellar Expert explorer link.
+ * Uses the network-aware helpers from `@/lib/constants` so testnet vs mainnet
+ * is handled in one place — no inline `STELLAR_EXPERT` constants in call sites.
+ */
+export function ExplorerLink({
+  type,
+  value,
+  children,
+  className = '',
+  title,
+}: ExplorerLinkProps) {
+  const url =
+    type === 'contract'
+      ? explorerContractUrl(value)
+      : type === 'account'
+        ? explorerAccountUrl(value)
+        : explorerTxUrl(value);
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={className}
+      title={title ?? 'View on Stellar Expert'}
+    >
+      {children ?? value}
+    </a>
+  );
+}

--- a/invofi/apps/frontend/src/components/layout/Footer.tsx
+++ b/invofi/apps/frontend/src/components/layout/Footer.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { REGISTRY_CONTRACT_ID, STELLAR_NETWORK, explorerContractUrl } from '@/lib/constants';
+import { ExplorerLink } from '@/components/common/ExplorerLink';
+import { REGISTRY_CONTRACT_ID, STELLAR_NETWORK } from '@/lib/constants';
 import { Heart } from 'lucide-react';
 
 const SITE_MAP = {
@@ -107,15 +108,14 @@ export function Footer() {
           {REGISTRY_CONTRACT_ID && (
             <p className="text-xs text-muted-foreground">
               {t('contractOnStellar', { network: STELLAR_NETWORK })}{' '}
-              <a
-                href={explorerContractUrl(REGISTRY_CONTRACT_ID)}
-                target="_blank"
-                rel="noreferrer"
+              <ExplorerLink
+                type="contract"
+                value={REGISTRY_CONTRACT_ID}
                 className="font-mono underline decoration-dotted underline-offset-2 hover:text-foreground transition-colors"
                 title={t('viewOnStellarExpert')}
               >
                 {REGISTRY_CONTRACT_ID.slice(0, 8)}…{REGISTRY_CONTRACT_ID.slice(-8)}
-              </a>
+              </ExplorerLink>
             </p>
           )}
 

--- a/invofi/apps/frontend/src/components/marketplace/MarketplaceCard.tsx
+++ b/invofi/apps/frontend/src/components/marketplace/MarketplaceCard.tsx
@@ -1,13 +1,12 @@
 import Link from 'next/link';
 import { Calendar, DollarSign, ArrowRight, ExternalLink, Clock, AlertTriangle } from 'lucide-react';
+import { ExplorerLink } from '@/components/common/ExplorerLink';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { formatAmount, formatDate, formatAddress, INVOICE_STATUS_COLORS } from '@/lib/utils';
 import type { Invoice } from '@/types';
 
-const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
-const STELLAR_EXPERT = `https://stellar.expert/explorer/${NETWORK}`;
 
 function DueLabel({ dueDateUnix }: { dueDateUnix: number }) {
   const now = Date.now() / 1000;
@@ -47,16 +46,14 @@ export function MarketplaceCard({ invoice }: MarketplaceCardProps) {
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-1 min-w-0">
             <p className="text-xs font-mono text-muted-foreground truncate max-w-[110px]">{invoice.id}</p>
-            <a
-              href={`${STELLAR_EXPERT}/contract/${invoice.originator}`}
-              target="_blank"
-              rel="noreferrer noopener"
+            <ExplorerLink
+              type="contract"
+              value={invoice.originator}
               title="View on Stellar Expert"
-              onClick={e => e.stopPropagation()}
               className="text-muted-foreground hover:text-blue-500 transition-colors shrink-0"
             >
               <ExternalLink className="h-3 w-3" />
-            </a>
+            </ExplorerLink>
           </div>
           <Badge className={INVOICE_STATUS_COLORS[invoice.status]}>{invoice.status}</Badge>
         </div>
@@ -76,14 +73,13 @@ export function MarketplaceCard({ invoice }: MarketplaceCardProps) {
 
           <p className="text-xs text-muted-foreground font-mono">
             Originator:{' '}
-            <a
-              href={`${STELLAR_EXPERT}/account/${invoice.originator}`}
-              target="_blank"
-              rel="noreferrer noopener"
+            <ExplorerLink
+              type="account"
+              value={invoice.originator}
               className="hover:text-blue-500 hover:underline transition-colors"
             >
               {formatAddress(invoice.originator)}
-            </a>
+            </ExplorerLink>
           </p>
         </div>
 

--- a/invofi/apps/frontend/src/components/marketplace/PositionListingCard.tsx
+++ b/invofi/apps/frontend/src/components/marketplace/PositionListingCard.tsx
@@ -7,11 +7,10 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { LISTING_STATUS_COLORS, unitPrice } from '@/lib/listings';
+import { ExplorerLink } from '@/components/common/ExplorerLink';
 import { formatAddress } from '@/lib/utils';
 import type { PositionListing, PositionListingStatus } from '@/types';
 
-const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
-const STELLAR_EXPERT = `https://stellar.expert/explorer/${NETWORK}`;
 
 interface PositionListingCardProps {
   listing: PositionListing;
@@ -71,14 +70,13 @@ export function PositionListingCard({ listing, isOwn, onStatusChange, busy }: Po
 
           <p className="text-xs text-muted-foreground font-mono">
             Seller:{' '}
-            <a
-              href={`${STELLAR_EXPERT}/account/${listing.seller}`}
-              target="_blank"
-              rel="noreferrer noopener"
+            <ExplorerLink
+              type="account"
+              value={listing.seller}
               className="hover:text-blue-500 hover:underline transition-colors"
             >
               {formatAddress(listing.seller)} <ExternalLink className="inline h-3 w-3" />
-            </a>
+            </ExplorerLink>
           </p>
 
           {listing.note && (

--- a/invofi/apps/frontend/src/components/marketplace/SuggestedMatches.tsx
+++ b/invofi/apps/frontend/src/components/marketplace/SuggestedMatches.tsx
@@ -34,10 +34,9 @@ import { cn } from '@/lib/utils';
 import { formatAmount, formatDate, formatAddress, INVOICE_STATUS_COLORS } from '@/lib/utils';
 import { MatchQualityBadge } from '@/components/marketplace/MatchQualityBadge';
 import type { MatchResult, ScoreBreakdown } from '@/types/matching';
+import { ExplorerLink } from '@/components/common/ExplorerLink';
 import type { Invoice } from '@/types';
 
-const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
-const STELLAR_EXPERT = `https://stellar.expert/explorer/${NETWORK}`;
 
 // ── Due label (extracted from MarketplaceCard, kept consistent) ───────────────
 
@@ -140,16 +139,14 @@ function MatchedInvoiceCard({ result }: MatchedInvoiceCardProps) {
         <div className="flex items-start justify-between mb-3 gap-2">
           <div className="flex items-center gap-1 min-w-0">
             <p className="text-xs font-mono text-muted-foreground truncate max-w-[90px]">{invoice.id}</p>
-            <a
-              href={`${STELLAR_EXPERT}/contract/${invoice.originator}`}
-              target="_blank"
-              rel="noreferrer noopener"
+            <ExplorerLink
+              type="contract"
+              value={invoice.originator}
               title="View on Stellar Expert"
-              onClick={e => e.stopPropagation()}
               className="text-muted-foreground hover:text-blue-500 transition-colors shrink-0"
             >
               <ExternalLink className="h-3 w-3" />
-            </a>
+            </ExplorerLink>
           </div>
           <div className="flex items-center gap-1 shrink-0">
             <MatchQualityBadge quality={quality} score={score} />
@@ -193,14 +190,13 @@ function MatchedInvoiceCard({ result }: MatchedInvoiceCardProps) {
 
           <p className="text-xs text-muted-foreground font-mono">
             Originator:{' '}
-            <a
-              href={`${STELLAR_EXPERT}/account/${invoice.originator}`}
-              target="_blank"
-              rel="noreferrer noopener"
+            <ExplorerLink
+              type="account"
+              value={invoice.originator}
               className="hover:text-blue-500 hover:underline transition-colors"
             >
               {formatAddress(invoice.originator)}
-            </a>
+            </ExplorerLink>
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Create a single reusable `ExplorerLink` component that wraps the network-aware explorer helpers already in `lib/constants.ts`. Migrate all inline Stellar Expert links across the frontend to the shared component.

## Changes

### New files
- **`components/common/ExplorerLink.tsx`** — Reusable link component supporting `contract`, `account`, and `tx` types. Uses the existing `explorerContractUrl`, `explorerAccountUrl`, and `explorerTxUrl` helpers from `lib/constants.ts`.
- **`components/common/ExplorerLink.test.tsx`** — Unit tests for the component.

### Modified files
- **`components/layout/Footer.tsx`** — Replace inline `<a>` with `ExplorerLink`.
- **`components/marketplace/MarketplaceCard.tsx`** — Remove duplicated `STELLAR_EXPERT` constant, use `ExplorerLink` for contract and account links.
- **`components/marketplace/PositionListingCard.tsx`** — Same.
- **`components/marketplace/SuggestedMatches.tsx`** — Same (two call sites).
- **`app/portfolio/page.tsx`** — Replace inline explorer link with `ExplorerLink`.

### Why
- Network-awareness (testnet vs mainnet) is now in one place instead of five.
- No more duplicated `STELLAR_EXPERT` constants across components.
- Consistent `target="_blank" rel="noreferrer noopener"` behavior.

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent links to Stellar Explorer pages for contracts, accounts, and transactions.
  - Explorer links now automatically use the configured network and open securely in a new tab.
  - Added customizable link text, styling, and titles.

- **Improvements**
  - Updated portfolio, marketplace, suggested matches, position listings, and footer links to use the standardized explorer-link experience.
  - Added coverage to verify supported link types and display options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->