### PR TITLE
feat(frontend): add skeleton loading states to InvoiceTable and OfferList (Closes #131)

### DIFF
--- a/invofi/apps/frontend/src/components/invoices/InvoiceTable.tsx
+++ b/invofi/apps/frontend/src/components/invoices/InvoiceTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { formatAmount, formatDate, formatWalletAddress } from '@/lib/formatters';
 import type { Invoice } from '@/types';
@@ -20,9 +21,10 @@ type SortDir = 'asc' | 'desc';
 interface InvoiceTableProps {
   invoices: Invoice[];
   onRowClick?: (invoice: Invoice) => void;
+  loading?: boolean;
 }
 
-export function InvoiceTable({ invoices, onRowClick }: InvoiceTableProps) {
+export function InvoiceTable({ invoices, onRowClick, loading }: InvoiceTableProps) {
   const [sortField, setSortField] = useState<SortField>('created_at');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 
@@ -63,6 +65,35 @@ export function InvoiceTable({ invoices, onRowClick }: InvoiceTableProps) {
           <SortIcon field={field} />
         </span>
       </TableHead>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Invoice ID</TableHead>
+              <TableHead>Business</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Due Date</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <TableRow key={i}>
+                <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+                <TableCell><Skeleton className="h-4 w-28" /></TableCell>
+                <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+                <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                <TableCell><Skeleton className="h-5 w-16 rounded-full" /></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     );
   }
 

--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Loader2, Plus, Download } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -39,6 +40,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
   const { publicKey } = useWallet();
   const { toast } = useToast();
   const [offers, setOffers] = useState<FinancingOffer[]>([]);
+  const [loadingOffers, setLoadingOffers] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [loading, setLoading] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
@@ -67,6 +69,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
           amount: toStroopsBigInt(o.amount),
           amount_repaid: toStroopsBigInt(o.amount_repaid),
         })));
+        setLoadingOffers(false);
       });
   }, [invoiceId]);
 
@@ -314,9 +317,21 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
         )}
 
         {/* Offers list */}
-        {offers.length === 0 && !showForm && (
+        {loadingOffers ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between border rounded-lg p-3">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-36" />
+                  <Skeleton className="h-3 w-48" />
+                </div>
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+            ))}
+          </div>
+        ) : offers.length === 0 && !showForm ? (
           <p className="text-sm text-gray-400 text-center py-6">No offers yet.</p>
-        )}
+        ) : null}
 
         {offers.map(offer => {
           const repaid = toStroopsBigInt(offer.amount_repaid);


### PR DESCRIPTION
## Summary

Add table-row skeleton loading states to `InvoiceTable` and `OfferList` using the existing `Skeleton` UI primitive.

### InvoiceTable
- Added `loading` prop (boolean)
- When `loading` is true, renders a 5-column skeleton matching the table header columns (Invoice ID, Business, Amount, Due Date, Status) with 5 rows
- Skeleton columns use approximate widths matching real data

### OfferList
- Added `loadingOffers` state for the initial supabase data fetch
- Shows a 3-row skeleton matching the offer card layout while data loads
- Skeleton rows are styled to match the real offer card (address + amount + badge)

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators for invoice tables and financing offer lists.
  * Displays placeholder rows while data is being retrieved.
  * Preserves existing populated and empty states after loading completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->