### PR TITLE
test(frontend): add comprehensive unit tests for money math and currency formatting (Closes #194)

### DIFF
--- a/invofi/apps/frontend/src/lib/constants.test.ts
+++ b/invofi/apps/frontend/src/lib/constants.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   CURRENCIES,
   EXPLORER_BASE,
@@ -12,9 +12,16 @@ import {
 } from './constants';
 
 describe('protocol constants', () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+  });
+
   it('keeps Stellar unit conversion internally consistent', () => {
     expect(STROOPS_PER_XLM).toBe(10 ** XLM_DECIMALS);
     expect(XLM_DECIMALS).toBe(7);
+    // 1 XLM in stroops, plus a couple of manual edge checks
+    expect(STROOPS_PER_XLM).toBe(10_000_000);
+    expect(1e7).toBe(10_000_000);
   });
 
   it('uses the testnet explorer by default', () => {
@@ -28,5 +35,16 @@ describe('protocol constants', () => {
     expect(explorerAccountUrl('account-id')).toBe(`${EXPLORER_BASE}/account/account-id`);
     expect(CURRENCIES).toEqual(['XLM', 'USDC']);
     expect(GRACE_PERIOD_SECS).toBe(7 * 24 * 60 * 60);
+  });
+
+  it('builds mainnet explorer links when the network is configured as mainnet', async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'mainnet';
+    const mainnet = await import('./constants');
+    expect(mainnet.STELLAR_NETWORK).toBe('mainnet');
+    expect(mainnet.EXPLORER_BASE).toBe('https://stellar.expert/explorer/public');
+    expect(mainnet.explorerTxUrl('tx-hash')).toBe(
+      'https://stellar.expert/explorer/public/tx/tx-hash',
+    );
   });
 });

--- a/invofi/apps/frontend/src/lib/formatters.test.ts
+++ b/invofi/apps/frontend/src/lib/formatters.test.ts
@@ -11,36 +11,134 @@ import {
 describe('formatters', () => {
   afterEach(() => vi.useRealTimers());
 
-  it('formats stroops as a two-decimal currency amount', () => {
-    expect(formatAmount(12_345_678)).toBe('1.23 XLM');
-    expect(formatAmount(0, 'USDC')).toBe('0.00 USDC');
-    expect(formatAmount(12_345_678, 'XLM')).toBe('1.23 XLM');
+  describe('formatAmount', () => {
+    it('converts stroops to a two-decimal XLM amount', () => {
+      expect(formatAmount(12_345_678)).toBe('1.23 XLM');
+      expect(formatAmount(12_345_678, 'XLM')).toBe('1.23 XLM');
+    });
+
+    it('handles zero stroops for all supported currencies', () => {
+      expect(formatAmount(0)).toBe('0.00 XLM');
+      expect(formatAmount(0, 'USDC')).toBe('0.00 USDC');
+    });
+
+    it('handles 1 stroop as the smallest unit', () => {
+      // 1 stroop = 0.0000001 XLM, rounds to 0.00 at 2 decimal places
+      expect(formatAmount(1)).toBe('0.00 XLM');
+      expect(formatAmount(1, 'USDC')).toBe('0.00 USDC');
+    });
+
+    it('converts exactly 1 XLM (10^7 stroops)', () => {
+      // 1e7 stroops = exactly 1 XLM
+      expect(formatAmount(10_000_000)).toBe('1.00 XLM');
+      expect(formatAmount(10_000_000, 'USDC')).toBe('1.00 USDC');
+    });
+
+    it('rounds boundary values correctly', () => {
+      // 5,000 stroops = 0.0005 XLM → rounds to 0.00
+      expect(formatAmount(5_000)).toBe('0.00 XLM');
+      // 5,001 stroops = 0.0005001 XLM → still rounds to 0.00
+      expect(formatAmount(5_001)).toBe('0.00 XLM');
+      // 50,000 stroops = 0.005 XLM → rounds to 0.01 (rounds up)
+      expect(formatAmount(50_000)).toBe('0.01 XLM');
+      // 99,999 stroops = 0.0099999 XLM → rounds to 0.01
+      expect(formatAmount(99_999)).toBe('0.01 XLM');
+      // 999,999 stroops = 0.0999999 XLM → rounds to 0.10
+      expect(formatAmount(999_999)).toBe('0.10 XLM');
+    });
+
+    it('formats large values with thousands separators', () => {
+      // 123,456,789,000 stroops = 12,345.6789 XLM → "12,345.68 XLM"
+      expect(formatAmount(123_456_789_000)).toBe('12,345.68 XLM');
+      // 1,000,000,000,000 stroops = 100,000 XLM
+      expect(formatAmount(1_000_000_000_000)).toBe('100,000.00 XLM');
+    });
+
+    it('handles bigint inputs', () => {
+      expect(formatAmount(BigInt(10_000_000))).toBe('1.00 XLM');
+      expect(formatAmount(BigInt(0))).toBe('0.00 XLM');
+      expect(formatAmount(BigInt(12_345_678))).toBe('1.23 XLM');
+    });
+
+    it('handles string inputs', () => {
+      expect(formatAmount('10000000')).toBe('1.00 XLM');
+      expect(formatAmount('0')).toBe('0.00 XLM');
+      expect(formatAmount('12345678')).toBe('1.23 XLM');
+    });
   });
 
-  it('formats basis points and durations', () => {
-    expect(formatBasisPoints(525)).toBe('5.25%');
-    expect(formatDuration(86_400)).toBe('1 day');
-    expect(formatDuration(7_200)).toBe('2 hours');
+  describe('formatBasisPoints', () => {
+    it('formats typical basis point values', () => {
+      expect(formatBasisPoints(525)).toBe('5.25%');
+      expect(formatBasisPoints(0)).toBe('0.00%');
+      expect(formatBasisPoints(10000)).toBe('100.00%');
+      expect(formatBasisPoints(50)).toBe('0.50%');
+    });
+
+    it('handles bigint and string basis points', () => {
+      expect(formatBasisPoints(BigInt(525))).toBe('5.25%');
+      expect(formatBasisPoints('525')).toBe('5.25%');
+    });
   });
 
-  it('formats Unix-second and millisecond dates consistently', () => {
-    expect(formatDate(0)).toBe('Jan 1, 1970');
-    expect(formatDate(1_704_067_200)).toBe('Jan 1, 2024');
-    expect(formatDate(1_704_067_200_000)).toBe('Jan 1, 2024');
+  describe('formatDuration', () => {
+    it('formats durations in days when >= 1 day', () => {
+      expect(formatDuration(86_400)).toBe('1 day');
+      expect(formatDuration(172_800)).toBe('2 days');
+      expect(formatDuration(604_800)).toBe('7 days');
+    });
+
+    it('formats durations in hours when < 1 day', () => {
+      expect(formatDuration(3_600)).toBe('1 hour');
+      expect(formatDuration(7_200)).toBe('2 hours');
+      expect(formatDuration(86_399)).toBe('23 hours');
+    });
+
+    it('handles zero and very short durations', () => {
+      expect(formatDuration(0)).toBe('0 hours');
+      expect(formatDuration(1)).toBe('0 hours');
+    });
+
+    it('handles bigint and string inputs', () => {
+      expect(formatDuration(BigInt(86_400))).toBe('1 day');
+      expect(formatDuration('86400')).toBe('1 day');
+    });
   });
 
-  it('reports past, present, and future relative dates', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-10T00:00:00Z'));
+  describe('formatDate', () => {
+    it('formats Unix-second and millisecond dates consistently', () => {
+      expect(formatDate(0)).toBe('Jan 1, 1970');
+      expect(formatDate(1_704_067_200)).toBe('Jan 1, 2024');
+      expect(formatDate(1_704_067_200_000)).toBe('Jan 1, 2024');
+    });
 
-    expect(formatRelativeDate(1_704_067_200)).toBe('9d overdue');
-    expect(formatRelativeDate(1_704_844_800)).toBe('Due today');
-    expect(formatRelativeDate(1_704_931_200)).toBe('1d remaining');
-
+    it('handles string and bigint date inputs', () => {
+      expect(formatDate('1704067200')).toBe('Jan 1, 2024');
+      expect(formatDate(BigInt(1_704_067_200))).toBe('Jan 1, 2024');
+    });
   });
 
-  it('shortens only addresses long enough to retain both ends', () => {
-    expect(formatWalletAddress('GABCDEF1234567890', 4)).toBe('GABC…7890');
-    expect(formatWalletAddress('short', 4)).toBe('short');
+  describe('formatRelativeDate', () => {
+    it('reports past, present, and future relative dates', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-10T00:00:00Z'));
+
+      expect(formatRelativeDate(1_704_067_200)).toBe('9d overdue');
+      expect(formatRelativeDate(1_704_844_800)).toBe('Due today');
+      expect(formatRelativeDate(1_704_931_200)).toBe('1d remaining');
+    });
+  });
+
+  describe('formatWalletAddress', () => {
+    it('shortens only addresses long enough to retain both ends', () => {
+      expect(formatWalletAddress('GABCDEF1234567890', 4)).toBe('GABC…7890');
+      expect(formatWalletAddress('short', 4)).toBe('short');
+    });
+
+    it('handles empty and edge-case addresses', () => {
+      expect(formatWalletAddress('')).toBe('');
+      expect(formatWalletAddress('GABCDEF')).toBe('GABCDEF');
+      expect(formatWalletAddress('GABCDEF1234567890123456', 6)).toBe('GABCDE…123456');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for money math and currency formatting helpers, covering the acceptance criteria from #194.

### Changes

**`src/lib/formatters.test.ts`** — expanded from 5 to 19 tests:

- **formatAmount**: stroop edge cases (0, 1, 10^7), rounding boundaries (5000 → 0.00, 50000 → 0.01, 999999 → 0.10), thousands separators, bigint and string inputs, all supported currencies (XLM, USDC)
- **formatBasisPoints**: zero, 100% boundary, 0.50% fractional, bigint/string inputs
- **formatDuration**: hours branch (< 1 day), zero/very short durations, bigint/string
- **formatWalletAddress**: empty string, edge-case short addresses
- Retained all existing tests (formatDate, formatRelativeDate, main formatAmount cases)

**`src/lib/constants.test.ts`** — expanded from 3 to 4 tests:

- **mainnet explorer**: verifies that setting `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` switches `EXPLORER_BASE` to `stellar.expert/explorer/public` (uses `vi.resetModules()` + dynamic import per env-module-scope pattern)
- Retained all existing tests (STROOPS_PER_XLM consistency, testnet default, explorer links)

### Test Results

```
 ✓ src/lib/constants.test.ts (4 tests)
 ✓ src/lib/formatters.test.ts (19 tests)
 Test Files  2 passed (2)
      Tests  23 passed (23)
```

Closes #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for amount, basis-point, duration, date, relative-date, and wallet-address formatting.
  * Added checks for zero, boundary, large, bigint, string, and empty inputs.
  * Added validation for mainnet explorer settings and transaction links.
  * Improved test isolation when switching network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->