### PR TITLE
feat(frontend): default display currency preference in settings (Closes #128)

### DIFF
--- a/invofi/apps/frontend/src/app/settings/page.tsx
+++ b/invofi/apps/frontend/src/app/settings/page.tsx
@@ -9,6 +9,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PageHeader } from '@/components/common/PageHeader';
 import { useToast } from '@/components/ui/use-toast';
 import { createClient } from '@/utils/supabase/client';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { DEFAULT_CURRENCY_STORAGE_KEY } from '@/lib/formatters';
 import {
   EXPLORER_BASE,
   FINANCING_CONTRACT_ID,
@@ -111,6 +113,10 @@ export default function SettingsPage() {
   const router = useRouter();
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
+  const [defaultCurrency, setDefaultCurrency] = useLocalStorage<string>(
+    DEFAULT_CURRENCY_STORAGE_KEY,
+    'XLM',
+  );
 
   const handleSignOut = async () => {
     setLoading(true);
@@ -167,6 +173,44 @@ export default function SettingsPage() {
                 <ContractRow label="Registry" contractId={REGISTRY_CONTRACT_ID} />
                 <ContractRow label="Financing" contractId={FINANCING_CONTRACT_ID} />
                 <ContractRow label="Repayment" contractId={REPAYMENT_CONTRACT_ID} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Display</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              <p className="text-sm text-gray-500">Default display currency</p>
+              <p className="text-xs text-gray-400">
+                Amounts shown without an explicit currency will use this preference.
+              </p>
+              <div className="flex gap-6">
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    name="defaultCurrency"
+                    value="XLM"
+                    checked={defaultCurrency === 'XLM'}
+                    onChange={() => setDefaultCurrency('XLM')}
+                    className="accent-blue-600"
+                  />
+                  XLM
+                </label>
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    name="defaultCurrency"
+                    value="USDC"
+                    checked={defaultCurrency === 'USDC'}
+                    onChange={() => setDefaultCurrency('USDC')}
+                    className="accent-blue-600"
+                  />
+                  USDC
+                </label>
               </div>
             </div>
           </CardContent>

--- a/invofi/apps/frontend/src/lib/formatters.test.ts
+++ b/invofi/apps/frontend/src/lib/formatters.test.ts
@@ -6,14 +6,28 @@ import {
   formatDuration,
   formatRelativeDate,
   formatWalletAddress,
+  DEFAULT_CURRENCY_STORAGE_KEY,
 } from './formatters';
 
+const STORAGE_KEY = DEFAULT_CURRENCY_STORAGE_KEY;
+
 describe('formatters', () => {
-  afterEach(() => vi.useRealTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.removeItem(STORAGE_KEY);
+  });
 
   it('formats stroops as a two-decimal currency amount', () => {
     expect(formatAmount(12_345_678)).toBe('1.23 XLM');
     expect(formatAmount(0, 'USDC')).toBe('0.00 USDC');
+    expect(formatAmount(12_345_678, 'XLM')).toBe('1.23 XLM');
+  });
+
+  it('respects the default display currency preference from localStorage', () => {
+    window.localStorage.setItem(STORAGE_KEY, '"USDC"');
+    expect(formatAmount(12_345_678)).toBe('1.23 USDC');
+    expect(formatAmount(0)).toBe('0.00 USDC');
+    // explicit currency still overrides
     expect(formatAmount(12_345_678, 'XLM')).toBe('1.23 XLM');
   });
 

--- a/invofi/apps/frontend/src/lib/formatters.ts
+++ b/invofi/apps/frontend/src/lib/formatters.ts
@@ -1,11 +1,30 @@
 import { STROOPS_PER_XLM } from './constants';
 
-export function formatAmount(stroops: string | number | bigint, currency: string = 'XLM'): string {
+export const DEFAULT_CURRENCY_STORAGE_KEY = 'invofi-default-currency';
+
+/** Read the user's preferred display currency from localStorage, defaulting to
+ *  'XLM' when none is stored or the environment has no Storage API. */
+export function getDefaultCurrency(): string {
+  if (typeof window === 'undefined') return 'XLM';
+  try {
+    const stored = window.localStorage.getItem(DEFAULT_CURRENCY_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as string;
+      if (parsed === 'XLM' || parsed === 'USDC') return parsed;
+    }
+  } catch {
+    /* localStorage unavailable — use default */
+  }
+  return 'XLM';
+}
+
+export function formatAmount(stroops: string | number | bigint, currency?: string): string {
   const units = Number(stroops) / STROOPS_PER_XLM;
+  const cur = currency || getDefaultCurrency();
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
-  }).format(units) + ` ${currency}`;
+  }).format(units) + ` ${cur}`;
 }
 
 export function formatBasisPoints(bps: number | bigint | string): string {


### PR DESCRIPTION
## Summary

Adds a **Default display currency** preference (XLM/USDC) to the Settings page, persisted via `useLocalStorage`. The shared `formatAmount` formatter falls back to this preference when no explicit currency is given.

## Changes

- **`formatters.ts`**:
  - Export `DEFAULT_CURRENCY_STORAGE_KEY` constant
  - Export `getDefaultCurrency()` helper that reads from localStorage
  - `formatAmount` now accepts `currency?: string` (optional) and falls back to the stored preference
- **`settings/page.tsx`**: New **Display** card with radio buttons for XLM/USDC
- **`formatters.test.ts`**: New test verifying the stored preference is respected, plus explicit-currency override

## Acceptance criteria

- [x] Preference persists across sessions
- [x] Amounts rendered without an explicit currency use the chosen default
- [x] Explicit currency overrides the preference

## Testing

All 300 tests pass (34 files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Display Currency setting with XLM and USDC options.
  * Currency preference is saved locally and remembered across sessions.
  * Amounts now use the selected default currency when no currency is specified.

* **Bug Fixes**
  * Added safe fallback to XLM when saved currency data is unavailable or invalid.
  * Explicitly specified currencies continue to override the default preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->