### PR TITLE
fix(frontend): keyboard navigation and focus management for dialogs

### DIFF
--- a/invofi/apps/frontend/src/components/layout/Navbar.tsx
+++ b/invofi/apps/frontend/src/components/layout/Navbar.tsx
@@ -15,7 +15,7 @@ import {
   X,
   Keyboard,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { WalletButton } from "@/components/auth/WalletButton";
@@ -48,6 +48,9 @@ export function Navbar() {
 
   const [mounted, setMounted] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const drawerToggleRef = useRef<HTMLButtonElement | null>(null);
+  const shortcutsRef = useRef<HTMLDivElement | null>(null);
 
   const [theme, setTheme] = useLocalStorage<"light" | "dark">("theme", "light");
 
@@ -68,6 +71,69 @@ export function Navbar() {
   useEffect(() => {
     setDrawerOpen(false);
   }, [pathname]);
+
+  // Focus management for the mobile drawer (WCAG 2.1 AA): trap focus while
+  // open, return focus to the toggle on close.
+  useEffect(() => {
+    if (!drawerOpen) {
+      if (drawerToggleRef.current) drawerToggleRef.current.focus();
+      return;
+    }
+
+    const previousFocus = document.activeElement as HTMLElement | null;
+    const drawer = drawerRef.current;
+    // Move focus into the drawer on open.
+    if (drawer) {
+      const firstFocusable = drawer.querySelector<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      (firstFocusable ?? drawer).focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Escape closes the drawer
+      if (e.key === 'Escape') {
+        setDrawerOpen(false);
+        return;
+      }
+      // Trap Tab within the drawer
+      if (e.key !== 'Tab' || !drawer) return;
+      const focusables = drawer.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocus?.focus();
+    };
+  }, [drawerOpen]);
+
+  // Escape closes the keyboard-shortcuts help popover.
+  useEffect(() => {
+    if (!helpOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setHelpOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [helpOpen, setHelpOpen]);
 
   const toggleTheme = () => setTheme(theme === "light" ? "dark" : "light");
 
@@ -144,7 +210,12 @@ export function Navbar() {
                     aria-hidden
                     onClick={() => setHelpOpen(false)}
                   />
-                  <div className="absolute right-0 top-full mt-2 z-50 w-60 rounded-lg border border-border bg-background shadow-lg p-3 space-y-2">
+                  <div
+                    ref={shortcutsRef}
+                    role="dialog"
+                    aria-label="Keyboard shortcuts"
+                    className="absolute right-0 top-full mt-2 z-50 w-60 rounded-lg border border-border bg-background shadow-lg p-3 space-y-2"
+                  >
                     <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
                       Keyboard shortcuts
                     </p>
@@ -222,9 +293,11 @@ export function Navbar() {
 
             {/* Mobile hamburger */}
             <button
+              ref={drawerToggleRef}
               onClick={() => setDrawerOpen((v) => !v)}
               className="md:hidden p-2 rounded-md text-muted-foreground hover:bg-accent transition-colors"
               aria-label={drawerOpen ? "Close menu" : "Open menu"}
+              aria-expanded={drawerOpen}
             >
               {drawerOpen ? (
                 <X className="h-5 w-5" />
@@ -247,10 +320,14 @@ export function Navbar() {
 
       {/* Mobile drawer */}
       <div
+        ref={drawerRef}
         className={cn(
           "fixed top-16 right-0 bottom-0 z-40 w-72 bg-background border-l border-border shadow-xl flex flex-col transition-transform duration-200 md:hidden",
           drawerOpen ? "translate-x-0" : "translate-x-full",
         )}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu"
       >
         <nav className="flex-1 p-4 space-y-1">
           {NAV_LINKS.map((link) => (


### PR DESCRIPTION
## Summary

Audit and fix keyboard navigation + focus management across all dialogs to meet WCAG 2.1 AA dialog requirements.

## Changes

### Mobile drawer (Navbar)
- Added `role="dialog"`, `aria-modal="true"`, and `aria-label` for proper ARIA semantics
- **Focus trap**: Tab navigation cycles within the drawer while open
- **Escape key**: Pressing Escape closes the drawer
- **Focus on open**: Focus moves to the first focusable element inside the drawer
- **Focus return**: Focus returns to the hamburger toggle button when the drawer closes
- Added `aria-expanded` to the hamburger button for accessibility

### Keyboard shortcuts help popover
- Added `role="dialog"` and `aria-label` for proper ARIA semantics
- Escape key handling (already present in `useKeyboardShortcuts` hook)

### Radix UI Dialogs
The existing dialogs (`WalletSelectDialog`, `ConfirmDialog`, `DocumentPreviewDialog`) already use Radix UI's `Dialog` primitive, which natively handles focus trap, focus return, and Escape key. No changes needed for these components.

## Acceptance criteria
- [x] Tab order is logical and visible inside every dialog
- [x] Focus returns to the triggering element after close
- [x] Escape key closes every dialog/modal
- [x] axe-core reports no critical dialog-related violations

Closes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation in the mobile menu with focus placement, focus trapping, and focus restoration.
  * Added Escape-key support to close the mobile menu and keyboard shortcuts dialog.
  * Enhanced dialog semantics for the mobile menu and shortcuts panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->