### PR TITLE
feat(frontend): remember last wallet and clear preference on disconnect (Closes #172)

### DIFF
--- a/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
@@ -11,6 +11,12 @@ import {
 import { APPROVED_WALLETS } from '@/lib/approved-wallets';
 import { isMockMode } from '@/lib/mock-mode';
 import { MOCK_WALLET_ADDRESS } from '@/lib/mock';
+import {
+  LAST_WALLET_STORAGE_KEY,
+  readLastWallet,
+  persistLastWallet,
+  clearLastWallet,
+} from '@/lib/last-wallet';
 import type { WalletState } from '@/types';
 
 interface WalletContextValue extends WalletState {
@@ -48,46 +54,8 @@ function networkMismatchFor(walletNet: string | null): boolean {
 /**
  * Persistent "last wallet" choice (issue #187): the only wallet state allowed
  * in localStorage is the *public address* — never a key, seed, or signature.
- * The stored entry is a hint that lets a returning user reconnect to the
- * wallet they chose last time without probing every installed wallet first.
+ * See `@/lib/last-wallet` for the read/persist/clear contract (issue #172).
  */
-interface LastWalletEntry {
-  walletId: string;
-  publicKey: string;
-}
-
-const LAST_WALLET_STORAGE_KEY = 'invofi:last-wallet';
-
-function readLastWallet(): LastWalletEntry | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const raw = window.localStorage.getItem(LAST_WALLET_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<LastWalletEntry>;
-    if (
-      typeof parsed.walletId === 'string' &&
-      typeof parsed.publicKey === 'string' &&
-      parsed.publicKey.startsWith('G') // Stellar public addresses start with G
-    ) {
-      return { walletId: parsed.walletId, publicKey: parsed.publicKey };
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function persistLastWallet(walletId: string, publicKey: string): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(
-      LAST_WALLET_STORAGE_KEY,
-      JSON.stringify({ walletId, publicKey } satisfies LastWalletEntry),
-    );
-  } catch {
-    // private mode or quota exceeded — persistence is best-effort
-  }
-}
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [isCheckingWallet, setIsCheckingWallet] = useState(!MOCK_MODE);
@@ -223,6 +191,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       isConnecting: false,
       networkMismatch: false,
     }));
+    // Clear the persisted last-wallet hint so a page refresh won't
+    // silently re-connect (issue #172).
+    clearLastWallet();
     // Sign out of Supabase so protected routes redirect to login.
     supabaseSignOut().catch(() => { });
   }, []);

--- a/invofi/apps/frontend/src/lib/last-wallet.test.ts
+++ b/invofi/apps/frontend/src/lib/last-wallet.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  LAST_WALLET_STORAGE_KEY,
+  readLastWallet,
+  persistLastWallet,
+  clearLastWallet,
+} from './last-wallet';
+
+describe('last-wallet storage', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('readLastWallet', () => {
+    it('returns null when nothing is stored', () => {
+      expect(readLastWallet()).toBeNull();
+    });
+
+    it('returns null when stored JSON is malformed', () => {
+      window.localStorage.setItem(LAST_WALLET_STORAGE_KEY, '{bad json');
+      expect(readLastWallet()).toBeNull();
+    });
+
+    it('returns null when walletId is missing', () => {
+      window.localStorage.setItem(
+        LAST_WALLET_STORAGE_KEY,
+        JSON.stringify({ publicKey: 'GABC123' }),
+      );
+      expect(readLastWallet()).toBeNull();
+    });
+
+    it('returns null when publicKey is missing', () => {
+      window.localStorage.setItem(
+        LAST_WALLET_STORAGE_KEY,
+        JSON.stringify({ walletId: 'freighter' }),
+      );
+      expect(readLastWallet()).toBeNull();
+    });
+
+    it('returns null when publicKey does not start with G', () => {
+      window.localStorage.setItem(
+        LAST_WALLET_STORAGE_KEY,
+        JSON.stringify({ walletId: 'freighter', publicKey: 'SABCDEF' }),
+      );
+      expect(readLastWallet()).toBeNull();
+    });
+
+    it('reads a valid last-wallet entry', () => {
+      window.localStorage.setItem(
+        LAST_WALLET_STORAGE_KEY,
+        JSON.stringify({ walletId: 'freighter', publicKey: 'GABCDEF123456' }),
+      );
+      const entry = readLastWallet();
+      expect(entry).not.toBeNull();
+      expect(entry!.walletId).toBe('freighter');
+      expect(entry!.publicKey).toBe('GABCDEF123456');
+    });
+  });
+
+  describe('persistLastWallet', () => {
+    it('writes a valid JSON entry', () => {
+      persistLastWallet('lobstr', 'GXYZ789');
+      const raw = window.localStorage.getItem(LAST_WALLET_STORAGE_KEY);
+      expect(raw).toBe(JSON.stringify({ walletId: 'lobstr', publicKey: 'GXYZ789' }));
+    });
+
+    it('is immediately readable back', () => {
+      persistLastWallet('freighter', 'GABC');
+      const entry = readLastWallet();
+      expect(entry).toEqual({ walletId: 'freighter', publicKey: 'GABC' });
+    });
+  });
+
+  describe('clearLastWallet', () => {
+    it('removes the stored entry', () => {
+      persistLastWallet('freighter', 'GABC');
+      clearLastWallet();
+      expect(window.localStorage.getItem(LAST_WALLET_STORAGE_KEY)).toBeNull();
+    });
+
+    it('makes readLastWallet return null', () => {
+      persistLastWallet('freighter', 'GABC');
+      clearLastWallet();
+      expect(readLastWallet()).toBeNull();
+    });
+
+    it('is safe to call when nothing is stored', () => {
+      expect(() => clearLastWallet()).not.toThrow();
+    });
+  });
+});

--- a/invofi/apps/frontend/src/lib/last-wallet.ts
+++ b/invofi/apps/frontend/src/lib/last-wallet.ts
@@ -1,0 +1,70 @@
+/**
+ * Persistent "last wallet" choice (issue #172 / #187): the only wallet state
+ * allowed in localStorage is the *public address* — never a key, seed, or
+ * signature. The stored entry is a hint that lets a returning user reconnect
+ * to the wallet they chose last time without probing every installed wallet
+ * first.
+ *
+ * Extracted from `WalletProvider` into its own module so the read/persist/
+ * clear contract can be unit-tested without rendering the provider tree.
+ */
+
+export interface LastWalletEntry {
+  walletId: string;
+  publicKey: string;
+}
+
+export const LAST_WALLET_STORAGE_KEY = 'invofi:last-wallet';
+
+const hasWindow = (): boolean => typeof window !== 'undefined';
+
+/**
+ * Reads the persisted last-wallet hint. Returns null when nothing is stored,
+ * the JSON is malformed, or the shape is invalid (Stellar public addresses
+ * start with "G", so anything else is rejected defensively).
+ */
+export function readLastWallet(): LastWalletEntry | null {
+  if (!hasWindow()) return null;
+  try {
+    const raw = window.localStorage.getItem(LAST_WALLET_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<LastWalletEntry>;
+    if (
+      typeof parsed.walletId === 'string' &&
+      typeof parsed.publicKey === 'string' &&
+      parsed.publicKey.startsWith('G') // Stellar public addresses start with G
+    ) {
+      return { walletId: parsed.walletId, publicKey: parsed.publicKey };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persists the last-selected wallet hint. Best-effort (private mode / quota). */
+export function persistLastWallet(walletId: string, publicKey: string): void {
+  if (!hasWindow()) return;
+  try {
+    window.localStorage.setItem(
+      LAST_WALLET_STORAGE_KEY,
+      JSON.stringify({ walletId, publicKey } satisfies LastWalletEntry),
+    );
+  } catch {
+    // private mode or quota exceeded — persistence is best-effort
+  }
+}
+
+/**
+ * Clears the persisted last-wallet hint. Called from `disconnect()` so that
+ * disconnecting also opts out of the next page load's silent auto-reconnect.
+ * Best-effort, never throws.
+ */
+export function clearLastWallet(): void {
+  if (!hasWindow()) return;
+  try {
+    window.localStorage.removeItem(LAST_WALLET_STORAGE_KEY);
+  } catch {
+    // best-effort, mirroring persistLastWallet
+  }
+}


### PR DESCRIPTION
## Summary

Extracts the last-wallet storage logic into a self-contained module (`src/lib/last-wallet.ts`) and closes the gap in acceptance criterion #2: **disconnect must clear the stored preference** so a page refresh does not silently re-connect.

## Changes

### `src/lib/last-wallet.ts` (new)
- `readLastWallet()` — reads the persisted hint, validates shape (Stellar addresses start with `G`)
- `persistLastWallet(walletId, publicKey)` — writes the hint
- `clearLastWallet()` — removes the hint (invoked on disconnect)

### `src/components/auth/WalletProvider.tsx`
- Replaces inline `readLastWallet` / `persistLastWallet` / `LAST_WALLET_STORAGE_KEY` / `LastWalletEntry` with imports from `@/lib/last-wallet`
- Calls `clearLastWallet()` in `disconnect()` so a user who explicitly disconnects does not auto-reconnect on the next page load

### `src/lib/last-wallet.test.ts` (new)
- 11 unit tests covering null/noop/valid/malformed/storage-clear scenarios

## Acceptance Criteria

- [x] Refresh keeps the wallet connected (already present via `readLastWallet` + `tryRestoreWallet` in the mount effect)
- [x] Disconnect clears the stored preference (new: `clearLastWallet()` in `disconnect()`)
- [x] A wallet that is no longer approved (allowlist change) is ignored safely (already present: `installed.has(lastWallet.walletId)` checks against APPROVED_WALLETS)

## Testing

- 325 tests pass (35 test files), including 11 new tests for `last-wallet.ts`
- ESLint: no warnings
- TypeScript: no errors
- `localstorage-secrets-guard`: OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remembers the previously connected wallet to streamline returning sessions.
  * Validates saved wallet details before restoring them.
  * Safely handles unavailable or corrupted browser storage without disrupting the app.

* **Bug Fixes**
  * Disconnecting now clears the remembered wallet, preventing stale wallet information from being reused.

* **Tests**
  * Added coverage for valid, invalid, missing, and malformed saved wallet data, along with storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->