### PR TITLE
feat(frontend): add upcoming-repayments widget for originators (Closes #126)

### DIFF
--- a/invofi/apps/frontend/src/app/dashboard/page.tsx
+++ b/invofi/apps/frontend/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { InvoiceTable } from '@/components/invoices/InvoiceTable';
 import { WalletButton } from '@/components/auth/WalletButton';
 import { CardSkeleton, TableSkeleton } from '@/components/common/LoadingSkeleton';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { UpcomingRepaymentsWidget } from '@/components/dashboard/UpcomingRepaymentsWidget';
 import { getUserProfile, supabase } from '@/lib/supabase';
 import { getXlmBalance } from '@/lib/horizon';
 import { useWallet } from '@/components/auth/WalletProvider';
@@ -160,6 +161,11 @@ export default function DashboardPage() {
             </>
           )}
         </div>
+
+        {/* Upcoming repayments (originators only) */}
+        {isBusiness && !loading && invoices.length > 0 && (
+          <UpcomingRepaymentsWidget invoices={invoices} />
+        )}
 
         {/* Invoices / offers */}
         {isBusiness && (

--- a/invofi/apps/frontend/src/components/dashboard/UpcomingRepaymentsWidget.tsx
+++ b/invofi/apps/frontend/src/components/dashboard/UpcomingRepaymentsWidget.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import Link from 'next/link';
+import { CalendarClock, ChevronRight, Clock } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatCurrencyAmount, formatDate, formatRelativeDate } from '@/lib/formatters';
+import type { Invoice } from '@/types';
+
+interface UpcomingRepaymentsWidgetProps {
+  /** All invoices owned by the signed-in originator (any status). */
+  invoices: Invoice[];
+}
+
+const DAY_SECS = 86_400;
+
+/** Whole day boundaries (ceil) until `dueDate`; negative means already due. */
+function daysUntil(dueDate: number): number {
+  return Math.ceil((dueDate * 1000 - Date.now()) / (DAY_SECS * 1000));
+}
+
+/**
+ * "Upcoming repayments" widget for originators (issue #126): lists the
+ * originator's Financed invoices sorted by due date, showing amount due and
+ * days remaining, with an amber highlight for anything due within 7 days.
+ * Presentation-only — each row links to the invoice detail page.
+ */
+export function UpcomingRepaymentsWidget({ invoices }: UpcomingRepaymentsWidgetProps) {
+  const upcoming = invoices
+    .filter(inv => inv.status === 'Financed')
+    .sort((a, b) => a.due_date - b.due_date)
+    .map(inv => ({ invoice: inv, days: daysUntil(inv.due_date) }));
+
+  return (
+    <Card className="mb-8">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <CalendarClock className="h-4 w-4" /> Upcoming Repayments
+        </CardTitle>
+        <CardDescription>
+          Financed invoices sorted by due date. Entries due within 7 days are highlighted.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {upcoming.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            No financed invoices with upcoming repayments.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {upcoming.map(({ invoice, days }) => {
+              const isDueSoon = days <= 7;
+              return (
+                <li key={invoice.id}>
+                  <Link
+                    href={`/invoices/${invoice.id}`}
+                    className={`flex items-center justify-between gap-3 px-3 py-2.5 rounded-md transition-colors hover:bg-accent ${
+                      isDueSoon ? 'bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800/70' : ''
+                    }`}
+                  >
+                    <div className="min-w-0">
+                      <p className="text-xs font-mono text-muted-foreground truncate" title={invoice.id}>
+                        {invoice.id}
+                      </p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {formatCurrencyAmount(invoice.amount, invoice.currency)}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <div className="text-right">
+                        <p className="text-xs text-muted-foreground">{formatDate(invoice.due_date)}</p>
+                        <p
+                          className={`text-xs font-medium flex items-center justify-end gap-1 ${
+                            isDueSoon ? 'text-amber-700 dark:text-amber-400' : 'text-muted-foreground'
+                          }`}
+                        >
+                          <Clock className="h-3 w-3" />
+                          {formatRelativeDate(invoice.due_date)}
+                        </p>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/invofi/apps/frontend/src/components/dashboard/__tests__/UpcomingRepaymentsWidget.test.tsx
+++ b/invofi/apps/frontend/src/components/dashboard/__tests__/UpcomingRepaymentsWidget.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UpcomingRepaymentsWidget } from '@/components/dashboard/UpcomingRepaymentsWidget';
+import type { Invoice } from '@/types';
+
+function makeInvoice(overrides: Partial<Invoice> & { id: string; due_date: number }): Invoice {
+  return {
+    originator: 'GAAAA...',
+    amount: 10_000_000n, // 1 XLM
+    currency: 'XLM',
+    status: 'Financed' as const,
+    ...overrides,
+  };
+}
+
+describe('UpcomingRepaymentsWidget', () => {
+  it('shows the empty message when no financed invoices', () => {
+    render(<UpcomingRepaymentsWidget invoices={[]} />);
+    expect(screen.getByText(/No financed invoices/i)).toBeInTheDocument();
+  });
+
+  it('shows the empty message when invoices exist but none are Financed', () => {
+    const invoices = [
+      makeInvoice({ id: 'inv-1', status: 'Pending' as const, due_date: 1_800_000_000 }),
+      makeInvoice({ id: 'inv-2', status: 'Repaid' as const, due_date: 1_800_000_000 }),
+    ];
+    render(<UpcomingRepaymentsWidget invoices={invoices} />);
+    expect(screen.getByText(/No financed invoices/i)).toBeInTheDocument();
+  });
+
+  it('renders a single Financed invoice', () => {
+    const invoices = [makeInvoice({ id: 'inv-abc', due_date: 1_800_000_000 })];
+    render(<UpcomingRepaymentsWidget invoices={invoices} />);
+    expect(screen.getByText('inv-abc')).toBeInTheDocument();
+    expect(screen.getByText(/1\.00 XLM/)).toBeInTheDocument();
+    // Should link to the invoice detail page
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/invoices/inv-abc');
+  });
+
+  it('sorts Financed invoices by due date (ascending)', () => {
+    const invoices = [
+      makeInvoice({ id: 'inv-later', due_date: 1_800_000_000 }),
+      makeInvoice({ id: 'inv-sooner', due_date: 1_700_000_000 }),
+    ];
+    render(<UpcomingRepaymentsWidget invoices={invoices} />);
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', '/invoices/inv-sooner');
+    expect(links[1]).toHaveAttribute('href', '/invoices/inv-later');
+  });
+
+  it('filters out non-Financed invoices', () => {
+    const invoices = [
+      makeInvoice({ id: 'inv-financed', status: 'Financed' as const, due_date: 1_800_000_000 }),
+      makeInvoice({ id: 'inv-pending', status: 'Pending' as const, due_date: 1_800_000_000 }),
+      makeInvoice({ id: 'inv-repaid', status: 'Repaid' as const, due_date: 1_800_000_000 }),
+    ];
+    render(<UpcomingRepaymentsWidget invoices={invoices} />);
+    expect(screen.getByText('inv-financed')).toBeInTheDocument();
+    expect(screen.queryByText('inv-pending')).not.toBeInTheDocument();
+    expect(screen.queryByText('inv-repaid')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **Upcoming Repayments** widget to the originator dashboard (issue #126). It lists the current user's Financed invoices sorted by repayment due date, showing the amount due and days remaining, highlighting anything due within 7 days.

## Changes

- **`src/components/dashboard/UpcomingRepaymentsWidget.tsx`** (new): presentational widget that:
  - Filters to `status === 'Financed'` invoices only
  - Sorts by `due_date` ascending (soonest first)
  - Shows amount due (currency-aware) + `formatRelativeDate` ("Xd remaining" / "Due today")
  - Visually highlights entries due within 7 days (amber border + background)
  - Each row links to the invoice detail page (`/invoices/[id]`)
  - Clean empty state ("No financed invoices with upcoming repayments.")
- **`src/app/dashboard/page.tsx`**: renders the widget between the stats grid and the invoice list, only for business-role originators and only when invoices exist
- **`src/components/dashboard/__tests__/UpcomingRepaymentsWidget.test.tsx`** (new): 5 tests — empty state, non-Financed filtering, single-invoice rendering + link href, due-date sorting, and status filtering

## Acceptance criteria

- ✅ Widget shows only the current user's Financed invoices — it renders from the dashboard's existing `invoices` state (already scoped to `originator_id = user.id`)
- ✅ Due-within-7-days entries are visually highlighted — amber style when `days <= 7`
- ✅ Each row links to the invoice detail page — `Link href="/invoices/{id}"`

## Stop constraints respected

- No repayment action from the widget — rows link out to the detail page
- No calendar views added

## Tests

```bash
NODE_ENV=test npx vitest run src/components/dashboard/__tests__/UpcomingRepaymentsWidget.test.tsx
# 5 tests passed

npm test   # full suite: 35 files / 328 tests passed (NODE_ENV=test)
npx tsc --noEmit   # clean
```

> Note: the full suite requires `NODE_ENV=test` on this machine (a global `NODE_ENV=production` environment kills React's `act` in React 19 CJS builds); with `NODE_ENV=test` all 328 tests pass.

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Upcoming Repayments widget to the dashboard for business users.
  - Displays financed invoices sorted by due date, including amounts, due dates, and time remaining.
  - Highlights repayments due within seven days.
  - Provides links to invoice details and an empty state when no financed invoices are available.

- **Tests**
  - Added coverage for filtering, sorting, empty states, display details, and invoice links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->