### PR TITLE
feat(frontend): paginate and virtualize portfolio position list (Closes #190)

### DIFF
--- a/invofi/apps/frontend/package-lock.json
+++ b/invofi/apps/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@supabase/ssr": "^0.12.4",
         "@supabase/supabase-js": "^2.111.0",
         "@tanstack/react-query": "^5.101.2",
+        "@tanstack/react-virtual": "^3.14.10",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -733,21 +734,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@creit.tech/xbull-wallet-connect": {
@@ -1865,7 +1851,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4546,7 +4531,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4560,7 +4544,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4574,7 +4557,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4588,7 +4570,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4602,7 +4583,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4616,7 +4596,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4630,7 +4609,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4644,7 +4622,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4658,7 +4635,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4672,7 +4648,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4686,7 +4661,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4700,7 +4674,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4714,7 +4687,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4728,7 +4700,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4742,7 +4713,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4756,7 +4726,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4770,7 +4739,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4784,7 +4752,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4798,7 +4765,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4812,7 +4778,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4826,7 +4791,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4840,7 +4804,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4854,7 +4817,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4868,7 +4830,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4882,7 +4843,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7249,6 +7209,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -10977,21 +10964,6 @@
         "@walletconnect/safe-json": "^1.0.2",
         "events": "^3.3.0",
         "ws": "^7.5.1"
-      }
-    },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
@@ -17100,21 +17072,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
@@ -18400,17 +18357,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/invofi/apps/frontend/package.json
+++ b/invofi/apps/frontend/package.json
@@ -33,6 +33,7 @@
     "@supabase/ssr": "^0.12.4",
     "@supabase/supabase-js": "^2.111.0",
     "@tanstack/react-query": "^5.101.2",
+    "@tanstack/react-virtual": "^3.14.10",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/invofi/apps/frontend/src/app/portfolio/page.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { TrendingUp, Clock, CheckCircle2, AlertCircle, Download, Copy, Check, Send, RefreshCw, Tag, DollarSign } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -20,6 +21,8 @@ import { stroopsToUsd } from '@/lib/live/prices';
 import { useLivePortfolio } from '@/components/portfolio/LivePortfolioProvider';
 import { ConnectionStatus } from '@/components/portfolio/ConnectionStatus';
 import { RepaymentProgress } from '@/components/portfolio/RepaymentProgress';
+import { PaginationControls } from '@/components/portfolio/PaginationControls';
+import { paginate } from '@/lib/pagination';
 import type { LivePosition } from '@/lib/live/types';
 
 
@@ -369,6 +372,36 @@ export default function PortfolioPage() {
     refresh,
   } = useLivePortfolio();
 
+  // Client-side pagination (issue #190): the contract layer still returns the
+  // full list; we slice it for rendering so a wallet with hundreds of
+  // positions stays smooth. Page size is user-adjustable, and each page is
+  // virtualized below so even 100-row pages only mount visible cards.
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  // Keep the current page valid when the stream shrinks (e.g. repayments move
+  // positions between buckets or the wallet changes).
+  const pageCount = Math.max(1, Math.ceil(positions.length / pageSize));
+  useEffect(() => {
+    setPage(p => Math.min(p, pageCount));
+  }, [pageCount]);
+
+  const pageItems = useMemo(
+    () => paginate(positions, page, pageSize),
+    [positions, page, pageSize],
+  );
+
+  // Virtualize the current page's rows. Every card uses `measureElement` so
+  // rows with different heights (active vs repaid) size correctly.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: pageItems.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 148,
+    overscan: 4,
+    // Placeholder height is overridden per-row by measureElement below.
+  });
+
   // An offer is active while it is financing an invoice: from acceptance until
   // it is fully repaid. Partial repayments flip offers to Financed on-chain,
   // so both statuses count as deployed capital.
@@ -514,10 +547,52 @@ export default function PortfolioPage() {
         )}
 
         <div className="space-y-3">
-          {positions.map(offer => (
-            <PositionCard key={offer.id} offer={offer} />
-          ))}
+          {pageItems.length === 0 ? (
+            <div className="text-center py-10 text-sm text-muted-foreground">
+              No positions on this page.
+            </div>
+          ) : (
+            <div
+              ref={scrollRef}
+              className="max-h-[70vh] overflow-y-auto rounded-xl border border-border"
+              data-testid="virtualized-position-list"
+            >
+              <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+                {virtualizer.getVirtualItems().map(vi => (
+                  <div
+                    key={pageItems[vi.index].id}
+                    ref={virtualizer.measureElement}
+                    data-index={vi.index}
+                    className="pb-3"
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      transform: `translateY(${vi.start}px)`,
+                    }}
+                  >
+                    <PositionCard offer={pageItems[vi.index]} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
+
+        {/* Pagination controls (issue #190) */}
+        {!loading && positions.length > 0 && (
+          <PaginationControls
+            page={page}
+            total={positions.length}
+            pageSize={pageSize}
+            onPageChange={setPage}
+            onPageSizeChange={size => {
+              setPageSize(size);
+              setPage(1);
+            }}
+          />
+        )}
 
         {/* useSearchParams (the listing hand-off prefill) needs a Suspense boundary. */}
         <Suspense fallback={null}>

--- a/invofi/apps/frontend/src/components/portfolio/PaginationControls.tsx
+++ b/invofi/apps/frontend/src/components/portfolio/PaginationControls.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { pageCountOf, rangeLabel } from '@/lib/pagination';
+
+export interface PaginationControlsProps {
+  /** Current 1-based page. */
+  page: number;
+  /** Total number of items across all pages. */
+  total: number;
+  /** Items per page. */
+  pageSize: number;
+  /** Called when the user navigates to a new page. */
+  onPageChange: (page: number) => void;
+  /** Called when the user picks a different page size. */
+  onPageSizeChange: (size: number) => void;
+}
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
+
+export function PaginationControls({
+  page,
+  total,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}: PaginationControlsProps) {
+  const count = pageCountOf(total, pageSize);
+  const prevDisabled = page <= 1 || count <= 1;
+  const nextDisabled = page >= count || count <= 1;
+
+  if (total === 0) {
+    return (
+      <div className="flex items-center justify-between mt-6 pt-4 border-t border-border">
+        <span className="text-xs text-muted-foreground">0 positions</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between mt-6 pt-4 border-t border-border">
+      {/* Left: item count + page-size selector */}
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {rangeLabel(page, pageSize, total)}
+        </span>
+        <select
+          value={pageSize}
+          onChange={e => onPageSizeChange(Number(e.target.value))}
+          className="text-xs px-2 py-1 rounded-lg border border-input bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+          aria-label="Page size"
+        >
+          {PAGE_SIZE_OPTIONS.map(s => (
+            <option key={s} value={s}>
+              {s} / page
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Right: pagination buttons */}
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(page - 1)}
+          disabled={prevDisabled}
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        {count <= 7 ? (
+          /* Few pages — show all */
+          Array.from({ length: count }, (_, i) => i + 1).map(p => (
+            <Button
+              key={p}
+              variant={p === page ? 'default' : 'outline'}
+              size="sm"
+              className="min-w-[32px]"
+              onClick={() => onPageChange(p)}
+            >
+              {p}
+            </Button>
+          ))
+        ) : (
+          /* Many pages — compact navigation */
+          <>
+            {/* Always show first page */}
+            <Button
+              variant={1 === page ? 'default' : 'outline'}
+              size="sm"
+              className="min-w-[32px]"
+              onClick={() => onPageChange(1)}
+            >
+              1
+            </Button>
+            {/* Page before current */}
+            {page > 3 && <span className="text-xs text-muted-foreground px-1">…</span>}
+            {page > 2 && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-w-[32px]"
+                onClick={() => onPageChange(page - 1)}
+              >
+                {page - 1}
+              </Button>
+            )}
+            {/* Current page (not shown if it's 1 or count) */}
+            {page !== 1 && page !== count && (
+              <Button variant="default" size="sm" className="min-w-[32px]">
+                {page}
+              </Button>
+            )}
+            {/* Page after current */}
+            {page < count - 1 && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-w-[32px]"
+                onClick={() => onPageChange(page + 1)}
+              >
+                {page + 1}
+              </Button>
+            )}
+            {page < count - 2 && <span className="text-xs text-muted-foreground px-1">…</span>}
+            {/* Always show last page */}
+            <Button
+              variant={count === page ? 'default' : 'outline'}
+              size="sm"
+              className="min-w-[32px]"
+              onClick={() => onPageChange(count)}
+            >
+              {count}
+            </Button>
+          </>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(page + 1)}
+          disabled={nextDisabled}
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/invofi/apps/frontend/src/components/portfolio/__tests__/PaginationControls.test.tsx
+++ b/invofi/apps/frontend/src/components/portfolio/__tests__/PaginationControls.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PaginationControls } from '@/components/portfolio/PaginationControls';
+
+function renderControls(overrides: Partial<Parameters<typeof PaginationControls>[0]> = {}) {
+  const props = {
+    page: 1,
+    total: 55,
+    pageSize: 10,
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<PaginationControls {...props} />) };
+}
+
+describe('PaginationControls', () => {
+  it('shows the item range and page-size selector', () => {
+    renderControls();
+    expect(screen.getByText('1–10 of 55')).toBeInTheDocument();
+    expect(screen.getByLabelText('Page size')).toBeInTheDocument();
+  });
+
+  it('shows nothing but a count when there are no items', () => {
+    renderControls({ total: 0 });
+    expect(screen.getByText('0 positions')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Page size')).not.toBeInTheDocument();
+  });
+
+  it('disables prev on the first page and next on the last page', () => {
+    const { props } = renderControls({ page: 1 });
+    expect(screen.getByLabelText('Previous page')).toBeDisabled();
+    expect(screen.getByLabelText('Next page')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('Next page'));
+    expect(props.onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onPageChange with an exact page number when clicked', () => {
+    const { props } = renderControls({ page: 2, total: 55 });
+    fireEvent.click(screen.getByText('3'));
+    expect(props.onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('calls onPageSizeChange with the new size', () => {
+    const { props } = renderControls();
+    const select = screen.getByLabelText('Page size') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '50' } });
+    expect(props.onPageSizeChange).toHaveBeenCalledWith(50);
+  });
+
+  it('renders a compact window for many pages', () => {
+    renderControls({ page: 30, total: 1000, pageSize: 10 });
+    // first + last page always visible in compact mode
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    // current page + neighbours
+    expect(screen.getByText('29')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+    expect(screen.getByText('31')).toBeInTheDocument();
+  });
+});

--- a/invofi/apps/frontend/src/lib/pagination.test.ts
+++ b/invofi/apps/frontend/src/lib/pagination.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampPage,
+  pageCountOf,
+  paginate,
+  rangeLabel,
+} from '@/lib/pagination';
+
+describe('pageCountOf', () => {
+  it('returns 0 for empty or invalid input', () => {
+    expect(pageCountOf(0, 10)).toBe(0);
+    expect(pageCountOf(10, 0)).toBe(0);
+    expect(pageCountOf(10, -1)).toBe(0);
+  });
+
+  it('computes ceil division', () => {
+    expect(pageCountOf(5, 10)).toBe(1);
+    expect(pageCountOf(10, 10)).toBe(1);
+    expect(pageCountOf(11, 10)).toBe(2);
+    expect(pageCountOf(512, 25)).toBe(21);
+  });
+});
+
+describe('clampPage', () => {
+  it('clamps into the valid 1-based range', () => {
+    expect(clampPage(0, 100, 10)).toBe(1);
+    expect(clampPage(3, 100, 10)).toBe(3);
+    expect(clampPage(99, 100, 10)).toBe(10);
+    expect(clampPage(-5, 100, 10)).toBe(1);
+  });
+
+  it('returns 1 when there are no items', () => {
+    expect(clampPage(4, 0, 10)).toBe(1);
+  });
+});
+
+describe('paginate', () => {
+  const items = Array.from({ length: 55 }, (_, i) => i + 1); // 1..55
+
+  it('returns the first page by default', () => {
+    expect(paginate(items, 1, 10)).toEqual(Array.from({ length: 10 }, (_, i) => i + 1));
+  });
+
+  it('returns the third page', () => {
+    expect(paginate(items, 3, 10)).toEqual(Array.from({ length: 10 }, (_, i) => 21 + i));
+  });
+
+  it('returns a short last page', () => {
+    expect(paginate(items, 6, 10)).toEqual([51, 52, 53, 54, 55]);
+  });
+
+  it('clamps an out-of-range page to the last page', () => {
+    expect(paginate(items, 99, 10)).toEqual([51, 52, 53, 54, 55]);
+  });
+
+  it('returns an empty array when there are no items', () => {
+    expect(paginate([], 1, 10)).toEqual([]);
+  });
+});
+
+describe('rangeLabel', () => {
+  it('formats a standard window', () => {
+    expect(rangeLabel(1, 10, 55)).toBe('1–10 of 55');
+    expect(rangeLabel(6, 10, 55)).toBe('51–55 of 55');
+  });
+
+  it('handles the empty case', () => {
+    expect(rangeLabel(1, 10, 0)).toBe('0 of 0');
+  });
+});

--- a/invofi/apps/frontend/src/lib/pagination.ts
+++ b/invofi/apps/frontend/src/lib/pagination.ts
@@ -1,0 +1,46 @@
+/**
+ * Client-side pagination helpers for large portfolio position lists.
+ *
+ * The portfolio page renders every position token/offer a wallet holds; as the
+ * protocol grows a single wallet can end up with hundreds of rows. Rather than
+ * rendering them all at once we slice the list client-side (the contract layer
+ * is explicitly out of scope for this concern) and virtualize each page.
+ */
+
+/** Convenience type so callers do not need to repeat the generic. */
+export type Paginated<T> = readonly T[];
+
+/**
+ * Clamp a 1-based page number into the valid range for `total` items.
+ * Returns 1 when there is nothing to page over.
+ */
+export function clampPage(page: number, total: number, pageSize: number): number {
+  const pageCount = pageCountOf(total, pageSize);
+  if (pageCount === 0) return 1;
+  return Math.min(Math.max(1, page), pageCount);
+}
+
+/** Number of pages needed to show `total` items at `pageSize` per page. */
+export function pageCountOf(total: number, pageSize: number): number {
+  if (total <= 0 || pageSize <= 0) return 0;
+  return Math.ceil(total / pageSize);
+}
+
+/**
+ * Return the slice of `items` that belongs to `page` (1-based) when arranged
+ * at `pageSize` per page. `page` is clamped so callers can pass anything.
+ */
+export function paginate<T>(items: readonly T[], page: number, pageSize: number): Paginated<T> {
+  if (!items.length || pageSize <= 0) return [];
+  const start = (clampPage(page, items.length, pageSize) - 1) * pageSize;
+  return items.slice(start, start + pageSize);
+}
+
+/** Human label like "1–20 of 512". */
+export function rangeLabel(page: number, pageSize: number, total: number): string {
+  if (total === 0) return '0 of 0';
+  const clamped = clampPage(page, total, pageSize);
+  const start = (clamped - 1) * pageSize + 1;
+  const end = Math.min(clamped * pageSize, total);
+  return `${start}–${end} of ${total}`;
+}


### PR DESCRIPTION
## Summary

Closes #190 — paginate and virtualize the portfolio position list.

As the protocol grows a wallet can hold hundreds of position tokens/offers; the portfolio page previously rendered every row at once, causing long tables and slow renders. This PR makes the rendering layer scale client-side without touching the contract call layer.

## What changed

- **New `lib/pagination.ts`** — pure, tested helpers (`paginate`, `pageCountOf`, `clampPage`, `rangeLabel`) so page slicing is deterministic and reusable.
- **New `components/portfolio/PaginationControls.tsx`** — page-size selector (10/20/50/100 per page), prev/next buttons, numbered pages with an ellipsis compact mode for large lists, and a live "X–Y of N" range label.
- **`app/portfolio/page.tsx`** — the position list is now sliced client-side per page and rendered through `@tanstack/react-virtual` (`useVirtualizer` with per-row `measureElement`, so active tall cards and compact repaid cards size correctly). The page keeps the current page valid when the live stream shrinks, and the summary stats / CSV export still operate on the full list.
- **Tests** — 11 unit tests for the pagination helpers, 6 component tests for `PaginationControls`, all green (350 total, 38 files) alongside `tsc --noEmit` and ESLint.

## Verification

- `tsc --noEmit` — clean
- ESLint — clean
- `NODE_ENV=test npx vitest run` — 38 files / 350 tests passed (17 new)

## Notes

- `@tanstack/react-virtual@^3.14.10` added to `apps/frontend/package.json` per the issue's guidance (check before adding; nothing virtual was present).
- Presentation only — no changes to the contract/SDK layer.