### PR TITLE
feat(frontend): add live APR/APY preview to offer form (Closes #122)

### DIFF
--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -21,6 +21,7 @@ import { GRACE_PERIOD_SECS, STROOPS_PER_XLM } from '@/lib/constants';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import { toErrorMessage } from '@/lib/errors';
+import { OfferTermsPreview } from './OfferTermsPreview';
 import type { Currency, FinancingOffer, Invoice } from '@/types';
 
 const offerSchema = z.object({
@@ -51,7 +52,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
   >(null);
   const [repayAmounts, setRepayAmounts] = useState<Record<string, string>>({});
 
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<OfferFormValues>({
+  const { register, watch, handleSubmit, formState: { errors }, reset } = useForm<OfferFormValues>({
     resolver: zodResolver(offerSchema),
     defaultValues: { currency: 'USDC', interestRate: 500, durationDays: 30 },
   });
@@ -263,6 +264,9 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
     downloadCsv(`invofi-offers-${invoiceId}-${new Date().toISOString().slice(0, 10)}.csv`, csv);
   };
 
+  // Live form values for the repayment preview — re-renders on every keystroke.
+  const liveValues = watch();
+
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
@@ -326,6 +330,12 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
                 {errors.durationDays && <p className="text-xs text-red-500">{errors.durationDays.message}</p>}
               </div>
             </div>
+            <OfferTermsPreview
+              amount={liveValues.amount ?? ''}
+              rateBps={Number(liveValues.interestRate)}
+              durationDays={Number(liveValues.durationDays)}
+              currency={liveValues.currency ?? 'USDC'}
+            />
             <div className="flex gap-2">
               <Button type="submit" size="sm" disabled={loading}>
                 {loading && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}

--- a/invofi/apps/frontend/src/components/invoices/OfferTermsPreview.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferTermsPreview.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Info, AlertTriangle } from 'lucide-react';
+import { computeOfferTerms, formatPct, formatMoney } from '@/lib/offerTerms';
+
+interface OfferTermsPreviewProps {
+  amount: string;
+  rateBps: number;
+  durationDays: number;
+  currency: string;
+}
+
+/**
+ * Live preview panel shown inside the offer form.
+ * Computes annualized APR/APY and projected total repayment as the user types,
+ * mirroring the contract's simple-interest math. Flags out-of-range values inline.
+ */
+export function OfferTermsPreview({
+  amount,
+  rateBps,
+  durationDays,
+  currency,
+}: OfferTermsPreviewProps) {
+  const terms = computeOfferTerms(amount, rateBps, durationDays);
+
+  if (!terms) {
+    // No valid principal yet — hint the user to enter a number
+    return (
+      <div className="rounded-md border border-gray-200 bg-gray-50 p-3 text-xs text-gray-500">
+        <Info className="h-3 w-3 inline-block mr-1 -mt-0.5" />
+        Enter an amount, interest rate, and duration to see a live repayment preview.
+      </div>
+    );
+  }
+
+  const hasWarnings = terms.rateOutOfRange || terms.durationOutOfRange;
+
+  return (
+    <div
+      className={`rounded-md border p-3 space-y-1.5 text-xs ${
+        hasWarnings
+          ? 'border-amber-200 bg-amber-50'
+          : 'border-blue-100 bg-blue-50'
+      }`}
+    >
+      <p className="flex items-center gap-1 font-medium text-gray-700">
+        <Info className="h-3 w-3" />
+        Repayment Preview
+      </p>
+
+      {terms.rateOutOfRange && (
+        <p className="flex items-center gap-1 text-amber-700">
+          <AlertTriangle className="h-3 w-3 shrink-0" />
+          Rate must be between 1 and 5,000 bps ({formatPct(0.01)}–{formatPct(50)}).
+        </p>
+      )}
+      {terms.durationOutOfRange && (
+        <p className="flex items-center gap-1 text-amber-700">
+          <AlertTriangle className="h-3 w-3 shrink-0" />
+          Duration must be between 1 and 365 days.
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+        <span className="text-gray-500">Simple Rate</span>
+        <span className="text-right font-mono tabular-nums">
+          {formatPct(terms.simpleRatePct)}
+        </span>
+
+        <span className="text-gray-500">Interest</span>
+        <span className="text-right font-mono tabular-nums">
+          {formatMoney(terms.interest)} {currency}
+        </span>
+
+        <span className="text-gray-500 font-medium">Total Repayment</span>
+        <span className="text-right font-mono tabular-nums font-medium text-gray-800">
+          {formatMoney(terms.totalRepayment)} {currency}
+        </span>
+
+        <span className="text-gray-500">Annualized APR</span>
+        <span className="text-right font-mono tabular-nums">
+          {formatPct(terms.annualizedApr)}
+        </span>
+
+        <span className="text-gray-500">Annualized APY</span>
+        <span className="text-right font-mono tabular-nums">
+          {formatPct(terms.annualizedApy)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/invofi/apps/frontend/src/lib/offerTerms.test.ts
+++ b/invofi/apps/frontend/src/lib/offerTerms.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeOfferTerms,
+  formatPct,
+  formatMoney,
+  MIN_RATE_BPS,
+  MAX_RATE_BPS,
+  MIN_DURATION_DAYS,
+  MAX_DURATION_DAYS,
+} from './offerTerms';
+
+describe('computeOfferTerms', () => {
+  it('computes the acceptance example: 500 bps over 30 days on a 10,000 invoice', () => {
+    const terms = computeOfferTerms('10000', 500, 30);
+    expect(terms).not.toBeNull();
+    expect(terms!.simpleRatePct).toBeCloseTo(5, 8);
+    expect(terms!.interest).toBeCloseTo(500, 8);
+    expect(terms!.totalRepayment).toBeCloseTo(10500, 8);
+    // Annualized simple rate: 5% * 365/30
+    expect(terms!.annualizedApr).toBeCloseTo(60.833_333, 4);
+    // Annualized compounded rate over the term
+    expect(terms!.annualizedApy).toBeCloseTo(79.585_6, 2);
+    expect(terms!.rateOutOfRange).toBe(false);
+    expect(terms!.durationOutOfRange).toBe(false);
+  });
+
+  it('accepts both string and numeric principal inputs', () => {
+    const fromString = computeOfferTerms('2500.50', 1000, 60);
+    const fromNumber = computeOfferTerms(2500.5, 1000, 60);
+    expect(fromString).not.toBeNull();
+    expect(fromNumber).not.toBeNull();
+    expect(fromString!.principal).toBeCloseTo(fromNumber!.principal, 8);
+    expect(fromString!.interest).toBeCloseTo(fromNumber!.interest, 8);
+  });
+
+  it('uses simple (non-compounded) contract math for repayment', () => {
+    // 2,000 XLM at 400 bps over 90 days -> 8% simple interest
+    const terms = computeOfferTerms('2000', 400, 90);
+    expect(terms!.interest).toBeCloseTo(160, 8);
+    expect(terms!.totalRepayment).toBeCloseTo(2160, 8);
+    // Contract math never compounds within the term
+    expect(terms!.totalRepayment).toBeLessThan(2000 * Math.pow(1.08, 1));
+  });
+
+  it('returns null for unparseable or non-positive principal', () => {
+    expect(computeOfferTerms('', 500, 30)).toBeNull();
+    expect(computeOfferTerms('abc', 500, 30)).toBeNull();
+    expect(computeOfferTerms('0', 500, 30)).toBeNull();
+    expect(computeOfferTerms('-100', 500, 30)).toBeNull();
+    expect(computeOfferTerms('NaN', 500, 30)).toBeNull();
+  });
+
+  it('flags rates outside the contract-allowed range', () => {
+    expect(computeOfferTerms('10000', MIN_RATE_BPS - 1, 30)!.rateOutOfRange).toBe(true);
+    expect(computeOfferTerms('10000', MAX_RATE_BPS + 1, 30)!.rateOutOfRange).toBe(true);
+    expect(computeOfferTerms('10000', MIN_RATE_BPS, 30)!.rateOutOfRange).toBe(false);
+    expect(computeOfferTerms('10000', MAX_RATE_BPS, 30)!.rateOutOfRange).toBe(false);
+  });
+
+  it('flags durations outside the contract-allowed range', () => {
+    expect(computeOfferTerms('10000', 500, MIN_DURATION_DAYS - 1)!.durationOutOfRange).toBe(true);
+    expect(computeOfferTerms('10000', 500, MAX_DURATION_DAYS + 1)!.durationOutOfRange).toBe(true);
+    expect(computeOfferTerms('10000', 500, MIN_DURATION_DAYS)!.durationOutOfRange).toBe(false);
+    expect(computeOfferTerms('10000', 500, MAX_DURATION_DAYS)!.durationOutOfRange).toBe(false);
+  });
+
+  it('does not divide by zero for zero duration', () => {
+    const terms = computeOfferTerms('10000', 500, 0);
+    expect(terms).not.toBeNull();
+    expect(terms!.durationOutOfRange).toBe(true);
+    expect(Number.isFinite(terms!.annualizedApr)).toBe(true);
+  });
+});
+
+describe('formatPct', () => {
+  it('formats percentages with two fraction digits by default', () => {
+    expect(formatPct(5)).toBe('5.00%');
+    expect(formatPct(60.833_333)).toBe('60.83%');
+  });
+
+  it('honors a custom fraction digits argument', () => {
+    expect(formatPct(5, 1)).toBe('5.0%');
+  });
+});
+
+describe('formatMoney', () => {
+  it('adds thousands separators', () => {
+    expect(formatMoney(10500)).toBe('10,500');
+    expect(formatMoney(1234567.5)).toBe('1,234,567.5');
+  });
+});

--- a/invofi/apps/frontend/src/lib/offerTerms.ts
+++ b/invofi/apps/frontend/src/lib/offerTerms.ts
@@ -1,0 +1,99 @@
+/**
+ * Client-side offer term math for the offer form live preview.
+ *
+ * The on-chain contract computes repayment with a simple (non-compounded)
+ * yield: total_due = principal + principal * rate_bps / 10_000. These helpers
+ * mirror that math and additionally annualize it (APR/APY) so lenders can see
+ * what their terms mean in real money before submitting.
+ */
+
+/** Contract-enforced bounds (mirrors the offer schema in OfferList.tsx). */
+export const MIN_RATE_BPS = 1;
+export const MAX_RATE_BPS = 5000;
+export const MIN_DURATION_DAYS = 1;
+export const MAX_DURATION_DAYS = 365;
+
+export interface OfferTerms {
+  /** Parsed principal in human units. */
+  principal: number;
+  /** Interest rate in basis points (1 bps = 0.01%). */
+  rateBps: number;
+  /** Term length in days. */
+  durationDays: number;
+  /** Simple rate as a percentage (rateBps / 100), e.g. 500 -> 5. */
+  simpleRatePct: number;
+  /** Simple interest owed in human units (contract math). */
+  interest: number;
+  /** Principal + interest in human units. */
+  totalRepayment: number;
+  /** Annualized simple rate: simpleRatePct * 365 / durationDays. */
+  annualizedApr: number;
+  /** Annualized compounded rate over the term. */
+  annualizedApy: number;
+  /** True when rateBps is outside the contract-allowed range. */
+  rateOutOfRange: boolean;
+  /** True when durationDays is outside the contract-allowed range. */
+  durationOutOfRange: boolean;
+}
+
+const DAYS_PER_YEAR = 365;
+
+/**
+ * Compute the offer terms for a live preview. Returns null when the principal
+ * cannot be parsed as a positive number. Range violations are reported via
+ * flags (not null) so the UI can show inline warnings while the user types.
+ */
+export function computeOfferTerms(
+  principalInput: string | number,
+  rateBps: number,
+  durationDays: number,
+): OfferTerms | null {
+  const principal = typeof principalInput === 'number'
+    ? principalInput
+    : Number.parseFloat(String(principalInput).trim());
+
+  if (!Number.isFinite(principal) || principal <= 0) return null;
+  // A blank rate/duration field yields '' which coerces to 0 — that is a
+  // legitimate "out of range" state; only NaN (unparseable) short-circuits.
+  if (!Number.isFinite(rateBps) || !Number.isFinite(durationDays)) return null;
+
+  const simpleRatePct = rateBps / 100;
+  const interest = (principal * rateBps) / 10_000;
+  const totalRepayment = principal + interest;
+
+  const annualizedApr = durationDays > 0
+    ? simpleRatePct * (DAYS_PER_YEAR / durationDays)
+    : 0;
+
+  let annualizedApy = 0;
+  if (durationDays > 0) {
+    annualizedApy =
+      (Math.pow(1 + rateBps / 10_000, DAYS_PER_YEAR / durationDays) - 1) * 100;
+  }
+
+  return {
+    principal,
+    rateBps,
+    durationDays,
+    simpleRatePct,
+    interest,
+    totalRepayment,
+    annualizedApr,
+    annualizedApy,
+    rateOutOfRange: rateBps < MIN_RATE_BPS || rateBps > MAX_RATE_BPS,
+    durationOutOfRange:
+      durationDays < MIN_DURATION_DAYS || durationDays > MAX_DURATION_DAYS,
+  };
+}
+
+/** Human-friendly formatting for the preview, e.g. 5 -> "5.00%". */
+export function formatPct(value: number, fractionDigits = 2): string {
+  return `${value.toFixed(fractionDigits)}%`;
+}
+
+/** Format a money amount with thousands separators, e.g. 10500 -> "10,500". */
+export function formatMoney(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+  }).format(value);
+}


### PR DESCRIPTION
## Summary

Adds a live repayment preview panel to the offer form that computes annualized APR/APY and projected total repayment as the user types.

### Changes

- **`lib/offerTerms.ts`** — Pure functions: `computeOfferTerms()` mirrors the contract's simple-interest math and annualizes it (APR/APY); includes range-bound flags for inline validation.
- **`lib/offerTerms.test.ts`** — 10 tests covering the acceptance example (500 bps / 30 days / 10,000 XLM → 5% simple rate, 500 interest, 10,500 total, ~60.83% APR), null inputs, range flags, zero-duration edge case, and formatting helpers.
- **`components/invoices/OfferTermsPreview.tsx`** — Live preview panel component with conditional styling (amber warning for out-of-range values, blue info for valid inputs).
- **`components/invoices/OfferList.tsx`** — Integrated `OfferTermsPreview` via `watch()` from react-hook-form; re-renders on every keystroke with no extra network calls.

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a live offer terms preview to the offer form.
  - Displays estimated interest, total repayment, APR, APY, and currency values.
  - Preview updates as amount, rate, duration, or currency changes.
  - Shows guidance and inline warnings for incomplete or invalid terms.

- **Tests**
  - Added coverage for offer calculations, validation limits, zero-duration scenarios, and value formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->