### PR TITLE
refactor(frontend): centralize XLM/USDC amount formatting into lib/formatters (Closes #123)

### DIFF
--- a/invofi/apps/frontend/src/app/dashboard/page.tsx
+++ b/invofi/apps/frontend/src/app/dashboard/page.tsx
@@ -18,6 +18,7 @@ import { getXlmBalance } from '@/lib/horizon';
 import { useWallet } from '@/components/auth/WalletProvider';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { STROOPS_PER_XLM } from '@/lib/constants';
+import { formatUnits } from '@/lib/formatters';
 import { toCsv, downloadCsv } from '@/lib/csv';
 import type { UserProfile, Invoice } from '@/types';
 import { SupabaseUser } from '@/lib/types/supabase-auth';
@@ -137,7 +138,7 @@ export default function DashboardPage() {
             <WalletButton />
             {xlmBalance !== null && (
               <span className="text-sm text-muted-foreground font-mono">
-                {parseFloat(xlmBalance).toFixed(2)} XLM
+                {formatUnits(xlmBalance)}
               </span>
             )}
           </CardContent>

--- a/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/page.tsx
@@ -19,7 +19,8 @@ import { supabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import { toErrorMessage } from '@/lib/errors';
-import { formatAmount, formatDate, formatAddress, INVOICE_STATUS_COLORS, generateInvoiceId } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatDate, formatAddress, INVOICE_STATUS_COLORS, generateInvoiceId } from '@/lib/utils';
 import type { Invoice, FinancingOffer } from '@/types';
 
 export default function InvoiceDetailPage() {
@@ -218,7 +219,7 @@ export default function InvoiceDetailPage() {
                 </div>
               </CardHeader>
               <CardContent className="grid grid-cols-2 gap-4 text-sm">
-                <Field label="Amount" value={`${formatAmount(invoice.amount)} ${invoice.currency}`} mono />
+                <Field label="Amount" value={formatAmount(invoice.amount, invoice.currency)} mono />
                 <Field label="Currency" value={invoice.currency} />
                 <Field label="Due Date" value={formatDate(invoice.due_date)} />
                 <Field

--- a/invofi/apps/frontend/src/app/invoices/[id]/print/InvoicePrintView.tsx
+++ b/invofi/apps/frontend/src/app/invoices/[id]/print/InvoicePrintView.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import { getInvoice } from '@/lib/contract';
-import { formatAmount, formatDate, interestRateLabel, durationLabel } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatDate, interestRateLabel, durationLabel } from '@/lib/utils';
 import { toStroopsBigInt } from '@/lib/utils';
 import {
   REGISTRY_CONTRACT_ID,
@@ -315,7 +316,7 @@ export default function InvoicePrintView() {
               <div className="meta-field">
                 <label>Amount</label>
                 <p className="mono">
-                  {formatAmount(invoice.amount)} {invoice.currency}
+                  {formatAmount(invoice.amount, invoice.currency)}
                 </p>
               </div>
               <div className="meta-field">
@@ -389,20 +390,20 @@ export default function InvoicePrintView() {
                           {offer.lender.slice(0, 6)}…{offer.lender.slice(-6)}
                         </td>
                         <td className="mono">
-                          {formatAmount(offer.amount)} {offer.currency}
+                          {formatAmount(offer.amount, offer.currency)}
                         </td>
                         <td>{interestRateLabel(offer.interest_rate)}</td>
                         <td>{durationLabel(offer.duration)}</td>
-                        <td className="mono">{formatAmount(due)} {offer.currency}</td>
+                        <td className="mono">{formatAmount(due, offer.currency)}</td>
                         <td className="mono">
                           {repaid > 0n ? (
                             <>
                               <span style={{ color: '#16a34a' }}>
-                                {formatAmount(repaid)} {offer.currency}
+                                {formatAmount(repaid, offer.currency)}
                               </span>
                               {remaining > 0n && (
                                 <span style={{ color: '#9ca3af', fontSize: 10 }}>
-                                  {' '}/ {formatAmount(remaining)} {offer.currency} rem.
+                                  {' '}/ {formatAmount(remaining, offer.currency)} rem.
                                 </span>
                               )}
                             </>

--- a/invofi/apps/frontend/src/app/portfolio/page.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/page.tsx
@@ -14,7 +14,7 @@ import { TableSkeleton } from '@/components/common/LoadingSkeleton';
 import { useToast } from '@/components/ui/use-toast';
 import { toErrorMessage } from '@/lib/errors';
 import { addPositionTrustline, getPositionTokenId, getTokenBalance, getTokenDecimals, hasPositionTrustline, transferPositionToken } from '@/lib/contract';
-import { formatAmount, formatDate } from '@/lib/utils';
+import { formatDate, interestRateLabel, durationLabel, OFFER_STATUS_COLORS } from '@/lib/utils';
 import { formatAmount as formatAmountDisplay } from '@/lib/formatters';
 import { STROOPS_PER_XLM } from '@/lib/constants';
 import { toCsv, downloadCsv } from '@/lib/csv';

--- a/invofi/apps/frontend/src/app/portfolio/page.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/page.tsx
@@ -14,7 +14,8 @@ import { TableSkeleton } from '@/components/common/LoadingSkeleton';
 import { useToast } from '@/components/ui/use-toast';
 import { toErrorMessage } from '@/lib/errors';
 import { addPositionTrustline, getPositionTokenId, getTokenBalance, getTokenDecimals, hasPositionTrustline, transferPositionToken } from '@/lib/contract';
-import { formatAmount, formatDate, interestRateLabel, durationLabel, OFFER_STATUS_COLORS } from '@/lib/utils';
+import { formatAmount, formatDate } from '@/lib/utils';
+import { formatAmount as formatAmountDisplay } from '@/lib/formatters';
 import { STROOPS_PER_XLM } from '@/lib/constants';
 import { toCsv, downloadCsv } from '@/lib/csv';
 import { stroopsToUsd } from '@/lib/live/prices';
@@ -318,7 +319,7 @@ function PositionCard({ offer }: { offer: LivePosition }) {
           <div className="text-right flex items-center gap-3 shrink-0">
             <div>
               <p className="text-sm font-semibold font-mono text-foreground">
-                {formatAmount(offer.amount)} {offer.currency}
+                {formatAmountDisplay(offer.amount, offer.currency)}
               </p>
               <p className="text-xs text-muted-foreground font-mono">
                 ≈ ${offer.liveValueUsd.toFixed(2)} USD
@@ -338,7 +339,7 @@ function PositionCard({ offer }: { offer: LivePosition }) {
               <div>
                 <p className="text-xs text-muted-foreground mb-0.5">Earned to date</p>
                 <p className="text-sm font-semibold font-mono text-foreground">
-                  {formatAmount(offer.earnedToDate)} {offer.currency}
+                  {formatAmountDisplay(offer.earnedToDate, offer.currency)}
                   <span className="text-xs text-muted-foreground font-normal">
                     {' '}≈ ${stroopsToUsd(offer.earnedToDate, offer.currency).toFixed(2)}
                   </span>
@@ -352,7 +353,7 @@ function PositionCard({ offer }: { offer: LivePosition }) {
             <div className="mt-3">
               <RepaymentProgress value={offer.repaymentProgress} label={`${pct}% of total due repaid`} />
               <p className="text-xs mt-1 text-muted-foreground">
-                {formatAmount(offer.amount_repaid)} {offer.currency} repaid · {formatAmount(offer.remaining)} {offer.currency} remaining ·{' '}
+                {formatAmountDisplay(offer.amount_repaid, offer.currency)} repaid · {formatAmountDisplay(offer.remaining, offer.currency)} remaining ·{' '}
                 <span className="text-muted-foreground/70">updated {relativeUpdate(offer.updatedAt)}</span>
               </p>
             </div>

--- a/invofi/apps/frontend/src/app/stats/page.tsx
+++ b/invofi/apps/frontend/src/app/stats/page.tsx
@@ -21,7 +21,7 @@ import { StatsCard } from '@/components/common/StatsCard';
 import { StatsGrid } from '@/components/common/StatsGrid';
 import { CardSkeleton } from '@/components/common/LoadingSkeleton';
 import { supabase } from '@/lib/supabase';
-import { STROOPS_PER_XLM } from '@/lib/constants';
+import { formatAmount } from '@/lib/formatters';
 
 interface ProtocolStats {
   id: number;
@@ -38,15 +38,7 @@ interface ProtocolStats {
   updated_at?: string;
 }
 
-/** Stroops (i128 stored as text) → XLM with 2 decimals. */
-function xlm(stroops: string): string {
-  const n = Number(stroops) / STROOPS_PER_XLM;
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(n);
-}
-
+/** ISO date → display string. */
 function formatDate(iso?: string): string {
   if (!iso) return '—';
   return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(iso));
@@ -133,7 +125,7 @@ export default function StatsPage() {
             />
             <StatsCard
               title="Total Volume"
-              value={`${xlm(stats.total_volume)} XLM`}
+              value={formatAmount(stats.total_volume)}
               icon={TrendingUp}
               description="Financed principal (on-chain total_financed)"
             />
@@ -163,7 +155,7 @@ export default function StatsPage() {
             />
             <StatsCard
               title="Insurance Pool"
-              value={`${xlm(stats.insurance_pool)} XLM`}
+              value={formatAmount(stats.insurance_pool)}
               icon={ShieldCheck}
               description="Staked by insurance providers"
             />

--- a/invofi/apps/frontend/src/components/auth/WalletButton.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletButton.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { useWallet } from './WalletProvider';
 import { WalletSelectDialog } from './WalletSelectDialog';
 import { formatAddress } from '@/lib/utils';
+import { formatUnits } from '@/lib/formatters';
 import { useToast } from '@/components/ui/use-toast';
 import { getXlmBalance } from '@/lib/horizon';
 import { explorerAccountUrl } from '@/lib/constants';
@@ -29,7 +30,7 @@ export function WalletButton({ onConnected }: WalletButtonProps) {
   useEffect(() => {
     if (!isConnected || !publicKey) { setXlmBalance(null); return; }
     getXlmBalance(publicKey)
-      .then(b => setXlmBalance(parseFloat(b).toFixed(2)))
+      .then(b => setXlmBalance(formatUnits(b, 'XLM')))
       .catch(() => setXlmBalance(null));
   }, [isConnected, publicKey]);
 
@@ -93,7 +94,7 @@ export function WalletButton({ onConnected }: WalletButtonProps) {
             </a>
             {xlmBalance !== null && (
               <span className="text-xs text-green-700 dark:text-green-300 font-medium border-l border-green-200 dark:border-green-800 px-2 py-1.5">
-                {xlmBalance} XLM
+                {xlmBalance}
               </span>
             )}
             <button

--- a/invofi/apps/frontend/src/components/invoices/InvoiceCard.tsx
+++ b/invofi/apps/frontend/src/components/invoices/InvoiceCard.tsx
@@ -2,7 +2,8 @@ import Link from 'next/link';
 import { Calendar, DollarSign } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { formatAmount, formatDate, INVOICE_STATUS_COLORS } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatDate, INVOICE_STATUS_COLORS } from '@/lib/utils';
 import type { Invoice } from '@/types';
 
 interface InvoiceCardProps {
@@ -24,7 +25,7 @@ export function InvoiceCard({ invoice, href }: InvoiceCardProps) {
             <div className="flex items-center gap-1.5 text-gray-700">
               <DollarSign className="h-3.5 w-3.5 text-gray-400" />
               <span className="font-semibold">
-                {formatAmount(invoice.amount)} {invoice.currency}
+                {formatAmount(invoice.amount, invoice.currency)}
               </span>
             </div>
             <div className="flex items-center gap-1.5 text-gray-500">

--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -15,7 +15,8 @@ import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { useWallet } from '@/components/auth/WalletProvider';
 import { createOffer, acceptOffer, rejectOffer, repayInvoice, markOverdue, reclaimInvoice } from '@/lib/contract';
 import { supabase } from '@/lib/supabase';
-import { formatAmount, interestRateLabel, durationLabel, generateOfferId, amountToStroops, toStroopsBigInt, OFFER_STATUS_COLORS } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatAmount as formatUnits, interestRateLabel, durationLabel, generateOfferId, amountToStroops, toStroopsBigInt, OFFER_STATUS_COLORS } from '@/lib/utils';
 import { toCsv, downloadCsv } from '@/lib/csv';
 import { GRACE_PERIOD_SECS, STROOPS_PER_XLM } from '@/lib/constants';
 import { useToast } from '@/components/ui/use-toast';
@@ -187,7 +188,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
       const newRepaid = toStroopsBigInt(offer.amount_repaid) + amountStroops;
       setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: nextOfferStatus, amount_repaid: newRepaid } : o));
       // Mirror stores human-decimal strings (same format as its amount column).
-      await supabase.from('financing_offers').update({ status: nextOfferStatus, amount_repaid: formatAmount(newRepaid) }).eq('id', offer.id);
+      await supabase.from('financing_offers').update({ status: nextOfferStatus, amount_repaid: formatUnits(newRepaid) }).eq('id', offer.id);
       await supabase.from('invoices').update({ status: nextInvoiceStatus }).eq('id', invoiceId);
       onUpdate(updatedInvoice);
       toast({
@@ -371,14 +372,14 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
             <div>
               <p className="text-sm font-mono text-gray-600">{formatAddress(offer.lender)}</p>
               <p className="text-xs text-gray-400 mt-0.5">
-                {formatAmount(offer.amount)} {offer.currency} ·{' '}
+                {formatAmount(offer.amount, offer.currency)} ·{' '}
                 {interestRateLabel(offer.interest_rate)} · {durationLabel(offer.duration)}
               </p>
               {(offer.status === 'Accepted' || offer.status === 'Financed') && repaid > 0n && (
                 <p className="text-xs mt-1">
-                  <span className="text-green-600">{formatAmount(repaid)} repaid</span>
+                  <span className="text-green-600">{formatAmount(repaid, offer.currency)} repaid</span>
                   {' · '}
-                  <span className="text-gray-500">{formatAmount(remaining)} remaining</span>
+                  <span className="text-gray-500">{formatAmount(remaining, offer.currency)} remaining</span>
                 </p>
               )}
             </div>
@@ -408,8 +409,8 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
                 <div className="flex items-center gap-1.5">
                   <Input
                     className="h-8 w-28 text-xs"
-                    placeholder={formatAmount(remainingBalance(offer))}
-                    title={`Remaining balance: ${formatAmount(remainingBalance(offer))} ${offer.currency} (total due ${formatAmount(totalDue(offer))} minus ${formatAmount(repaid)})`}
+                    placeholder={formatUnits(remainingBalance(offer))}
+                    title={`Remaining balance: ${formatAmount(remainingBalance(offer), offer.currency)} (total due ${formatAmount(totalDue(offer), offer.currency)} minus ${formatAmount(repaid, offer.currency)})`}
                     value={repayAmounts[offer.id] ?? ''}
                     onChange={e => setRepayAmounts(prev => ({ ...prev, [offer.id]: e.target.value }))}
                   />

--- a/invofi/apps/frontend/src/components/marketplace/ListPositionForm.tsx
+++ b/invofi/apps/frontend/src/components/marketplace/ListPositionForm.tsx
@@ -18,7 +18,8 @@ import {
   listingDraftSchema,
   type ListingDraft,
 } from '@/lib/listings';
-import { formatAmount, formatAddress, toStroopsBigInt } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatAmount as formatUnits, formatAddress, toStroopsBigInt } from '@/lib/utils';
 import type { FinancingOffer, PositionListing } from '@/types';
 
 interface ListPositionFormProps {
@@ -30,7 +31,7 @@ interface ListPositionFormProps {
 
 /** Position tokens are minted 1:1 with principal (ADR-0002). */
 function positionSize(offer: FinancingOffer): string {
-  return formatAmount(toStroopsBigInt(offer.amount));
+  return formatUnits(toStroopsBigInt(offer.amount));
 }
 
 export function ListPositionForm({ sellerAddress, sellerId, onCreated }: ListPositionFormProps) {
@@ -144,7 +145,7 @@ export function ListPositionForm({ sellerAddress, sellerId, onCreated }: ListPos
               <option value="">Select a position…</option>
               {positions.map(p => (
                 <option key={p.id} value={p.id}>
-                  Invoice {p.invoice_id} — {positionSize(p)} {p.currency} principal
+                  Invoice {p.invoice_id} — {formatAmount(toStroopsBigInt(p.amount), p.currency)} principal
                 </option>
               ))}
             </select>

--- a/invofi/apps/frontend/src/components/marketplace/MarketplaceCard.tsx
+++ b/invofi/apps/frontend/src/components/marketplace/MarketplaceCard.tsx
@@ -4,7 +4,8 @@ import { Calendar, DollarSign, ArrowRight, ExternalLink, Clock, AlertTriangle } 
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { formatAmount, formatDate, formatAddress, INVOICE_STATUS_COLORS } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatDate, formatAddress, INVOICE_STATUS_COLORS } from '@/lib/utils';
 import type { Invoice } from '@/types';
 
 const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
@@ -66,7 +67,7 @@ export const MarketplaceCard = memo(function MarketplaceCard({ invoice }: Market
           <div className="flex items-center gap-1.5 text-foreground">
             <DollarSign className="h-4 w-4 text-muted-foreground shrink-0" />
             <span className="font-semibold text-lg">
-              {formatAmount(invoice.amount)} {invoice.currency}
+              {formatAmount(invoice.amount, invoice.currency)}
             </span>
           </div>
 

--- a/invofi/apps/frontend/src/components/marketplace/SuggestedMatches.tsx
+++ b/invofi/apps/frontend/src/components/marketplace/SuggestedMatches.tsx
@@ -31,7 +31,8 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import { formatAmount, formatDate, formatAddress, INVOICE_STATUS_COLORS } from '@/lib/utils';
+import { formatAmount } from '@/lib/formatters';
+import { formatDate, formatAddress, INVOICE_STATUS_COLORS } from '@/lib/utils';
 import { MatchQualityBadge } from '@/components/marketplace/MatchQualityBadge';
 import type { MatchResult, ScoreBreakdown } from '@/types/matching';
 import type { Invoice } from '@/types';
@@ -180,7 +181,7 @@ function MatchedInvoiceCard({ result }: MatchedInvoiceCardProps) {
             <div className="flex items-center gap-1.5 text-foreground">
               <DollarSign className="h-4 w-4 text-muted-foreground shrink-0" />
               <span className="font-semibold text-lg">
-                {formatAmount(invoice.amount)} {invoice.currency}
+                {formatAmount(invoice.amount, invoice.currency)}
               </span>
             </div>
             <Badge className={INVOICE_STATUS_COLORS[invoice.status]}>{invoice.status}</Badge>

--- a/invofi/apps/frontend/src/lib/formatters.test.ts
+++ b/invofi/apps/frontend/src/lib/formatters.test.ts
@@ -3,9 +3,11 @@ import {
   formatAmount,
   formatBasisPoints,
   formatCurrencyAmount,
+  formatCurrencyPair,
   formatDate,
   formatDuration,
   formatRelativeDate,
+  formatUnits,
   formatWalletAddress,
 } from './formatters';
 
@@ -65,6 +67,36 @@ describe('formatters', () => {
       expect(formatAmount('10000000')).toBe('1.00 XLM');
       expect(formatAmount('0')).toBe('0.00 XLM');
       expect(formatAmount('12345678')).toBe('1.23 XLM');
+    });
+
+    it('handles negative inputs', () => {
+      expect(formatAmount(-10_000_000, 'XLM')).toBe('-1.00 XLM');
+      expect(formatAmount(-1_234_567_800, 'USDC')).toBe('-123.46 USDC');
+      expect(formatAmount(BigInt(-10_000_000), 'XLM')).toBe('-1.00 XLM');
+      expect(formatAmount('-5000000', 'XLM')).toBe('-0.50 XLM');
+    });
+  });
+
+  describe('formatUnits', () => {
+    it('formats values already in human units', () => {
+      expect(formatUnits('12.3456789')).toBe('12.35 XLM');
+      expect(formatUnits(2.5, 'USDC')).toBe('2.50 USDC');
+    });
+
+    it('handles zero and negative units', () => {
+      expect(formatUnits('0')).toBe('0.00 XLM');
+      expect(formatUnits(0, 'USDC')).toBe('0.00 USDC');
+      expect(formatUnits('-1.2345')).toBe('-1.23 XLM');
+      expect(formatUnits(-5, 'USDC')).toBe('-5.00 USDC');
+    });
+  });
+
+  describe('formatCurrencyPair', () => {
+    it('formats a units + currency pair like formatUnits', () => {
+      expect(formatCurrencyPair('12.3456789', 'XLM')).toBe('12.35 XLM');
+      expect(formatCurrencyPair('0', 'USDC')).toBe('0.00 USDC');
+      expect(formatCurrencyPair('-3.5', 'XLM')).toBe('-3.50 XLM');
+      expect(formatCurrencyPair(2.5)).toBe('2.50 XLM');
     });
   });
 

--- a/invofi/apps/frontend/src/lib/formatters.ts
+++ b/invofi/apps/frontend/src/lib/formatters.ts
@@ -1,11 +1,34 @@
 import { STROOPS_PER_XLM } from './constants';
 
+/**
+ * Format a stroops-denominated amount for display.
+ *
+ * Converts stroops (1 XLM = 10^7 stroops) to human units and renders them with
+ * a two-decimal Intl representation plus a trailing currency code suffix,
+ * e.g. `formatAmount(12_345_678, 'XLM')` → `"1.23 XLM"`.
+ *
+ * @remarks
+ * Rounding rules (identical on every page, per issue #123):
+ * - always exactly 2 fraction digits, en-US locale with thousands separators
+ * - negative inputs format with a leading minus sign (`-1.23 XLM`)
+ * - the currency code is appended as `" 1.23 XLM"` (not `$`/`€` symbols)
+ * This helper does NOT perform currency conversion.
+ */
 export function formatAmount(stroops: string | number | bigint, currency: string = 'XLM'): string {
   const units = Number(stroops) / STROOPS_PER_XLM;
+  return formatUnits(units, currency);
+}
+
+/**
+ * Format an amount that is already in human units (not stroops) for display.
+ * e.g. a Horizon `getXlmBalance` string `"12.3456789"` → `"12.35 XLM"`.
+ * See {@link formatAmount} for the shared rounding rules.
+ */
+export function formatUnits(units: string | number, currency: string = 'XLM'): string {
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
-  }).format(units) + ` ${currency}`;
+  }).format(Number(units)) + ` ${currency}`;
 }
 
 /**
@@ -19,6 +42,18 @@ export function formatCurrencyAmount(
   currency: string = 'XLM',
 ): string {
   return formatAmount(stroops, currency);
+}
+
+/**
+ * Format a (amount, currency) pair for display — same output as
+ * {@link formatAmount} but accepts inputs already in human units.
+ * Produces e.g. "1.23 XLM".
+ */
+export function formatCurrencyPair(
+  units: string | number,
+  currency: string = 'XLM',
+): string {
+  return formatUnits(units, currency);
 }
 
 export function formatBasisPoints(bps: number | bigint | string): string {


### PR DESCRIPTION
## Summary

Centralizes all XLM/USDC amount formatting into the shared `lib/formatters` module, per issue #123. Every page/component that displays amounts now renders through a shared helper — no duplicate formatting logic remains in the app.

## Changes

**`lib/formatters.ts`** — became the single home for amount display formatting:
- `formatAmount(stroops, currency)` — stroops → `"1.23 XLM"` (unchanged behavior: 2 decimals, en-US Intl, currency suffix)
- `formatUnits(units, currency)` — **new**, for values already in human units (e.g. Horizon balances) → `"12.35 XLM"`
- `formatCurrencyPair(units, currency)` — **new** named helper requested by the issue; same output as `formatUnits`
- `formatCurrencyAmount(...)` — kept as a backwards-compatible alias
- Added module docs stating the shared rounding rules (exactly 2 fraction digits, en-US thousands separators, `"1.23 XLM"` suffix, leading `-` for negatives; no currency conversion)

**Call sites migrated from `utils.formatAmount` (raw number) to the formatters module:**
- `app/stats/page.tsx` — deleted the local `xlm()` duplicate, now uses `formatAmount`
- `app/dashboard/page.tsx` — inline `parseFloat(x).toFixed(2)` → `formatUnits(xlmBalance)`
- `app/portfolio/page.tsx` — offer amount / earned-to-date / repaid / remaining now carry the currency suffix via `formatAmount(stroops, currency)`
- `components/auth/WalletButton.tsx` — balance uses `formatUnits`
- `components/invoices/InvoiceCard.tsx`, `components/marketplace/MarketplaceCard.tsx`, `SuggestedMatches.tsx`, `app/invoices/[id]/page.tsx`, `InvoicePrintView.tsx`, `components/invoices/OfferList.tsx` — all amount displays now pass the currency through the shared helper

**Deliberately untouched (raw-number storage/input paths):**
- `utils.formatAmount` stays as-is: `OfferList` writes `amount_repaid` to the supabase mirror as a human-decimal string, and `ListPositionForm` seeds the token-amount input — both need the currency-less number, not display text.

**Tests** (`lib/formatters.test.ts`):
- `formatAmount` — added negative-input coverage (number, bigint, string) for XLM and USDC
- `formatUnits` — new coverage: units input, zero, negative
- `formatCurrencyPair` — new coverage: XLM/USDC, zero, negative

Closes #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent currency-aware formatting across balances, invoices, marketplace listings, portfolio views, and statistics.
  * Improved display of amounts in different currencies, including standard two-decimal formatting and currency labels.
  * Added clearer formatting for wallet balances and currency pairs.

* **Bug Fixes**
  * Removed inconsistent manual currency suffixes and corrected amount displays across the application.

* **Tests**
  * Expanded formatter coverage for negative values, zero values, multiple input types, and currency-specific formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->