### PR TITLE
feat(frontend): show wallet network mismatch warning in WalletSelectDialog (Closes #137)

### DIFF
--- a/apps/frontend/src/components/auth/WalletSelectDialog.tsx
+++ b/apps/frontend/src/components/auth/WalletSelectDialog.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Check, ExternalLink, Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { APPROVED_WALLETS, WALLET_IDS } from '@/lib/approved-wallets';
+import { checkWalletNetwork } from '@/lib/walletkit';
+import { networkLabel } from '@/lib/network';
+
+interface WalletSelectDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (walletId: string) => void;
+  connecting: boolean;
+}
+
+interface WalletOption {
+  id: string;
+  name: string;
+  description: string;
+  installUrl: string;
+  installed: boolean | null;
+  logo: React.ReactNode;
+  /** Detected wallet network string (e.g. 'PUBLIC', 'TESTNET'), or null when
+   *  the wallet does not expose its network or the check hasn't run yet. */
+  network: string | null;
+  /** Whether the wallet's network mismatches the app's configured network.
+   *  null = not yet checked or wallet does not expose its network. */
+  mismatch: boolean | null;
+}
+
+const FreighterLogo = () => (
+  <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm shrink-0">
+    F
+  </div>
+);
+
+const LobstrLogo = () => (
+  <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-400 to-cyan-500 flex items-center justify-center text-white font-bold text-sm shrink-0">
+    L
+  </div>
+);
+
+const LOGOS: Record<string, React.ReactNode> = {
+  [WALLET_IDS.freighter]: <FreighterLogo />,
+  [WALLET_IDS.lobstr]: <LobstrLogo />,
+};
+
+export function WalletSelectDialog({
+  open,
+  onClose,
+  onSelect,
+  connecting,
+}: WalletSelectDialogProps) {
+  // The list is driven entirely by the approved-wallets allowlist, so a newly
+  // approved wallet appears here automatically.
+  const [wallets, setWallets] = useState<WalletOption[]>(() =>
+    APPROVED_WALLETS.map(w => ({
+      id: w.id,
+      name: w.name,
+      description: w.description,
+      installUrl: w.installUrl,
+      installed: null,
+      logo: LOGOS[w.id] ?? null,
+      network: null,
+      mismatch: null,
+    })),
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    APPROVED_WALLETS.forEach(w => {
+      w.isInstalled().then(installed => {
+        setWallets(prev =>
+          prev.map(o => (o.id === w.id ? { ...o, installed } : o)),
+        );
+        if (installed) {
+          checkWalletNetwork(w.id).then(({ network, mismatch }) => {
+            setWallets(prev =>
+              prev.map(o => (o.id === w.id ? { ...o, network, mismatch } : o)),
+            );
+          });
+        }
+      });
+    });
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Connect Wallet</DialogTitle>
+          <DialogDescription>
+            Choose a Stellar wallet extension to connect.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3 pt-2">
+          {wallets.map(wallet => {
+            const isReady = wallet.installed === true;
+            const isChecking = wallet.installed === null;
+
+            return (
+              <div
+                key={wallet.id}
+                className="flex items-center gap-4 p-4 rounded-xl border border-border bg-card"
+              >
+                {wallet.logo}
+
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold text-card-foreground text-sm">{wallet.name}</p>
+                  <p className="text-xs text-muted-foreground">{wallet.description}</p>
+
+                  {/* Network status line — shown when the wallet is installed
+                      and its network is detectable (Freighter only today). */}
+                  {wallet.installed === true && wallet.mismatch !== null && (
+                    wallet.mismatch ? (
+                      <p className="flex items-center gap-1 text-xs text-amber-600 mt-0.5">
+                        <AlertTriangle className="h-3 w-3 shrink-0" />
+                        Network mismatch: {wallet.network ? networkLabel(wallet.network) : 'unknown'} — switch your wallet&apos;s network to continue.
+                      </p>
+                    ) : (
+                      <p className="flex items-center gap-1 text-xs text-emerald-600 mt-0.5">
+                        <Check className="h-3 w-3 shrink-0" />
+                        Network: {wallet.network ? networkLabel(wallet.network) : 'connected'}
+                      </p>
+                    )
+                  )}
+
+                  {wallet.installed === false && (
+                    <a
+                      href={wallet.installUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center gap-1 text-xs text-blue-500 hover:underline mt-0.5"
+                    >
+                      Install extension <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
+                </div>
+
+                {isChecking ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />
+                ) : isReady ? (
+                  <Button
+                    size="sm"
+                    disabled={connecting}
+                    onClick={() => onSelect(wallet.id)}
+                  >
+                    {connecting ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      'Connect'
+                    )}
+                  </Button>
+                ) : (
+                  <Button size="sm" variant="outline" disabled className="opacity-50">
+                    Not found
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="text-xs text-muted-foreground text-center pt-1">
+          Approved wallets connect via their browser extensions.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/lib/network.test.ts
+++ b/apps/frontend/src/lib/network.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// EXPECTED_NETWORK is computed at module load, so each test block that changes
+// the env must reset module state and re-import dynamically.
+async function loadNetwork() {
+  vi.resetModules();
+  return await import('./network');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('networkMismatchFor', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_STELLAR_NETWORK', 'testnet');
+  });
+
+  it('returns false for null (wallet does not expose network)', async () => {
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor(null)).toBe(false);
+  });
+
+  it('returns false when wallet matches testnet', async () => {
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor('TESTNET')).toBe(false);
+  });
+
+  it('returns true when wallet is on mainnet but app expects testnet', async () => {
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor('PUBLIC')).toBe(true);
+  });
+
+  it('handles mixed case input', async () => {
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor('public')).toBe(true);
+    expect(networkMismatchFor('testnet')).toBe(false);
+  });
+
+  it('returns true for mainnet passphrase when app expects testnet', async () => {
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor('Public Global Stellar Network ; September 2015')).toBe(true);
+  });
+
+  it('returns false for testnet passphrase when app expects testnet', async () => {
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor('Test SDF Network ; September 2015')).toBe(false);
+  });
+
+  it('respects app configured mainnet', async () => {
+    vi.stubEnv('NEXT_PUBLIC_STELLAR_NETWORK', 'mainnet');
+    const { networkMismatchFor } = await loadNetwork();
+    expect(networkMismatchFor('TESTNET')).toBe(true);
+    expect(networkMismatchFor('PUBLIC')).toBe(false);
+  });
+});
+
+describe('networkLabel', () => {
+  it('maps PUBLIC to mainnet', async () => {
+    const { networkLabel } = await loadNetwork();
+    expect(networkLabel('PUBLIC')).toBe('mainnet');
+  });
+
+  it('passes through TESTNET', async () => {
+    const { networkLabel } = await loadNetwork();
+    expect(networkLabel('TESTNET')).toBe('testnet');
+  });
+
+  it('normalizes testnet passphrase to testnet', async () => {
+    const { networkLabel } = await loadNetwork();
+    expect(networkLabel('Test SDF Network ; September 2015')).toBe('testnet');
+  });
+});

--- a/apps/frontend/src/lib/network.ts
+++ b/apps/frontend/src/lib/network.ts
@@ -1,0 +1,41 @@
+/**
+ * Expected network derived from the app's configured Stellar network.
+ * NEXT_PUBLIC_* variables are inlined at build time by Next.js.
+ */
+export const EXPECTED_NETWORK = (
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet'
+).toLowerCase();
+
+/**
+ * Normalizes a wallet's detected network string to the short form
+ * ('mainnet' | 'testnet' | lowercased original). Freighter returns
+ * 'PUBLIC' or 'TESTNET' for its built-in networks, or the full
+ * network passphrase for custom networks.
+ */
+function normalizeWalletNetwork(net: string): string {
+  const lower = net.toLowerCase();
+  if (lower === 'public' || lower.includes('public global')) return 'mainnet';
+  if (lower === 'testnet' || lower.includes('test sdf')) return 'testnet';
+  return lower;
+}
+
+/**
+ * Returns true when the wallet's detected network does not match the app's
+ * configured network. Accepts the string returned by probeWalletNetwork
+ * (e.g. 'PUBLIC', 'TESTNET', or a network passphrase).
+ *
+ * @param walletNet - The network string returned by the wallet's API, or null
+ *                    when the wallet does not expose its network.
+ */
+export function networkMismatchFor(walletNet: string | null): boolean {
+  if (!walletNet) return false;
+  return normalizeWalletNetwork(walletNet) !== EXPECTED_NETWORK;
+}
+
+/**
+ * Returns a human-readable label for the wallet's detected network.
+ * Maps 'PUBLIC' → 'mainnet' and 'TESTNET' → 'testnet'.
+ */
+export function networkLabel(walletNet: string): string {
+  return normalizeWalletNetwork(walletNet);
+}

--- a/apps/frontend/src/lib/walletkit.ts
+++ b/apps/frontend/src/lib/walletkit.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { StellarWalletsKit } from '@creit.tech/stellar-wallets-kit';
+import { getNetwork } from '@stellar/freighter-api';
+import { APPROVED_WALLETS, WALLET_IDS } from './approved-wallets';
+import { networkMismatchFor } from './network';
+
+export { WALLET_IDS };
+
+const NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet'
+    ? 'Public Global Stellar Network ; September 2015'
+    : 'Test SDF Network ; September 2015';
+
+let _initialized = false;
+let activeWalletId: string | null = null;
+
+/**
+ * Initializes the kit with exactly the approved wallets. A future third
+ * approved wallet requires editing only `approved-wallets.ts`.
+ */
+export function initWalletKit(): void {
+  if (typeof window === 'undefined' || _initialized) return;
+  StellarWalletsKit.init({
+    modules: APPROVED_WALLETS.map(w => new w.module()),
+  });
+  _initialized = true;
+}
+
+/** Records which approved wallet is currently connected. */
+export function setActiveWallet(id: string | null): void {
+  activeWalletId = id;
+}
+
+/**
+ * Signs a transaction with the currently connected wallet via the kit, so
+ * signing works identically regardless of which approved wallet connected.
+ */
+export async function signTransactionWithActiveWallet(
+  txXdr: string,
+  networkPassphrase: string,
+): Promise<string> {
+  if (!activeWalletId) {
+    throw new Error('No wallet connected — connect a wallet to sign transactions.');
+  }
+  StellarWalletsKit.setWallet(activeWalletId);
+  const result = await StellarWalletsKit.signTransaction(txXdr, { networkPassphrase });
+  if (!result.signedTxXdr) {
+    throw new Error('Wallet did not return a signed transaction.');
+  }
+  return result.signedTxXdr;
+}
+
+/**
+ * Probes the connected wallet's network so the UI can warn on a mismatch.
+ * Only Freighter exposes its network today; other wallets report null.
+ */
+export async function probeWalletNetwork(walletId: string): Promise<string | null> {
+  if (walletId !== WALLET_IDS.freighter) return null;
+  try {
+    const result = await getNetwork();
+    if ('error' in result && result.error) return null;
+    return (result as { network: string }).network ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks the connected wallet's network against the app's configured network
+ * (NEXT_PUBLIC_STELLAR_NETWORK). Wallets that do not expose their network
+ * report mismatch: false so the UI stays quiet for them.
+ */
+export async function checkWalletNetwork(walletId: string): Promise<{
+  network: string | null;
+  mismatch: boolean;
+}> {
+  const walletNet = await probeWalletNetwork(walletId);
+  return {
+    network: walletNet,
+    mismatch: networkMismatchFor(walletNet),
+  };
+}
+
+export { StellarWalletsKit, NETWORK_PASSPHRASE };


### PR DESCRIPTION
## Description

Shows the detected Stellar network for each installed wallet in the wallet select dialog, and warns when it does not match the app's configured network (`NEXT_PUBLIC_STELLAR_NETWORK`).

- **Wallet network detected**: Freighter exposes its network via `@stellar/freighter-api` → shows a green confirmation when matching, or an amber warning with a hint to switch when mismatched.
- **No detection possible**: LOBSTR does not expose its network through the kit → no network status shown (quiet fallback).

## Changes

| File | Change |
|:---|:---|
| `src/lib/network.ts` | **New** — shared `EXPECTED_NETWORK`, `networkMismatchFor()`, `networkLabel()` helpers |
| `src/lib/network.test.ts` | **New** — 10 tests covering mismatch detection and label normalization |
| `src/lib/walletkit.ts` | Add `checkWalletNetwork()` export |
| `src/components/auth/WalletSelectDialog.tsx` | Show network status per wallet card |

## Acceptance

- [x] A wallet on the wrong network shows a visible warning in the dialog.
- [x] Matching network shows a subtle confirmation.
- [x] No multi-network switching added — warn only.

Closes #137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a wallet selection dialog showing installed and unavailable wallets.
  - Added wallet installation links, connection actions, loading states, and connection status.
  - Added network compatibility checks with clear mismatch messaging.
  - Added Stellar wallet connection and transaction-signing support.
  - Added normalized network labels for clearer display.

- **Tests**
  - Added coverage for network detection, labeling, and mismatch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->