### PR TITLE
feat(frontend): live wallet account-change detection on account switch (Closes #111)

### DIFF
--- a/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react';
 import { signOut as supabaseSignOut, signInWithWallet } from '@/lib/supabase';
 import {
   StellarWalletsKit,
   initWalletKit,
   setActiveWallet,
   probeWalletNetwork,
+  subscribeToWalletEvents,
 } from '@/lib/walletkit';
 import { APPROVED_WALLETS } from '@/lib/approved-wallets';
 import { isMockMode } from '@/lib/mock-mode';
@@ -45,9 +46,21 @@ const EXPECTED_NETWORK = (
 // reachable without a browser extension or testnet access.
 const MOCK_MODE = isMockMode();
 
+/**
+ * Normalises a wallet network value (name or passphrase) to the app's
+ * internal label so it can be compared with `EXPECTED_NETWORK`.
+ */
+function normaliseNetwork(walletNet: string | null): string | null {
+  if (!walletNet) return null;
+  const n = walletNet.toLowerCase();
+  if (n === 'public' || n.includes('public global')) return 'mainnet';
+  if (n === 'testnet' || (n.includes('test sdf') && n.includes('network'))) return 'testnet';
+  return n;
+}
+
 function networkMismatchFor(walletNet: string | null): boolean {
-  if (!walletNet) return false;
-  const n = walletNet.toLowerCase() === 'public' ? 'mainnet' : walletNet.toLowerCase();
+  const n = normaliseNetwork(walletNet);
+  if (!n) return false;
   return n !== EXPECTED_NETWORK;
 }
 
@@ -78,6 +91,12 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
           networkMismatch: false,
         },
   );
+
+  // Always-current view of wallet state for event-listener closures (the kit's
+  // STATE_UPDATE callback must read the latest walletId/publicKey without
+  // re-subscribing on every state change).
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   /**
    * Attempts to restore a previously-granted wallet session (Freighter returns
@@ -112,10 +131,63 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  const disconnect = useCallback(() => {
+    // The demo stays connected — there is no real wallet to disconnect.
+    if (MOCK_MODE) return;
+    setActiveWallet(null);
+    setState(s => ({
+      ...s,
+      publicKey: null,
+      walletId: null,
+      isConnected: false,
+      isConnecting: false,
+      networkMismatch: false,
+    }));
+    // Clear the persisted last-wallet hint so a page refresh won't
+    // silently re-connect (issue #172).
+    clearLastWallet();
+    // Sign out of Supabase so protected routes redirect to login.
+    supabaseSignOut().catch(() => { });
+  }, []);
+
   useEffect(() => {
     if (MOCK_MODE) return;
 
     initWalletKit();
+
+    // Listen for wallet account switches and disconnects that happen inside
+    // the browser extension while the app is open (issue #111). Without this,
+    // the cached address goes stale until a manual page reload.
+    const unsubscribe = subscribeToWalletEvents(
+      (address, networkPassphrase) => {
+        const current = stateRef.current;
+        // Ignore events fired before a wallet is connected (kit emits an
+        // initial STATE_UPDATE with an undefined address) and dedupe events
+        // for the address we already show.
+        if (current.walletId === null || current.publicKey === address) return;
+
+        setActiveWallet(current.walletId);
+        setState({
+          publicKey: address,
+          walletId: current.walletId,
+          isConnected: true,
+          isConnecting: false,
+          isInstalled: true,
+          networkMismatch: networkMismatchFor(normaliseNetwork(networkPassphrase)),
+        });
+        // Refresh the persisted last-wallet hint so a page reload lands on
+        // the newly selected account (issue #172/#187 contract).
+        persistLastWallet(current.walletId, address);
+        // Refresh the Supabase session so protected routes and contract reads
+        // stay attached to the switched account.
+        signInWithWallet(address).catch(() => { });
+      },
+      () => {
+        // Wallet disconnected from the extension side — fall back to the
+        // same teardown path the UI's Disconnect button uses.
+        disconnect();
+      },
+    );
 
     (async () => {
       const installed = new Set<string>();
@@ -147,7 +219,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
       setIsCheckingWallet(false);
     })();
-  }, [tryRestoreWallet]);
+
+    return unsubscribe;
+  }, [tryRestoreWallet, disconnect]);
 
   const connect = useCallback(async (walletId: string): Promise<string> => {
     if (MOCK_MODE) return MOCK_WALLET_ADDRESS;
@@ -177,25 +251,6 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       setState(s => ({ ...s, isConnecting: false }));
       throw err;
     }
-  }, []);
-
-  const disconnect = useCallback(() => {
-    // The demo stays connected — there is no real wallet to disconnect.
-    if (MOCK_MODE) return;
-    setActiveWallet(null);
-    setState(s => ({
-      ...s,
-      publicKey: null,
-      walletId: null,
-      isConnected: false,
-      isConnecting: false,
-      networkMismatch: false,
-    }));
-    // Clear the persisted last-wallet hint so a page refresh won't
-    // silently re-connect (issue #172).
-    clearLastWallet();
-    // Sign out of Supabase so protected routes redirect to login.
-    supabaseSignOut().catch(() => { });
   }, []);
 
   return (

--- a/invofi/apps/frontend/src/lib/walletkit.ts
+++ b/invofi/apps/frontend/src/lib/walletkit.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { StellarWalletsKit } from '@creit.tech/stellar-wallets-kit';
+import { StellarWalletsKit, KitEventType } from '@creit.tech/stellar-wallets-kit';
+import type { KitEventStateUpdated } from '@creit.tech/stellar-wallets-kit';
 import { getNetwork } from '@stellar/freighter-api';
 import { APPROVED_WALLETS, WALLET_IDS } from './approved-wallets';
 
@@ -66,3 +67,35 @@ export async function probeWalletNetwork(walletId: string): Promise<string | nul
 }
 
 export { StellarWalletsKit, NETWORK_PASSPHRASE };
+
+/**
+ * Subscribes to wallet account-change and disconnect events emitted by the
+ * StellarWalletsKit so the app can react without a manual page reload.
+ *
+ * Returns a cleanup function that unsubscribes both listeners.
+ * Usage: call after `initWalletKit()` (e.g. in WalletProvider's useEffect).
+ */
+export function subscribeToWalletEvents(
+  onAddressChange: (address: string, networkPassphrase: string) => void,
+  onDisconnect: () => void,
+): () => void {
+  const unsubState = StellarWalletsKit.on(
+    KitEventType.STATE_UPDATED,
+    (event) => {
+      const { address } = (event as KitEventStateUpdated).payload;
+      if (address) {
+        onAddressChange(address, (event as KitEventStateUpdated).payload.networkPassphrase);
+      }
+    },
+  );
+  const unsubDisconnect = StellarWalletsKit.on(
+    KitEventType.DISCONNECT,
+    () => {
+      onDisconnect();
+    },
+  );
+  return () => {
+    unsubState();
+    unsubDisconnect();
+  };
+}


### PR DESCRIPTION
## Summary

Closes #111 — wallet switch-account and disconnect UX polish.

When the user switches accounts inside Freighter/LOBSTR while the app is open, the cached address and any derived contract reads go stale until a manual page reload. This PR makes the UI react to in-extension account switches and disconnects without reloading.

### Changes

- **`src/lib/walletkit.ts`** — adds `subscribeToWalletEvents(onAddressChange, onDisconnect)` which wires up the StellarWalletsKit's `STATE_UPDATED` (account/network change) and `DISCONNECT` events and returns a cleanup function.
- **`src/components/auth/WalletProvider.tsx`** — calls `subscribeToWalletEvents` after `initWalletKit()`:
  - On account switch: refreshes `publicKey`, network-mismatch badge, the persisted last-wallet hint, and the Supabase session.
  - On extension-side disconnect: falls back to the same teardown path the UI's Disconnect button uses.
  - `normaliseNetwork()` now understands Stellar network passphrases (e.g. `Test SDF Network ; September 2015`) in addition to the short-form names, so mismatch detection works with the kit's `networkPassphrase` payload.

### Acceptance criteria

- ✅ Switching accounts in Freighter/LOBSTR updates the UI without a manual reload.
- ✅ Disconnect clears wallet state and returns the wallet button to its idle state (existing behavior preserved, now also triggered by the kit's DISCONNECT event).

### Tests

- `tsc --noEmit` clean (only pre-existing `MarketplaceSearch.test.tsx` `user-event` missing-dep error remains, unrelated).
- `eslint` clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet account changes now update the active session and saved wallet information.
  * Wallet disconnects are handled consistently, including disconnects initiated by wallet extensions.
  * Improved recognition of Stellar mainnet and testnet networks.
  * Added cleanup for wallet event subscriptions to prevent stale connection updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->