### PR TITLE
feat(frontend): add optimistic UI for create_offer and accept_offer

### DIFF
--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -48,6 +48,8 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
   const [showForm, setShowForm] = useState(false);
   const [loading, setLoading] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
+  /** IDs of offers currently being submitted/accepted on-chain (optimistic UI). */
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
   const [confirmTarget, setConfirmTarget] = useState<
     { offer: FinancingOffer; kind: 'reject' | 'reclaim' } | null
   >(null);
@@ -81,8 +83,29 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
     if (!publicKey) return;
     setLoading(true);
     const offerId = generateOfferId();
+    const durationSecs = values.durationDays * 86_400;
+
+    // Optimistic: add the offer to local state immediately so the UI reflects
+    // the pending offer while the on-chain transaction confirms.
+    const optimisticOffer: FinancingOffer & { pending?: boolean } = {
+      id: offerId,
+      invoice_id: invoiceId,
+      lender: publicKey,
+      amount: amountToStroops(values.amount),
+      currency: values.currency as Currency,
+      interest_rate: values.interestRate,
+      duration: durationSecs,
+      amount_repaid: 0n,
+      status: 'Pending',
+      funded_at: 0,
+      pending: true,
+    };
+    setOffers(prev => [optimisticOffer, ...prev]);
+    setPendingIds(prev => new Set(prev).add(offerId));
+    reset();
+    setShowForm(false);
+
     try {
-      const durationSecs = values.durationDays * 86_400;
       const offer = await createOffer(
         {
           offerId,
@@ -103,13 +126,19 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
           status: 'Pending', funded_at: 0,
         });
       }
-      setOffers(prev => [offer, ...prev]);
-      reset();
-      setShowForm(false);
+      // Replace the optimistic offer with the real one from the contract.
+      setOffers(prev => prev.map(o => o.id === offerId ? offer : o));
       toast({ title: 'Offer submitted!', description: 'The invoice originator will be notified.' });
     } catch (err: unknown) {
+      // Rollback: remove the optimistic offer on failure.
+      setOffers(prev => prev.filter(o => o.id !== offerId));
       toast({ title: 'Failed to submit offer', description: toErrorMessage(err, 'Error'), variant: 'destructive' });
     } finally {
+      setPendingIds(prev => {
+        const next = new Set(prev);
+        next.delete(offerId);
+        return next;
+      });
       setLoading(false);
     }
   };
@@ -117,8 +146,18 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
   const handleAccept = async (offer: FinancingOffer) => {
     if (!publicKey) return;
     setActionId(offer.id);
+    setPendingIds(prev => new Set(prev).add(offer.id));
+
+    // Optimistic: immediately flip the offer and invoice to their expected
+    // post-acceptance states so the UI reflects the action instantly.
+    const previousOfferStatus = offer.status;
+    const previousInvoiceStatus = invoice.status;
+    setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: 'Accepted' as const } : o));
+    onUpdate({ ...invoice, status: 'Financed' as const });
+
     try {
       const updatedOffer = await acceptOffer(offer.id, publicKey);
+      // Reconcile with the authoritative on-chain response.
       setOffers(prev => prev.map(o => o.id === offer.id ? updatedOffer : o));
       await supabase.from('financing_offers').update({ status: 'Accepted', funded_at: Math.floor(Date.now() / 1000) }).eq('id', offer.id);
       const updatedInvoice = { ...invoice, status: 'Financed' as const };
@@ -126,8 +165,16 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
       onUpdate(updatedInvoice);
       toast({ title: 'Offer accepted!', description: 'Invoice is now marked as Financed.' });
     } catch (err: unknown) {
+      // Rollback: revert to the previous states on failure.
+      setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: previousOfferStatus } : o));
+      onUpdate({ ...invoice, status: previousInvoiceStatus });
       toast({ title: 'Failed to accept offer', description: toErrorMessage(err, 'Error'), variant: 'destructive' });
     } finally {
+      setPendingIds(prev => {
+        const next = new Set(prev);
+        next.delete(offer.id);
+        return next;
+      });
       setActionId(null);
     }
   };
@@ -368,7 +415,7 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
           const repaid = toStroopsBigInt(offer.amount_repaid);
           const remaining = totalDue(offer) - repaid;
           return (
-          <div key={offer.id} className="flex items-center justify-between border rounded-lg p-3">
+          <div key={offer.id} className={`flex items-center justify-between border rounded-lg p-3 ${pendingIds.has(offer.id) ? 'opacity-60' : ''}`}>
             <div>
               <p className="text-sm font-mono text-gray-600">{formatAddress(offer.lender)}</p>
               <p className="text-xs text-gray-400 mt-0.5">
@@ -384,7 +431,10 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
               )}
             </div>
             <div className="flex items-center gap-2">
-              <Badge className={OFFER_STATUS_COLORS[offer.status]}>{offer.status}</Badge>
+              <Badge className={pendingIds.has(offer.id) ? 'bg-amber-100 text-amber-800 border-amber-200 animate-pulse' : OFFER_STATUS_COLORS[offer.status]}>
+                {pendingIds.has(offer.id) && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                {offer.status}
+              </Badge>
               {isOriginator && offer.status === 'Pending' && (
                 <>
                   <Button

--- a/invofi/apps/frontend/src/components/invoices/__tests__/OfferList.optimistic.test.tsx
+++ b/invofi/apps/frontend/src/components/invoices/__tests__/OfferList.optimistic.test.tsx
@@ -1,0 +1,441 @@
+import { useState } from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OfferList } from '../OfferList';
+import type { FinancingOffer, Invoice } from '@/types';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockToast = vi.fn();
+const mockCreateOffer = vi.fn();
+const mockAcceptOffer = vi.fn();
+const mockSupabaseInsert = vi.fn();
+const mockSupabaseUpdate = vi.fn();
+const mockSupabaseSelect = vi.fn();
+const mockGetUser = vi.fn();
+
+const WALLET_ADDRESS = 'GBPLP3Y6J6KQZ3X7Y6J6KQZ3X7Y6J6KQZ3X7Y6J6KQZ3X7Y';
+
+vi.mock('@/components/auth/WalletProvider', () => ({
+  useWallet: () => ({
+    publicKey: WALLET_ADDRESS,
+  }),
+}));
+
+vi.mock('@/lib/contract', () => ({
+  createOffer: (...args: unknown[]) => mockCreateOffer(...args),
+  acceptOffer: (...args: unknown[]) => mockAcceptOffer(...args),
+  rejectOffer: vi.fn(),
+  repayInvoice: vi.fn(),
+  markOverdue: vi.fn(),
+  reclaimInvoice: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => {
+  const fromFn = (table: string) => {
+    if (table === 'financing_offers') {
+      return {
+        select: () => ({
+          eq: () => ({
+            order: () => mockSupabaseSelect(),
+          }),
+        }),
+        insert: () => mockSupabaseInsert(),
+        update: () => ({
+          eq: () => mockSupabaseUpdate(),
+        }),
+      };
+    }
+    // For 'invoices' table
+    return {
+      select: () => ({
+        eq: () => ({
+          order: () => mockSupabaseSelect(),
+        }),
+      }),
+      insert: () => mockSupabaseInsert(),
+      update: () => ({
+        eq: () => mockSupabaseUpdate(),
+      }),
+    };
+  };
+  return {
+    supabase: {
+      from: vi.fn(fromFn),
+      auth: {
+        getUser: vi.fn(() => mockGetUser()),
+      },
+    },
+  };
+});
+
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: 'INV-001',
+    originator: WALLET_ADDRESS, // matches wallet so isOriginator = true
+    amount: 10000000000n,
+    currency: 'USDC',
+    status: 'Pending',
+    due_date: Math.floor(Date.now() / 1000) + 86400 * 30,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as Invoice;
+}
+
+function makeOffer(overrides: Partial<FinancingOffer> = {}): FinancingOffer {
+  return {
+    id: 'off_existing123',
+    invoice_id: 'INV-001',
+    lender: 'GBPLP3Y6J6KQZ3X7Y6J6KQZ3X7Y6J6KQZ3X7Y6J6KQZ3X7Y',
+    amount: 5000000000n,
+    currency: 'USDC',
+    interest_rate: 500,
+    duration: 2592000,
+    amount_repaid: 0n,
+    status: 'Pending',
+    funded_at: 0,
+    ...overrides,
+  } as FinancingOffer;
+}
+
+function makeAcceptedOffer(overrides: Partial<FinancingOffer> = {}): FinancingOffer {
+  return makeOffer({ ...overrides, status: 'Accepted', funded_at: Math.floor(Date.now() / 1000) });
+}
+
+interface WrapperProps {
+  initialInvoice?: Invoice;
+}
+
+function OfferListWrapper({ initialInvoice }: WrapperProps) {
+  const [invoice, setInvoice] = useState(initialInvoice ?? makeInvoice());
+  return (
+    <OfferList
+      invoiceId={invoice.id}
+      invoice={invoice}
+      onUpdate={setInvoice}
+    />
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('OfferList — optimistic UI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabaseSelect.mockResolvedValue({ data: [] });
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    mockSupabaseInsert.mockResolvedValue({ error: null });
+    mockSupabaseUpdate.mockResolvedValue({ error: null });
+  });
+
+  // ── Optimistic create offer ─────────────────────────────────────────────────
+
+  describe('optimistic create offer', () => {
+    it('adds the offer to the list immediately on submit (before contract resolves)', async () => {
+      // The contract call never resolves — we check that the offer is visible
+      // while it's still pending.
+      let resolveCreateOffer: (value: FinancingOffer) => void;
+      mockCreateOffer.mockImplementation(
+        () => new Promise(resolve => { resolveCreateOffer = resolve; }),
+      );
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Pending', originator: 'GCSOMEONEELSEADDRESS123456789012345678' })} />);
+
+      // Wait for initial load (empty)
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(0\)/)).toBeInTheDocument();
+      });
+
+      // Open form, fill, and submit via fireEvent (bypasses react-hook-form input registration)
+      fireEvent.click(screen.getByRole('button', { name: /make offer/i }));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '1000' } });
+      fireEvent.change(screen.getByLabelText(/interest/i), { target: { value: '500' } });
+      fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30' } });
+      fireEvent.click(screen.getByRole('button', { name: /submit offer/i }));
+
+      // The optimistic offer should appear immediately
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      // A pulsing "Pending" badge should be visible
+      const pendingBadges = screen.getAllByText('Pending');
+      expect(pendingBadges.length).toBeGreaterThanOrEqual(1);
+
+      // Now resolve the contract call
+      resolveCreateOffer!(makeOffer({ id: 'off_real123', status: 'Pending' }));
+
+      // After reconciliation, the real offer should replace the optimistic one
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Offer submitted!' }),
+        );
+      });
+    });
+
+    it('removes the optimistic offer from the list on contract failure', async () => {
+      mockCreateOffer.mockRejectedValue(new Error('Contract call failed'));
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Pending', originator: 'GCSOMEONEELSEADDRESS123456789012345678' })} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(0\)/)).toBeInTheDocument();
+      });
+
+      // Open form, fill, and submit
+      fireEvent.click(screen.getByRole('button', { name: /make offer/i }));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '500' } });
+      fireEvent.change(screen.getByLabelText(/interest/i), { target: { value: '300' } });
+      fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '15' } });
+      fireEvent.click(screen.getByRole('button', { name: /submit offer/i }));
+
+      // Wait for the error toast
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to submit offer',
+            variant: 'destructive',
+          }),
+        );
+      });
+
+      // The offer should be rolled back — count back to 0
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(0\)/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows the pulsing pending badge with opacity on the card while in flight', async () => {
+      mockCreateOffer.mockImplementation(() => new Promise(() => {})); // never resolves
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Pending', originator: 'GCSOMEONEELSEADDRESS123456789012345678' })} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(0\)/)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /make offer/i }));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '750' } });
+      fireEvent.change(screen.getByLabelText(/interest/i), { target: { value: '400' } });
+      fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '20' } });
+      fireEvent.click(screen.getByRole('button', { name: /submit offer/i }));
+
+      // The pending badge should have animate-pulse class
+      await waitFor(() => {
+        const pendingBadges = screen.getAllByText('Pending');
+        const pulsing = pendingBadges.find(el =>
+          el.closest('[class*="animate-pulse"]'),
+        );
+        expect(pulsing).toBeDefined();
+      });
+
+      // The card should have opacity-60
+      await waitFor(() => {
+        const cards = document.querySelectorAll('[class*="opacity-60"]');
+        expect(cards.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+
+  // ── Optimistic accept offer ─────────────────────────────────────────────────
+
+  describe('optimistic accept offer', () => {
+    it('immediately flips offer to Accepted and invoice to Financed', async () => {
+      const existingOffer = makeOffer({ id: 'off_to_accept' });
+      mockSupabaseSelect.mockResolvedValue({ data: [existingOffer] });
+
+      let resolveAccept: (value: FinancingOffer) => void;
+      mockAcceptOffer.mockImplementation(
+        () => new Promise(resolve => { resolveAccept = resolve; }),
+      );
+
+      render(<OfferListWrapper />);
+
+      // Wait for offers to load
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      // The Accept button should be visible (originator matches wallet)
+      const acceptBtn = screen.getByRole('button', { name: /accept/i });
+      expect(acceptBtn).toBeInTheDocument();
+
+      // Click Accept
+      fireEvent.click(acceptBtn);
+
+      // Immediately, the badge should show "Accepted"
+      await waitFor(() => {
+        const badges = screen.getAllByText('Accepted');
+        expect(badges.length).toBeGreaterThanOrEqual(1);
+      });
+
+      // Resolve the contract call
+      resolveAccept!(makeAcceptedOffer({ id: 'off_to_accept' }));
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Offer accepted!' }),
+        );
+      });
+    });
+
+    it('rolls back offer to Pending and invoice to original status on failure', async () => {
+      const existingOffer = makeOffer({ id: 'off_rollback' });
+      mockSupabaseSelect.mockResolvedValue({ data: [existingOffer] });
+      mockAcceptOffer.mockRejectedValue(new Error('Accept failed'));
+
+      render(<OfferListWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+
+      // Wait for the error
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to accept offer',
+            variant: 'destructive',
+          }),
+        );
+      });
+
+      // The badge should be rolled back to Pending
+      await waitFor(() => {
+        const badges = screen.getAllByText('Pending');
+        expect(badges.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('shows a pulsing badge while accept is in flight', async () => {
+      const existingOffer = makeOffer({ id: 'off_pending_accept' });
+      mockSupabaseSelect.mockResolvedValue({ data: [existingOffer] });
+      mockAcceptOffer.mockImplementation(() => new Promise(() => {})); // never resolves
+
+      render(<OfferListWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+
+      // The badge should show "Accepted" (optimistic) with animate-pulse
+      await waitFor(() => {
+        const badges = screen.getAllByText('Accepted');
+        const pulsing = badges.find(el =>
+          el.closest('[class*="animate-pulse"]'),
+        );
+        expect(pulsing).toBeDefined();
+      });
+    });
+  });
+
+  // ── Edge cases & negative tests ─────────────────────────────────────────────
+
+  describe('edge cases and negative tests', () => {
+    it('shows a destructive toast with the original error message on create failure', async () => {
+      mockCreateOffer.mockRejectedValue(new Error('Insufficient balance'));
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Pending', originator: 'GCSOMEONEELSEADDRESS123456789012345678' })} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(0\)/)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /make offer/i }));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '2000' } });
+      fireEvent.change(screen.getByLabelText(/interest/i), { target: { value: '500' } });
+      fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30' } });
+      fireEvent.click(screen.getByRole('button', { name: /submit offer/i }));
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to submit offer',
+            variant: 'destructive',
+          }),
+        );
+      });
+    });
+
+    it('shows a destructive toast on accept failure with the error message', async () => {
+      const existingOffer = makeOffer({ id: 'off_err' });
+      mockSupabaseSelect.mockResolvedValue({ data: [existingOffer] });
+      mockAcceptOffer.mockRejectedValue(new Error('offer already accepted'));
+
+      render(<OfferListWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to accept offer',
+            variant: 'destructive',
+          }),
+        );
+      });
+    });
+
+    it('does not show Accept button when user is not the originator', async () => {
+      const otherWalletInvoice = makeInvoice({
+        status: 'Pending',
+        originator: 'GCSOMEONEELSEADDRESS123456789012345678',
+      });
+      const offer = makeOffer({ id: 'off_no_accept' });
+      mockSupabaseSelect.mockResolvedValue({ data: [offer] });
+
+      render(<OfferListWrapper initialInvoice={otherWalletInvoice} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      // No Accept button should be visible
+      expect(screen.queryByRole('button', { name: /accept/i })).not.toBeInTheDocument();
+    });
+
+    it('reconciles the optimistic offer with the real one on successful create', async () => {
+      const realOffer = makeOffer({ id: 'off_reconciled' });
+      mockCreateOffer.mockResolvedValue(realOffer);
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Pending', originator: 'GCSOMEONEELSEADDRESS123456789012345678' })} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(0\)/)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /make offer/i }));
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '3000' } });
+      fireEvent.change(screen.getByLabelText(/interest/i), { target: { value: '600' } });
+      fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '45' } });
+      fireEvent.click(screen.getByRole('button', { name: /submit offer/i }));
+
+      // After the contract resolves, the real offer should replace the optimistic one
+      await waitFor(() => {
+        // The card should NOT have opacity-60 (no longer pending)
+        const cards = document.querySelectorAll('[class*="opacity-60"]');
+        expect(cards.length).toBe(0);
+      });
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Offer submitted!' }),
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add optimistic updates to the financing offer create and accept flows in OfferList. State changes are applied instantly with a clear pending indicator, then reconciled from the authoritative on-chain response. On failure, the UI rolls back to the previous state and shows a destructive toast.

Closes #191

## Changes
- `OfferList.tsx`: Added `pendingIds` state to track in-flight offers. Modified `submitOffer` to add the offer to local state immediately (optimistic create), replacing with the real response on success or rolling back on failure. Modified `handleAccept` to flip offer status to Accepted and invoice status to Financed immediately (optimistic accept), rolling back on failure. Added pulsing amber badge with opacity for pending offers.
- `OfferList.optimistic.test.tsx` (new): 10 tests covering happy path, rollback on failure, visual pending indicators, edge cases, and negative cases.

## Testing
- All 10 new tests pass
- 423 existing tests pass (2 pre-existing failures in `offerTerms.test.ts` unrelated to this change)
- Lint passes (pre-existing warnings in `marketplace/page.tsx` unrelated to this change)

## Checklist
- [x] Follows CONTRIBUTING.md conventions (Conventional Commits, test style)
- [x] All acceptance criteria from #191 are met
- [x] Existing tests pass unchanged (2 pre-existing failures not caused by this change)
- [x] New tests cover happy path, named edge cases, and negative cases
- [ ] CI is green (PR created, awaiting CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Offer submissions and acceptances now update the interface immediately for a more responsive experience.
  - Pending operations display clear visual indicators, including updated badges and loading spinners.
  - Changes are automatically confirmed when successful or reverted if an operation fails.
  - Accept controls are shown based on the offer’s originator.

- **Bug Fixes**
  - Added clearer error notifications when offer operations cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->