### PR TITLE
feat(frontend): optimistic UI for repay_invoice (Closes #178)

### DIFF
--- a/invofi/apps/frontend/src/components/invoices/OfferList.tsx
+++ b/invofi/apps/frontend/src/components/invoices/OfferList.tsx
@@ -326,26 +326,52 @@ export function OfferList({ invoiceId, invoice, onUpdate }: OfferListProps) {
         toast({ title: 'Amount must be greater than zero', variant: 'destructive' });
         return;
       }
-      const updatedInvoice = await repayInvoice(invoiceId, offer.id, publicKey, amountStroops);
-      // A repayment that clears the full balance flips the invoice to Repaid;
-      // anything less keeps it Financed (offer → Financed for the remainder).
-      const fullyRepaid = updatedInvoice.status === 'Repaid';
-      const nextOfferStatus: FinancingOffer['status'] = fullyRepaid ? 'Repaid' : 'Financed';
-      const nextInvoiceStatus: Invoice['status'] = fullyRepaid ? 'Repaid' : 'Financed';
-      const newRepaid = toStroopsBigInt(offer.amount_repaid) + amountStroops;
-      setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: nextOfferStatus, amount_repaid: newRepaid } : o));
-      // Mirror stores human-decimal strings (same format as its amount column).
-      await supabase.from('financing_offers').update({ status: nextOfferStatus, amount_repaid: formatUnits(newRepaid) }).eq('id', offer.id);
-      await supabase.from('invoices').update({ status: nextInvoiceStatus }).eq('id', invoiceId);
-      onUpdate(updatedInvoice);
-      toast({
-        title: fullyRepaid ? 'Invoice fully repaid' : 'Repayment sent',
-        description: fullyRepaid
-          ? 'Principal + yield transferred to the lender. The invoice is now Repaid.'
-          : 'Partial repayment recorded on-chain. Continue repaying until the balance clears.',
-      });
-    } catch (err: unknown) {
-      toast({ title: 'Failed to repay', description: toErrorMessage(err, 'Error'), variant: 'destructive' });
+
+      // ── Optimistic (issue #178): apply the expected post-payment state
+      //    immediately so the UI reflects the repayment while the wallet/RPC
+      //    round-trip confirms — no offline queueing, so a failed tx rolls back.
+      const previousOfferStatus = offer.status;
+      const previousInvoiceStatus = invoice.status;
+      const previousRepaid = toStroopsBigInt(offer.amount_repaid);
+      const optimisticRepaid = previousRepaid + amountStroops;
+      const optimisticFullyRepaid = optimisticRepaid >= totalDue(offer);
+      const optimisticOfferStatus: FinancingOffer['status'] = optimisticFullyRepaid ? 'Repaid' : 'Financed';
+      const optimisticInvoiceStatus: Invoice['status'] = optimisticFullyRepaid ? 'Repaid' : 'Financed';
+      setPendingIds(prev => new Set(prev).add(offer.id));
+      setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: optimisticOfferStatus, amount_repaid: optimisticRepaid } : o));
+      onUpdate({ ...invoice, status: optimisticInvoiceStatus });
+
+      try {
+        const updatedInvoice = await repayInvoice(invoiceId, offer.id, publicKey, amountStroops);
+        // A repayment that clears the full balance flips the invoice to Repaid;
+        // anything less keeps it Financed (offer → Financed for the remainder).
+        const fullyRepaid = updatedInvoice.status === 'Repaid';
+        const nextOfferStatus: FinancingOffer['status'] = fullyRepaid ? 'Repaid' : 'Financed';
+        const nextInvoiceStatus: Invoice['status'] = fullyRepaid ? 'Repaid' : 'Financed';
+        const newRepaid = previousRepaid + amountStroops;
+        setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: nextOfferStatus, amount_repaid: newRepaid } : o));
+        // Mirror stores human-decimal strings (same format as its amount column).
+        await supabase.from('financing_offers').update({ status: nextOfferStatus, amount_repaid: formatUnits(newRepaid) }).eq('id', offer.id);
+        await supabase.from('invoices').update({ status: nextInvoiceStatus }).eq('id', invoiceId);
+        onUpdate(updatedInvoice);
+        toast({
+          title: fullyRepaid ? 'Invoice fully repaid' : 'Repayment sent',
+          description: fullyRepaid
+            ? 'Principal + yield transferred to the lender. The invoice is now Repaid.'
+            : 'Partial repayment recorded on-chain. Continue repaying until the balance clears.',
+        });
+      } catch (err: unknown) {
+        // Rollback: revert the optimistic state on failure.
+        setOffers(prev => prev.map(o => o.id === offer.id ? { ...o, status: previousOfferStatus, amount_repaid: previousRepaid } : o));
+        onUpdate({ ...invoice, status: previousInvoiceStatus });
+        toast({ title: 'Failed to repay', description: toErrorMessage(err, 'Error'), variant: 'destructive' });
+      } finally {
+        setPendingIds(prev => {
+          const next = new Set(prev);
+          next.delete(offer.id);
+          return next;
+        });
+      }
     } finally {
       setActionId(null);
     }

--- a/invofi/apps/frontend/src/components/invoices/__tests__/OfferList.optimistic.test.tsx
+++ b/invofi/apps/frontend/src/components/invoices/__tests__/OfferList.optimistic.test.tsx
@@ -9,6 +9,7 @@ import type { FinancingOffer, Invoice } from '@/types';
 const mockToast = vi.fn();
 const mockCreateOffer = vi.fn();
 const mockAcceptOffer = vi.fn();
+const mockRepayInvoice = vi.fn();
 const mockSupabaseInsert = vi.fn();
 const mockSupabaseUpdate = vi.fn();
 const mockSupabaseSelect = vi.fn();
@@ -26,7 +27,7 @@ vi.mock('@/lib/contract', () => ({
   createOffer: (...args: unknown[]) => mockCreateOffer(...args),
   acceptOffer: (...args: unknown[]) => mockAcceptOffer(...args),
   rejectOffer: vi.fn(),
-  repayInvoice: vi.fn(),
+  repayInvoice: (...args: unknown[]) => mockRepayInvoice(...args),
   markOverdue: vi.fn(),
   reclaimInvoice: vi.fn(),
 }));
@@ -368,6 +369,79 @@ describe('OfferList — optimistic UI', () => {
           el.closest('[class*="animate-pulse"]'),
         );
         expect(pulsing).toBeDefined();
+      });
+    });
+  });
+
+  // ── Optimistic repayment (issue #178) ──────────────────────────────────────
+
+  describe('optimistic repayment', () => {
+    /** Fills the repayment amount, opens the preview, and confirms it. */
+    async function repayThroughPreview() {
+      const amountInput = document.querySelector('input[class*="w-28"]') as HTMLInputElement;
+      fireEvent.change(amountInput, { target: { value: '100' } });
+      fireEvent.click(screen.getByRole('button', { name: /^repay$/i }));
+      const confirm = await screen.findByRole('button', { name: /submit repayment/i });
+      await waitFor(() => expect(confirm).toBeEnabled());
+      fireEvent.click(confirm);
+    }
+
+    it('updates the repaid amount and status immediately, before the contract resolves', async () => {
+      // Accepted offer on a Financed invoice — the row shows the Repay control.
+      const existingOffer = makeOffer({ id: 'off_repay', status: 'Financed', funded_at: Math.floor(Date.now() / 1000) });
+      mockSupabaseSelect.mockResolvedValue({ data: [existingOffer] });
+      mockRepayInvoice.mockImplementation(() => new Promise(() => {})); // never resolves
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Financed' })} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      // No "repaid" line yet — amount_repaid is 0n so the row is compact.
+      expect(screen.queryByText(/repaid/i)).not.toBeInTheDocument();
+
+      await repayThroughPreview();
+
+      // The optimistic update should surface immediately: a repaid-amount line,
+      // and the pulsing pending badge on the row.
+      await waitFor(() => {
+        expect(screen.queryAllByText(/repaid/i).length).toBeGreaterThanOrEqual(1);
+      });
+      await waitFor(() => {
+        const badges = screen.getAllByText(/Financed/);
+        const pulsing = badges.find(el => el.closest('[class*="animate-pulse"]'));
+        expect(pulsing).toBeDefined();
+      });
+      expect(screen.queryAllByText(/repaid/i).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('rolls the repayment back and shows a destructive toast on failure', async () => {
+      const existingOffer = makeOffer({ id: 'off_repay_fail', status: 'Financed', funded_at: Math.floor(Date.now() / 1000) });
+      mockSupabaseSelect.mockResolvedValue({ data: [existingOffer] });
+      mockRepayInvoice.mockRejectedValue(new Error('Transaction failed'));
+
+      render(<OfferListWrapper initialInvoice={makeInvoice({ status: 'Financed' })} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Financing Offers \(1\)/)).toBeInTheDocument();
+      });
+
+      await repayThroughPreview();
+
+      // Failure toast.
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to repay',
+            variant: 'destructive',
+          }),
+        );
+      });
+
+      // The repaid line must be gone — the optimistic state rolled back.
+      await waitFor(() => {
+        expect(screen.queryAllByText(/repaid/i).length).toBe(0);
       });
     });
   });


### PR DESCRIPTION
## Description

Implements **optimistic UI for `repay_invoice`** (Issue #178).

`accept_offer` optimistic UI is already covered by PR #310 (closes #191), which explicitly excluded repayment — this PR fills that gap.

### Changes

- **`OfferList.tsx` — `handleRepay`**: applies the expected post-payment state immediately on submit:
  - Optimistically sets the offer status (`Financed` for partial / `Repaid` when the balance clears) and `amount_repaid`
  - Optimistically updates the parent invoice status via `onUpdate`
  - Adds the offer id to `pendingIds`, so the row gets the shared pending indicator (opacity + pulsing amber badge + spinner) while the wallet/RPC round-trip confirms
  - On failure, rolls the offer and invoice back to their previous states and shows a destructive toast
  - No offline queueing — a failed tx reverts cleanly (double-submit protection retained via `actionId`)

- **`OfferList.optimistic.test.tsx`**: two new tests:
  1. Optimistic repayment updates the repaid-amount line and pending badge before the contract resolves
  2. Failed repayment rolls the state back and shows a destructive toast

### Acceptance criteria
- [x] Repaying updates the UI instantly, then reconciles on confirmation
- [x] Failed/declined tx rolls state back cleanly
- [x] Double-submit protection retained

### Verification
- `NODE_ENV=test npx vitest run` → 49 files / 459 tests pass
- `npx tsc --noEmit` → clean

Closes #178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repayment actions now update offer and invoice status immediately while the transaction is pending.
  * Pending repayments are clearly tracked to prevent inconsistent interactions.

* **Bug Fixes**
  * If repayment fails, the interface restores the previous status and repaid amount.
  * Failed repayments now display a clear error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->