### PR TITLE
feat(sdk): add typed send() envelope wrapper with InvofiError (Closes #188)

### DIFF
--- a/invofi/apps/sdk/README.md
+++ b/invofi/apps/sdk/README.md
@@ -121,6 +121,62 @@ component built against `client.contracts.*` works unchanged in offline demo
 mode. See the header comment in `src/types/contract-abi.ts` for how to
 regenerate the ABI after a contract build.
 
+## Typed error envelope — `client.send()` (#188)
+
+`client.send()` is a single-call convenience over the contract-invocation
+path that returns a **typed result envelope** instead of throwing. Decoded
+contract failures (auth, insufficient balance, paused, not-found, …) surface
+as `{ ok: false, error }` where `error` is an `InvofiError` — a
+`ContractError` carrying a machine-readable `errorType`/`rawCode`, a
+human-readable `message`, and an optional `recovery`. This lets UI layers
+render a toast and branch on the typed variant without a try/catch or
+regex-matching raw Soroban error text. Network/validation failures are still
+thrown (they are not decoded domain errors).
+
+```ts
+import { createInvofiClient, scValToNative, Networks } from '@invofi/sdk';
+
+const client = createInvofiClient(cfg);
+
+const result = await client.send(
+  { contractId: cfg.financingId, method: 'accept_offer', args: [scValToScvSymbol(offerId)] },
+  originatorAddress,
+  scValToNative, // optional decode of the return ScVal
+);
+
+if (result.ok) {
+  // result.value — decoded return
+} else {
+  // result.error.errorType  → 'UNAUTHORIZED' | 'NOT_FOUND' | 'PAUSED' | …
+  // result.error.message    → human-readable, safe to surface in a toast
+  // result.error.recovery   → optional recovery hint
+  toast({ title: 'Could not accept offer', description: result.error.message });
+}
+```
+
+The same envelope contract is implemented by `createMockClient`, so UI code
+written against `send()` is testable offline.
+
+### Contract error mapping table
+
+The SDK decodes the canonical Soroban error discriminants from
+`invofi-contracts` `common/src/errors.rs` (via `parseContractError`). The
+table below documents the mapping; frontends that previously regex-matched
+raw panic strings should branch on `error.errorType` / use `error.message`
+instead. Codes not in this table fall back to `UNKNOWN` with the raw code
+preserved on `error.rawCode`.
+
+| Code | Panic string (examples) | `InvofiError.errorType` | Human message | Recovery |
+|------|--------------------------|--------------------------|---------------|----------|
+| 1 | not authorized / unauthorized | `UNAUTHORIZED` | The calling address is not authorized to perform this action. | Sign with the address that owns/originated this resource. |
+| 2 | invoice not found / does not exist | `NOT_FOUND` | No resource was found with the given ID. | Double-check the ID and that it was created successfully. |
+| 3 | invalid transition | `INVALID_TRANSITION` | This action is not valid for the resource in its current status. | Refresh the resource status and confirm the action still applies. |
+| 4 | contract paused | `PAUSED` | This contract is currently paused and not accepting this action. | Try again later, or check protocol announcements. |
+| 5 | insufficient balance | `INSUFFICIENT_BALANCE` | The account does not have sufficient balance to complete this transaction. | Add funds to your wallet and try again. |
+| 6 | invalid input | `INVALID_INPUT` | One or more input values were invalid. | Check the submitted values and try again. |
+| 7 | already exists | `ALREADY_EXISTS` | A resource with this ID already exists. | Use a different ID, or look up the existing resource. |
+| 8 | blacklisted | `BLACKLISTED` | This address has been blacklisted and cannot perform this action. | Contact support if you believe this is a mistake. |
+
 ## Event stream — `listenToEvents`
 
 `listenToEvents` polls the Stellar Soroban RPC for on-chain protocol events and

--- a/invofi/apps/sdk/src/client.ts
+++ b/invofi/apps/sdk/src/client.ts
@@ -31,7 +31,7 @@ import {
   validateAssetString,
   validateConfigField,
 } from './validation';
-import { parseContractError } from './errors';
+import { parseContractError, ContractError, type InvofiError } from './errors';
 import { createCache, type CacheHandle } from './cache';
 import { createContractsNamespace } from './contracts';
 import { simulateOrThrow, simulateBatchOrThrow, SimulationError } from './simulation';
@@ -44,6 +44,26 @@ export interface BatchCall {
   method: string;
   args: xdr.ScVal[];
 }
+
+/** A single contract call to submit via `client.send()` — same shape as `batch()` entries. */
+export type SendCall = BatchCall;
+
+/**
+ * Typed result envelope returned by `client.send()` (#188).
+ *
+ * On success the decoded return value is carried under `{ ok: true, value }`;
+ * on a decoded contract failure the typed `InvofiError` is carried under
+ * `{ ok: false, error }`. This lets UI layers render a toast straight from
+ * `error.message` (human-readable) and branch on `error.errorType`
+ * (machine-readable) without a try/catch or regex-matching raw Soroban text.
+ *
+ * Network/validation failures are still thrown (they are not contract errors),
+ * so callers know a rejection is a transport/config problem, not a decoded
+ * domain failure.
+ */
+export type SendEnvelope<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: InvofiError };
 
 /**
  * The flat, hand-authored method surface `createInvofiClient` (and
@@ -82,6 +102,7 @@ export interface InvofiClientMethods {
   getTokenDecimals(tokenId: string): Promise<number>;
   transferPositionToken(tokenId: string, fromAddress: string, toAddress: string, amount: bigint): Promise<void>;
   batch(calls: BatchCall[], sourceAddress: string): Promise<xdr.ScVal[]>;
+  send<T = xdr.ScVal>(call: SendCall, sourceAddress: string, decode?: (val: xdr.ScVal) => T): Promise<SendEnvelope<T>>;
   hasPositionTrustline(address: string): Promise<boolean>;
   addPositionTrustline(address: string): Promise<void>;
 }
@@ -733,6 +754,47 @@ export function createInvofiClient(cfg: InvofiClientConfig) {
       }
 
       return collectBatchReturnValues(getResult, calls.length);
+    },
+
+    // ── Typed envelope wrapper (#188) ───────────────────────────────────────
+    // `send()` is a single-call convenience over the contract-invocation path
+    // that returns a typed `SendEnvelope` instead of throwing. Decoded
+    // contract failures (auth, insufficient balance, paused, not-found, …)
+    // surface as `{ ok: false, error: InvofiError }` so UI layers can render a
+    // toast from `error.message` and branch on `error.errorType` without
+    // try/catch or regex-matching raw Soroban text. Network/validation
+    // failures are still thrown — they are not decoded domain errors.
+
+    /**
+     * Submit a single contract call and return a typed result envelope.
+     *
+     * @param call          `{ contractId, method, args }` — one operation.
+     * @param sourceAddress The Stellar account that signs and pays.
+     * @param decode        Optional mapper from the raw `xdr.ScVal` return to
+     *                      a domain value (e.g. `scValToNative`). Defaults to
+     *                      the raw `ScVal`.
+     * @returns `{ ok: true, value }` on success, or
+     *          `{ ok: false, error: InvofiError }` on a decoded contract
+     *          failure. Network/validation failures still reject.
+     */
+    send: async <T = xdr.ScVal>(
+      call: SendCall,
+      sourceAddress: string,
+      decode?: (val: xdr.ScVal) => T,
+    ): Promise<SendEnvelope<T>> => {
+      validateStellarAddress(sourceAddress, 'sourceAddress');
+      try {
+        const val = await invokeContract(call.contractId, call.method, call.args, sourceAddress);
+        return { ok: true, value: decode ? decode(val) : (val as unknown as T) };
+      } catch (err) {
+        // Decoded domain failures go into the envelope; everything else
+        // (validation, transport) keeps rejecting so the caller knows it is
+        // not a decoded contract error.
+        if (err instanceof ContractError) {
+          return { ok: false, error: err };
+        }
+        throw err;
+      }
     },
 
     // ── Position-token trustline support ─────────────────────────────────────

--- a/invofi/apps/sdk/src/errors.ts
+++ b/invofi/apps/sdk/src/errors.ts
@@ -196,6 +196,21 @@ export class ContractError extends SdkError {
   }
 }
 
+// ── Invofi error — domain-facing name for a decoded contract failure (#188) ─
+//
+// `InvofiError` is the public, stable name consumers (frontend toasts,
+// analytics, debugging) use for a *decoded* contract-call failure. It is a
+// `ContractError`, so it carries:
+//   - a machine-readable code: `errorType` (`UNAUTHORIZED`, `NOT_FOUND`,
+//     `PAUSED`, `INSUFFICIENT_BALANCE`, …) plus the raw Soroban `rawCode`;
+//   - a human-readable `message` plus an optional `recovery` suggestion;
+//   - the original failure preserved as `cause`.
+// Branching on `errorType` replaces the regex-matching of raw Soroban error
+// text (#188) — the SDK decodes once, callers branch on the typed variant.
+
+/** A decoded contract-call failure surfaced by `client.send()`. */
+export type InvofiError = ContractError;
+
 // ── Error code extraction & mapping ──────────────────────────────────────────
 
 /**

--- a/invofi/apps/sdk/src/index.ts
+++ b/invofi/apps/sdk/src/index.ts
@@ -12,6 +12,8 @@ export {
   type InvofiClient,
   type InvofiClientMethods,
   type BatchCall,
+  type SendCall,
+  type SendEnvelope,
   SdkValidationError,
   ErrorCode,
 } from './client';
@@ -94,6 +96,7 @@ export {
   CONTRACT_ERROR_MAP,
   parseContractError,
   setErrorReporter,
+  type InvofiError,
   type RecoverySuggestion,
 } from './errors';
 

--- a/invofi/apps/sdk/src/mock.ts
+++ b/invofi/apps/sdk/src/mock.ts
@@ -30,7 +30,7 @@
 //     `./testing.ts` (re-exported from the package root) for composing
 //     custom pre-seeded data.
 
-import type { InvofiClient, InvofiClientMethods } from './client';
+import type { InvofiClient, InvofiClientMethods, SendCall, SendEnvelope } from './client';
 import type { Currency, FinancingOffer, Invoice } from './types';
 import type { CacheEntry, CacheHandle, CacheScope, StaleWhileRevalidateResult } from './cache';
 import { ContractError, ContractErrorType } from './errors';
@@ -613,6 +613,39 @@ export function createMockClient(options: MockClientOptions = {}): MockClient {
       // Real batch execution is network-dependent and cannot be simulated
       // without a Soroban RPC endpoint.
       return calls.map(() => xdr.ScVal.scvVoid());
+    },
+
+    // ── Typed envelope wrapper (#188) — parity with the real client ─────────
+    // `send()` returns a `SendEnvelope` instead of throwing. Injected failures
+    // (via `failNext`/`failures`) surface as `{ ok: false, error }`; otherwise
+    // a void result is returned, mirroring `batch()`'s in-memory semantics.
+    send: async <T = xdr.ScVal>(
+      call: SendCall,
+      sourceAddress: string,
+      decode?: (val: xdr.ScVal) => T,
+    ): Promise<SendEnvelope<T>> => {
+      validateStellarAddress(sourceAddress, 'sourceAddress');
+      const injected = takeFailure('send');
+      if (injected) {
+        // Match the real client's contract: decoded domain failures appear
+        // inside the envelope, typed as `InvofiError` (a `ContractError`).
+        const error =
+          injected instanceof ContractError
+            ? injected
+            : new ContractError(
+                -1,
+                ContractErrorType.UNKNOWN,
+                injected.message || 'Simulated send failure',
+                undefined,
+                injected,
+              );
+        return { ok: false, error };
+      }
+      // As with `batch()`, in-memory simulation returns a void result. The
+      // decode mapper (when supplied) is still invoked so the calling
+      // contract — decode always runs on success — matches the real client.
+      const voidVal = xdr.ScVal.scvVoid();
+      return { ok: true, value: decode ? decode(voidVal) : (voidVal as unknown as T) };
     },
 
     // ── Offline cache (Task 218) ─────────────────────────────────────────────

--- a/invofi/apps/sdk/tests/send.test.ts
+++ b/invofi/apps/sdk/tests/send.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests — `client.send()` typed envelope wrapper (#188)
+ *
+ * `send()` returns a `SendEnvelope` instead of throwing: decoded domain
+ * failures surface as `{ ok: false, error: InvofiError }` so UI layers can
+ * render a toast from `error.message` and branch on `error.errorType`
+ * without regex-matching raw Soroban text.
+ *
+ * These tests exercise the mock client's `send()` (parity with the real
+ * client), covering both envelope branches plus the error-normalisation rule
+ * (a non-ContractError injection is wrapped as an UNKNOWN InvofiError, while
+ * an injected ContractError passes through untouched).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createMockClient, ContractError, ContractErrorType, xdr } from '../src/index';
+import { MOCK_WALLET_ADDRESS, MOCK_FINANCING_ID } from '../src/mock';
+
+const call = {
+  contractId: MOCK_FINANCING_ID,
+  method: 'accept_offer',
+  args: [xdr.ScVal.scvSymbol('off_mock_006')],
+};
+
+describe('client.send() — success envelope', () => {
+  it('returns { ok: true } with the raw ScVal when no decode is supplied', async () => {
+    const client = createMockClient();
+    const result = await client.send(call, MOCK_WALLET_ADDRESS);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeInstanceOf(xdr.ScVal);
+    }
+  });
+
+  it('applies the supplied decode mapper on success', async () => {
+    const client = createMockClient();
+    const result = await client.send(call, MOCK_WALLET_ADDRESS, val => `decoded:${String(val?.['switch']?.name ?? 'void')}`);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toMatch(/^decoded:/);
+    }
+  });
+});
+
+describe('client.send() — error envelope', () => {
+  it('surfaces an injected ContractError inside the envelope, untouched', async () => {
+    const client = createMockClient();
+    const injected = new ContractError(5, ContractErrorType.INSUFFICIENT_BALANCE, 'Lender has no funds');
+    client.failNext('send', injected);
+
+    const result = await client.send(call, MOCK_WALLET_ADDRESS);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe(injected);
+      expect(result.error.errorType).toBe(ContractErrorType.INSUFFICIENT_BALANCE);
+      expect(result.error.rawCode).toBe(5);
+      // Human-readable message + machine-readable code are both available.
+      expect(result.error.message).toBe('Lender has no funds');
+    }
+  });
+
+  it('wraps a non-ContractError injection as an UNKNOWN InvofiError', async () => {
+    const client = createMockClient();
+    client.failNext('send', undefined, 'simulated outage');
+
+    const result = await client.send(call, MOCK_WALLET_ADDRESS);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ContractError);
+      expect(result.error.errorType).toBe(ContractErrorType.UNKNOWN);
+      expect(result.error.message).toContain('simulated outage');
+    }
+  });
+
+  it('branches cleanly on the typed variant without try/catch', async () => {
+    const client = createMockClient();
+    client.failNext('send', undefined, 'contract paused');
+
+    const result = await client.send(call, MOCK_WALLET_ADDRESS);
+
+    if (result.ok) {
+      // No failure injected on this branch — nothing to assert beyond shape.
+      expect(result.value).toBeDefined();
+    } else {
+      expect(result.error.errorType).toBe(ContractErrorType.UNKNOWN);
+    }
+  });
+});
+
+describe('client.send() — validation', () => {
+  it('still rejects on an invalid source address (not an envelope error)', async () => {
+    const client = createMockClient();
+    await expect(client.send(call, 'not-an-address')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #188 — adds a typed `send()` envelope wrapper to `@invofi/sdk` so frontends stop regex-matching raw Soroban error text.

## What's included

- **`client.send()``** — single-call convenience over the contract-invocation path returning a `SendEnvelope<T>` (`{ ok: true, value } | { ok: false, error }`) instead of throwing. Decoded contract failures (auth failures, insufficient balance, paused, not-found, …) surface as `{ ok: false, error: InvofiError }`, letting UI layers render a toast from `error.message` and branch on `error.errorType` without try/catch. Network/validation failures still throw (they are not decoded domain errors).
- **`InvofiError`** — typed variant alias of `ContractError` (machine-readable `errorType`/`rawCode` + human-readable `message` + optional `recovery`), re-exported from the package root for frontend toasts.
- **Documented error mapping table** in the SDK README — maps the canonical Soroban error codes 1–8 to panic-string examples, `InvofiError.errorType` variants, human messages and recovery hints.
- **Mock parity** — `createMockClient().send()` implements the same envelope contract (injected failures surface as `{ ok: false, error }`), so UI code written against `send()` is testable offline.

The `accept_offer`, `create_offer`, and `repay_invoice` paths already funnel through `parseContractError` → typed `ContractError`; the envelope now exposes the same decoded variants through a non-throwing API.

## Verification

- `NODE_ENV=test npx vitest run` → **328 tests passed** (322 existing + 6 new `tests/send.test.ts`)
- `npx tsc --noEmit` → clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed success and error responses for SDK contract calls through `send()`.
  * Contract failures are returned as structured errors, while network and validation failures continue to throw.
  * Added support for decoding successful responses and using the same behavior with mock clients.
  * Exposed new public types for calls, response envelopes, and SDK errors.

* **Documentation**
  * Added usage guidance, error details, recovery recommendations, and Soroban error-code mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->