### PR TITLE
feat(wallets): add xBull to approved-wallet allowlist (Closes #83)

### DIFF
--- a/invofi/apps/frontend/src/components/auth/WalletSelectDialog.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletSelectDialog.tsx
@@ -46,10 +46,17 @@ const AlbedoLogo = () => (
   </div>
 );
 
+const XBullLogo = () => (
+  <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-rose-400 to-red-600 flex items-center justify-center text-white font-bold text-sm shrink-0">
+    X
+  </div>
+);
+
 const LOGOS: Record<string, React.ReactNode> = {
   [WALLET_IDS.freighter]: <FreighterLogo />,
   [WALLET_IDS.lobstr]: <LobstrLogo />,
   [WALLET_IDS.albedo]: <AlbedoLogo />,
+  [WALLET_IDS.xbull]: <XBullLogo />,
 };
 
 export function WalletSelectDialog({

--- a/invofi/apps/frontend/src/lib/approved-wallets.ts
+++ b/invofi/apps/frontend/src/lib/approved-wallets.ts
@@ -6,6 +6,7 @@
 import { FreighterModule, FREIGHTER_ID } from '@creit.tech/stellar-wallets-kit/modules/freighter';
 import { LobstrModule, LOBSTR_ID } from '@creit.tech/stellar-wallets-kit/modules/lobstr';
 import { AlbedoModule, ALBEDO_ID } from '@creit.tech/stellar-wallets-kit/modules/albedo';
+import { xBullModule, XBULL_ID } from '@creit.tech/stellar-wallets-kit/modules/xbull';
 import { isConnected as isLobstrConnected } from '@lobstrco/signer-extension-api';
 import { isConnected as isFreighterConnected } from '@stellar/freighter-api';
 
@@ -40,6 +41,13 @@ function hasAlbedoAvailable(): Promise<boolean> {
   return Promise.resolve(hasWindow());
 }
 
+// xBull is a hot/wallet-connect style wallet (bridge at xbull.app): like
+// Albedo the SDK module pairs over a bridge rather than an installed browser
+// extension, so it is always available when the page is loaded.
+function hasXBullAvailable(): Promise<boolean> {
+  return Promise.resolve(hasWindow());
+}
+
 export const APPROVED_WALLETS = [
   {
     id: FREIGHTER_ID,
@@ -65,6 +73,14 @@ export const APPROVED_WALLETS = [
     module: AlbedoModule,
     isInstalled: hasAlbedoAvailable,
   },
+  {
+    id: XBULL_ID,
+    name: 'xBull',
+    description: 'Browser wallet and bridge wallet for Stellar',
+    installUrl: 'https://xbull.app',
+    module: xBullModule,
+    isInstalled: hasXBullAvailable,
+  },
 ] as const;
 
 export type ApprovedWallet = (typeof APPROVED_WALLETS)[number];
@@ -75,4 +91,5 @@ export const WALLET_IDS = {
   freighter: FREIGHTER_ID,
   lobstr: LOBSTR_ID,
   albedo: ALBEDO_ID,
+  xbull: XBULL_ID,
 } as const;


### PR DESCRIPTION
## Summary

Closes #83 — add xBull to the approved-wallet allowlist.

Following the ADR-0001 extension point, xBull is registered via the Stellar Wallets Kit `xBullModule` (mirroring the existing Albedo integration). xBull pairs over a bridge as a hot wallet, so like Albedo it is available whenever the page loads — no installed-extension detection needed.

## What changed

- **`src/lib/approved-wallets.ts`** — import `xBullModule`/`XBULL_ID` from `@creit.tech/stellar-wallets-kit/modules/xbull`; add the xBull allowlist entry (name, description, install URL, module, `isInstalled`); add `xbull` to `WALLET_IDS`.
- **`src/components/auth/WalletSelectDialog.tsx`** — add an xBull logo entry so the new wallet renders in the connect dialog automatically.

## Verification

- `npx tsc --noEmit` passes.
- `next lint` — no new warnings.
- `next build` compiles successfully (mock mode with dummy Supabase env).
- Existing unit tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting with the xBull wallet.
  * Added xBull wallet branding to wallet selection displays.
  * Included xBull in the list of supported wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->