### PR TITLE
feat(portfolio): add position-tokens panel with balance and transfer history (Closes #127)

### DIFF
--- a/invofi/apps/frontend/src/app/portfolio/page.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/page.tsx
@@ -23,6 +23,7 @@ import { useLivePortfolio } from '@/components/portfolio/LivePortfolioProvider';
 import { ConnectionStatus } from '@/components/portfolio/ConnectionStatus';
 import { RepaymentProgress } from '@/components/portfolio/RepaymentProgress';
 import { PaginationControls } from '@/components/portfolio/PaginationControls';
+import { PositionTokensPanel } from '@/components/portfolio/PositionTokensPanel';
 import { paginate } from '@/lib/pagination';
 import type { LivePosition } from '@/lib/live/types';
 
@@ -634,6 +635,10 @@ export default function PortfolioPage() {
         <Suspense fallback={null}>
           <TransferPositionCard />
         </Suspense>
+
+        {/* Position token balance + transfer history (issue #127). The
+            transfer form lives in the card above; this panel links to it. */}
+        <PositionTokensPanel />
       </div>
     </AuthGuard>
   );

--- a/invofi/apps/frontend/src/components/portfolio/PositionTokensPanel.tsx
+++ b/invofi/apps/frontend/src/components/portfolio/PositionTokensPanel.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowDownLeft, ArrowUpRight, RefreshCw, Send, Tag } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useWallet } from '@/components/auth/WalletProvider';
+import { getPositionTokenId, getTokenBalance, getTokenDecimals } from '@/lib/contract';
+import { getPositionTokenTransfers, type PositionTransfer } from '@/lib/horizon';
+import { formatDate } from '@/lib/utils';
+import { explorerTxUrl } from '@/lib/constants';
+
+/**
+ * Position tokens panel (issue #127).
+ *
+ * Lenders receive a SEP-41 position token when an offer is accepted, but the
+ * portfolio page did not surface the token balance or its transfer history, so
+ * a lender could not see or prove their claim. This panel shows:
+ *   - the connected wallet's position-token balance,
+ *   - the recent in/out position transfers for that wallet (via Horizon),
+ *   - a link to the "Transfer position" form (the existing card below).
+ */
+export function PositionTokensPanel() {
+  const { publicKey } = useWallet();
+  const [decimals, setDecimals] = useState(7);
+  const [balance, setBalance] = useState<bigint | null>(null);
+  const [transfers, setTransfers] = useState<PositionTransfer[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!publicKey) {
+      setBalance(null);
+      setTransfers(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const id = await getPositionTokenId();
+      if (id) {
+        const tokenDecimals = await getTokenDecimals(id);
+        setDecimals(tokenDecimals);
+        setBalance(await getTokenBalance(id, publicKey));
+      } else {
+        setBalance(null);
+      }
+      setTransfers(await getPositionTokenTransfers(publicKey));
+    } catch {
+      setError('Could not load position tokens. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [publicKey]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const balanceLabel =
+    balance === null
+      ? '—'
+      : (Number(balance) / 10 ** decimals).toFixed(decimals > 7 ? 7 : decimals);
+
+  return (
+    <Card className="mt-8" id="position-tokens">
+      <CardContent className="pt-5">
+        <div className="flex items-center justify-between mb-1">
+          <div className="flex items-center gap-2">
+            <Tag className="h-4 w-4 text-blue-500" />
+            <h2 className="text-lg font-semibold text-foreground">Position Tokens</h2>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={refresh}
+            disabled={loading}
+            aria-label="Refresh position tokens"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground mb-4">
+          Position tokens are minted to you when an offer is accepted — each token is
+          your claim on a financed invoice (1 token = 1 base unit of principal).
+        </p>
+
+        {!publicKey ? (
+          <p className="text-sm text-muted-foreground">
+            Connect a wallet to view your position tokens.
+          </p>
+        ) : (
+          <>
+            <div className="mb-4 flex items-center justify-between gap-4 rounded-xl border border-border bg-muted/40 px-4 py-3">
+              <div>
+                <p className="text-xs text-muted-foreground">Balance</p>
+                <p className="text-xl font-bold font-mono text-foreground">{balanceLabel}</p>
+              </div>
+              <Button size="sm" variant="outline" asChild>
+                <Link href="#transfer">
+                  <Send className="mr-1.5 h-3.5 w-3.5" /> Transfer position
+                </Link>
+              </Button>
+            </div>
+
+            <h3 className="text-sm font-medium text-foreground mb-2">Transfer history</h3>
+            {error ? (
+              <p className="text-sm text-red-600">{error}</p>
+            ) : transfers === null ? (
+              <p className="text-sm text-muted-foreground">Loading transfers…</p>
+            ) : transfers.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No position transfers yet. When you receive or send position tokens they
+                will appear here.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border rounded-xl border border-border">
+                {transfers.map(t => (
+                  <li key={t.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
+                    <div className="flex items-center gap-2 min-w-0">
+                      {t.direction === 'in' ? (
+                        <ArrowDownLeft className="h-4 w-4 text-green-500 shrink-0" />
+                      ) : (
+                        <ArrowUpRight className="h-4 w-4 text-orange-500 shrink-0" />
+                      )}
+                      <div className="min-w-0">
+                        <p className="text-sm text-foreground">
+                          {t.direction === 'in' ? 'Received' : 'Sent'}{' '}
+                          <span className="font-mono">{t.amount}</span>
+                        </p>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {t.direction === 'in' ? 'from' : 'to'}{' '}
+                          {t.counterparty.slice(0, 6)}…{t.counterparty.slice(-4)} ·{' '}
+                          {formatDate(t.createdAt)}
+                        </p>
+                      </div>
+                    </div>
+                    <a
+                      href={explorerTxUrl(t.hash)}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="text-xs text-blue-500 hover:underline shrink-0"
+                    >
+                      ↗
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/invofi/apps/frontend/src/lib/__tests__/position-tokens.test.ts
+++ b/invofi/apps/frontend/src/lib/__tests__/position-tokens.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isPositionTokenPayment,
+  parsePositionTokenAsset,
+  toPositionTransfer,
+} from '@/lib/horizon';
+
+/**
+ * Verification for issue #127: the portfolio "Position tokens" panel maps
+ * Horizon payment operations for the SEP-41 POS asset into a lender's in/out
+ * transfer history. These pure helpers are kept in lib/horizon.ts so the
+ * acceptance criteria are unit-testable without a DOM or a network call.
+ */
+
+const ASSET = { code: 'POS', issuer: 'GBDDLOWR6YUEEYUKFKS6ISTCLBQKDPUXAOVJMNJYAACT6UYQGEKYEVZR' };
+const WALLET = 'GA7QNFARKK6CFDVCZ3J2MD2S7YJ2Y5L3HZQKXZ2QJ3S7XQ6VYWYL4M2H';
+const OTHER = 'GBXDT4JUD7Q4H5Q7J7ZQKQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJQJ';
+
+const baseRecord = {
+  id: '123456789-1',
+  transaction_hash: 'a'.repeat(64),
+  created_at: '2026-08-27T10:00:00Z',
+  from: OTHER,
+  to: WALLET,
+  amount: '100.0000000',
+};
+
+describe('parsePositionTokenAsset', () => {
+  it('parses a well-formed "CODE:ISSUER" asset string', () => {
+    expect(parsePositionTokenAsset('POS:GBDDLOWR6YUEEYUKFKS6ISTCLBQKDPUXAOVJMNJYAACT6UYQGEKYEVZR')).toEqual(ASSET);
+  });
+
+  it('rejects a missing issuer', () => {
+    expect(parsePositionTokenAsset('POS')).toBeNull();
+  });
+
+  it('rejects an issuer that is not a valid Stellar address', () => {
+    expect(parsePositionTokenAsset('POS:not-an-address')).toBeNull();
+  });
+
+  it('rejects an empty code', () => {
+    expect(parsePositionTokenAsset(':GBDDLOWR6YUEEYUKFKS6ISTCLBQKDPUXAOVJMNJYAACT6UYQGEKYEVZR')).toBeNull();
+  });
+});
+
+describe('isPositionTokenPayment', () => {
+  it('accepts a payment of the matching POS asset', () => {
+    expect(
+      isPositionTokenPayment(
+        { type: 'payment', asset_code: 'POS', asset_issuer: ASSET.issuer },
+        ASSET,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a different asset code', () => {
+    expect(
+      isPositionTokenPayment(
+        { type: 'payment', asset_code: 'USDC', asset_issuer: ASSET.issuer },
+        ASSET,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a different issuer', () => {
+    expect(
+      isPositionTokenPayment(
+        { type: 'payment', asset_code: 'POS', asset_issuer: 'G' + 'A'.repeat(55) },
+        ASSET,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects native (XLM) payments, which have no asset code', () => {
+    expect(isPositionTokenPayment({ type: 'payment', asset_code: null, asset_issuer: null }, ASSET)).toBe(false);
+  });
+
+  it('rejects non-payment operations', () => {
+    expect(
+      isPositionTokenPayment(
+        { type: 'create_account', asset_code: 'POS', asset_issuer: ASSET.issuer },
+        ASSET,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('toPositionTransfer', () => {
+  it('maps an incoming payment to a Received transfer', () => {
+    expect(toPositionTransfer(baseRecord, WALLET)).toEqual({
+      id: '123456789-1',
+      hash: 'a'.repeat(64),
+      createdAt: '2026-08-27T10:00:00Z',
+      direction: 'in',
+      counterparty: OTHER,
+      amount: '100.0000000',
+    });
+  });
+
+  it('maps an outgoing payment to a Sent transfer', () => {
+    expect(
+      toPositionTransfer({ ...baseRecord, from: WALLET, to: OTHER }, WALLET),
+    ).toMatchObject({ direction: 'out', counterparty: OTHER });
+  });
+
+  it('returns null when the wallet is neither sender nor recipient', () => {
+    expect(toPositionTransfer(baseRecord, 'G' + 'B'.repeat(55))).toBeNull();
+  });
+});

--- a/invofi/apps/frontend/src/lib/horizon.ts
+++ b/invofi/apps/frontend/src/lib/horizon.ts
@@ -1,6 +1,7 @@
 import { Horizon } from '@stellar/stellar-sdk';
 import { isMockMode } from './mock-mode';
 import { mockXlmBalance } from './mock';
+import { POSITION_TOKEN_ASSET } from './constants';
 
 const HORIZON_URL =
   process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
@@ -108,4 +109,120 @@ export async function fundAccountViaFriendbot(publicKey: string): Promise<void> 
   }
   // Give Horizon a moment to index the funding transaction
   await new Promise(r => setTimeout(r, 2000));
+}
+
+// ── Position-token transfers (issue #127) ────────────────────────────────────
+// Position tokens (SEP-41 SAC) are a regular Stellar asset (`POS:ISSUER`), so
+// every mint/transfer shows up as a Horizon `payment` operation on that asset.
+// The portfolio panel reads these to show a lender their in/out history and
+// prove their claim. The mapping helpers are pure so the acceptance criteria
+// stay unit-testable without hitting the network.
+
+export interface PositionTransfer {
+  id: string;
+  hash: string;
+  createdAt: string;
+  direction: 'in' | 'out';
+  counterparty: string;
+  amount: string;
+}
+
+/** Parse a "CODE:ISSUER" asset string into its parts, or null if malformed. */
+export function parsePositionTokenAsset(
+  asset: string,
+): { code: string; issuer: string } | null {
+  const idx = asset.indexOf(':');
+  if (idx <= 0) return null;
+  const code = asset.slice(0, idx);
+  const issuer = asset.slice(idx + 1);
+  return code && /^G[A-Z2-7]{55}$/.test(issuer) ? { code, issuer } : null;
+}
+
+/** True when a Horizon operation record is a payment of the given POS asset. */
+export function isPositionTokenPayment(
+  rec: {
+    type?: string;
+    asset_code?: string | null;
+    asset_issuer?: string | null;
+  },
+  asset: { code: string; issuer: string },
+): boolean {
+  return (
+    rec.type === 'payment' &&
+    rec.asset_code === asset.code &&
+    rec.asset_issuer === asset.issuer
+  );
+}
+
+/**
+ * Shape of a payment-operation record as returned by Horizon, restricted to
+ * the fields this panel cares about. The SDK returns a union of operation
+ * types, so callers cast after filtering with `isPositionTokenPayment`.
+ */
+export interface PositionPaymentRecord {
+  id: string;
+  transaction_hash: string;
+  created_at: string;
+  type?: string;
+  asset_code?: string | null;
+  asset_issuer?: string | null;
+  from?: string;
+  to?: string;
+  amount?: string;
+}
+
+/**
+ * Map one Horizon payment record to a compact PositionTransfer, resolved
+ * against the connected wallet. Returns null when the wallet is neither the
+ * sender nor the recipient (e.g. a path-payment intermediary).
+ */
+export function toPositionTransfer(
+  rec: PositionPaymentRecord,
+  publicKey: string,
+): PositionTransfer | null {
+  if (rec.to === publicKey && rec.from && rec.amount !== undefined) {
+    return {
+      id: rec.id,
+      hash: rec.transaction_hash,
+      createdAt: rec.created_at,
+      direction: 'in',
+      counterparty: rec.from,
+      amount: rec.amount,
+    };
+  }
+  if (rec.from === publicKey && rec.to && rec.amount !== undefined) {
+    return {
+      id: rec.id,
+      hash: rec.transaction_hash,
+      createdAt: rec.created_at,
+      direction: 'out',
+      counterparty: rec.to,
+      amount: rec.amount,
+    };
+  }
+  return null;
+}
+
+/**
+ * Fetch the connected wallet's recent position-token transfers (in/out) from
+ * Horizon. Filters to the POS asset only, newest first. Returns [] in mock
+ * mode or when the POS asset is not configured.
+ */
+export async function getPositionTokenTransfers(
+  publicKey: string,
+  limit = 20,
+): Promise<PositionTransfer[]> {
+  if (isMockMode()) return [];
+  const asset = parsePositionTokenAsset(POSITION_TOKEN_ASSET);
+  if (!asset) return [];
+  const response = await horizon()
+    .payments()
+    .forAccount(publicKey)
+    .limit(limit)
+    .order('desc')
+    .call();
+  return response.records
+    .filter(rec => isPositionTokenPayment(rec, asset))
+    .map(rec => toPositionTransfer(rec as PositionPaymentRecord, publicKey))
+    .filter((t): t is PositionTransfer => t !== null);
 }


### PR DESCRIPTION
## Summary

Adds a **Position tokens** panel to the portfolio page (issue #127).

Lenders receive a SEP-41 position token when an offer is accepted, but the portfolio page did not display the token balance or its transfer history, so a lender could not see or prove their claim. This PR adds:

- **Balance** — the connected wallet's position-token balance (`getTokenBalance` via the SDK), refreshed on demand.
- **Transfer history** — recent in/out position transfers for that wallet, queried from Horizon (`payments()` for the account, filtered to the POS asset) with direction, counterparty, amount, timestamp, and an explorer link to the transaction.
- **Link to the transfer form** — a "Transfer position" button that scrolls to the existing `TransferPositionCard` (unchanged, per the issue's stop condition).

## Changes

- `src/lib/horizon.ts`: `parsePositionTokenAsset`, `isPositionTokenPayment`, `toPositionTransfer` (pure, unit-tested) + `getPositionTokenTransfers` fetcher.
- `src/components/portfolio/PositionTokensPanel.tsx`: new panel component.
- `src/app/portfolio/page.tsx`: render the panel below the existing transfer card.
- `src/lib/__tests__/position-tokens.test.ts`: 12 unit tests for the pure mapping helpers.

## Verification

- `npx vitest run src/lib/__tests__/position-tokens.test.ts` → 12/12 pass
- `tsc --noEmit` → no errors introduced (only pre-existing `MarketplaceSearch.test.tsx` user-event error)
- Full suite: 394/396 pass (2 pre-existing failures in `offerTerms.test.ts`, unmodified by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a position-token panel to the portfolio page.
  - View your position-token balance, decimals, and recent transfer history.
  - Refresh transfer data and open transactions in the explorer.
  - Added a quick link to the position transfer section.
  - Improved handling for disconnected wallets and unavailable transfer data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->