### PR TITLE
feat(frontend): add brand SVG illustrations to EmptyState variants (Closes #132)

### DIFF
--- a/invofi/apps/frontend/src/app/dashboard/page.tsx
+++ b/invofi/apps/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { InvoiceCard } from '@/components/invoices/InvoiceCard';
 import { InvoiceTable } from '@/components/invoices/InvoiceTable';
 import { WalletButton } from '@/components/auth/WalletButton';
 import { CardSkeleton, TableSkeleton } from '@/components/common/LoadingSkeleton';
+import { EmptyState } from '@/components/common/EmptyState';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { UpcomingRepaymentsWidget } from '@/components/dashboard/UpcomingRepaymentsWidget';
 import { ActivityFeed } from '@/components/dashboard/ActivityFeed';
@@ -213,15 +214,18 @@ export default function DashboardPage() {
                 {[1, 2, 3, 4].map(i => <CardSkeleton key={i} />)}
               </div>
             ) : invoices.length === 0 ? (
-              <div className="text-center py-16 border-2 border-dashed border-border rounded-xl">
-                <FileText className="h-10 w-10 text-muted-foreground/40 mx-auto mb-3" />
-                <p className="text-muted-foreground mb-4">No invoices yet.</p>
-                <Button asChild>
-                  <Link href="/invoices/new">
-                    <Plus className="mr-2 h-4 w-4" /> Create your first invoice
-                  </Link>
-                </Button>
-              </div>
+              <EmptyState
+                variant="no-invoices"
+                title="No invoices yet"
+                description="Create your first invoice to start financing on-chain."
+                action={
+                  <Button asChild>
+                    <Link href="/invoices/new">
+                      <Plus className="mr-2 h-4 w-4" /> Create your first invoice
+                    </Link>
+                  </Button>
+                }
+              />
             ) : view === 'table' ? (
               <InvoiceTable
                 invoices={invoices}
@@ -251,13 +255,16 @@ export default function DashboardPage() {
         {!isBusiness && (
           <section>
             <h2 className="text-lg font-semibold text-foreground mb-4">Your Investments</h2>
-            <div className="text-center py-16 border-2 border-dashed border-border rounded-xl">
-              <TrendingUp className="h-10 w-10 text-muted-foreground/40 mx-auto mb-3" />
-              <p className="text-muted-foreground mb-4">No active investments yet.</p>
-              <Button asChild>
-                <Link href="/marketplace">Browse Marketplace</Link>
-              </Button>
-            </div>
+            <EmptyState
+              variant="no-offers"
+              title="No active investments yet"
+              description="Browse the marketplace to finance invoices and earn yield."
+              action={
+                <Button asChild>
+                  <Link href="/marketplace">Browse Marketplace</Link>
+                </Button>
+              }
+            />
           </section>
         )}
       </div>

--- a/invofi/apps/frontend/src/app/marketplace/page.tsx
+++ b/invofi/apps/frontend/src/app/marketplace/page.tsx
@@ -14,6 +14,7 @@ import { MarketplaceTabs } from '@/components/marketplace/MarketplaceTabs';
 import { SuggestedMatches } from '@/components/marketplace/SuggestedMatches';
 import { LenderPreferencesForm } from '@/components/marketplace/LenderPreferencesForm';
 import { CardSkeleton } from '@/components/common/LoadingSkeleton';
+import { EmptyState } from '@/components/common/EmptyState';
 import { useLenderPreferences } from '@/hooks/useLenderPreferences';
 import { useMatchedInvoices } from '@/hooks/useMatchedInvoices';
 import { useMarketplace } from '@/hooks/useMarketplace';
@@ -307,10 +308,11 @@ function MarketplacePageInner() {
             )}
 
             {!allInvoicesQuery.isLoading && sortedAll.length === 0 && (
-              <div className="text-center py-20 text-muted-foreground">
-                <p className="text-lg font-medium">No invoices match your filters</p>
-                <p className="text-sm mt-1">Try adjusting the search query or filters.</p>
-              </div>
+              <EmptyState
+                variant="no-results"
+                title="No invoices match your filters"
+                description="Try adjusting the search query or filters."
+              />
             )}
 
             {!allInvoicesQuery.isLoading && sortedAll.length > 0 && (

--- a/invofi/apps/frontend/src/app/portfolio/page.tsx
+++ b/invofi/apps/frontend/src/app/portfolio/page.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { AuthGuard } from '@/components/auth/AuthGuard';
 import { useWallet } from '@/components/auth/WalletProvider';
 import { TableSkeleton } from '@/components/common/LoadingSkeleton';
+import { EmptyState } from '@/components/common/EmptyState';
 import { useToast } from '@/components/ui/use-toast';
 import { toErrorMessage } from '@/lib/errors';
 import { addPositionTrustline, getPositionTokenId, getTokenBalance, getTokenDecimals, hasPositionTrustline, transferPositionToken } from '@/lib/contract';
@@ -571,16 +572,19 @@ export default function PortfolioPage() {
 
         {/* Empty state */}
         {!loading && positions.length === 0 && (
-          <div className="text-center py-20 border-2 border-dashed border-border rounded-xl">
-            <TrendingUp className="h-10 w-10 text-muted-foreground/40 mx-auto mb-3" />
-            <p className="text-muted-foreground mb-4">No financing offers yet.</p>
-            <Link
-              href="/marketplace"
-              className="text-blue-600 hover:underline text-sm font-medium"
-            >
-              Browse the marketplace →
-            </Link>
-          </div>
+          <EmptyState
+            variant="no-positions"
+            title="No financing offers yet"
+            description="Browse the marketplace to find invoices to finance."
+            action={
+              <Link
+                href="/marketplace"
+                className="text-blue-600 hover:underline text-sm font-medium"
+              >
+                Browse the marketplace →
+              </Link>
+            }
+          />
         )}
 
         <div className="space-y-3">

--- a/invofi/apps/frontend/src/components/common/EmptyState.tsx
+++ b/invofi/apps/frontend/src/components/common/EmptyState.tsx
@@ -1,20 +1,119 @@
 import { type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
+export type EmptyStateVariant =
+  | 'no-invoices'
+  | 'no-offers'
+  | 'no-positions'
+  | 'no-results';
+
+const VARIANT_LABELS: Record<EmptyStateVariant, string> = {
+  'no-invoices': 'No invoices yet',
+  'no-offers': 'No financing offers yet',
+  'no-positions': 'No positions yet',
+  'no-results': 'No results found',
+};
+
 interface EmptyStateProps {
-  icon: LucideIcon;
+  icon?: LucideIcon;
   title: string;
   description: string;
   action?: React.ReactNode;
   className?: string;
+  /** When set, renders an inline brand illustration instead of the `icon`. */
+  variant?: EmptyStateVariant;
 }
 
-export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+/**
+ * Brand illustration built from the hexagon-invoice mark. Rendered as a fully
+ * inline SVG (no network requests) and inherits the surrounding text color so
+ * it adapts to both light and dark themes.
+ */
+function EmptyStateIllustration({ variant }: { variant: EmptyStateVariant }) {
+  const accent = 'currentColor';
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      className="mx-auto mb-4 h-20 w-20"
+      role="img"
+      aria-label={VARIANT_LABELS[variant]}
+    >
+      {/* Hexagon brand mark */}
+      <polygon
+        points="32,4 56,18 56,46 32,60 8,46 8,18"
+        fill="none"
+        stroke={accent}
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+        opacity="0.85"
+      />
+      {/* Corner-cut invoice document */}
+      <path
+        d="M 22,18 L 36,18 L 42,24 L 42,46 A 2,2 0 0 1 40,48 L 24,48 A 2,2 0 0 1 22,46 Z"
+        fill="none"
+        stroke={accent}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <path d="M 36,18 L 36,24 L 42,24 Z" fill="none" stroke={accent} strokeWidth="1.8" strokeLinejoin="round" />
+
+      {/* Variant-specific soft detail (low opacity = muted accent) */}
+      <g stroke={accent} opacity="0.5" strokeLinecap="round">
+        {variant === 'no-invoices' && (
+          <g strokeWidth="1.8">
+            <line x1="27" y1="33" x2="39" y2="33" />
+            <line x1="27" y1="38" x2="39" y2="38" />
+            <line x1="27" y1="43" x2="35" y2="43" />
+            {/* Plus badge signals "create" affordance */}
+            <circle cx="24" cy="28" r="4.2" fill={accent} opacity="0.18" stroke="none" />
+            <path d="M 24,26.5 L 24,29.5 M 22.5,28 L 25.5,28" stroke="white" strokeWidth="1.2" opacity="0.9" />
+          </g>
+        )}
+
+        {variant === 'no-offers' && (
+          <g strokeWidth="1.8">
+            <line x1="27" y1="33" x2="39" y2="33" />
+            <line x1="27" y1="38" x2="39" y2="38" />
+            <line x1="27" y1="43" x2="39" y2="43" />
+            <circle cx="42" cy="42" r="6" fill="none" strokeWidth="1.8" />
+            <path d="M 42,39 L 42,45 M 40.2,40.5 L 43.8,40.5" strokeWidth="1.4" />
+          </g>
+        )}
+
+        {variant === 'no-positions' && (
+          <g strokeWidth="1.8">
+            <line x1="27" y1="38" x2="39" y2="38" />
+            <line x1="27" y1="43" x2="39" y2="43" />
+            <path d="M 27,33 L 39,33" opacity="0.5" strokeDasharray="1.6 2.4" />
+          </g>
+        )}
+
+        {variant === 'no-results' && (
+          <g strokeWidth="1.8">
+            <line x1="27" y1="33" x2="39" y2="33" />
+            <line x1="27" y1="38" x2="39" y2="38" />
+            {/* Magnifier */}
+            <circle cx="43" cy="31" r="4.6" fill="none" strokeWidth="1.8" />
+            <line x1="46.5" y1="34.5" x2="50" y2="38" />
+            <path d="M 27,45 L 34,45" />
+          </g>
+        )}
+      </g>
+    </svg>
+  );
+}
+
+export function EmptyState({ icon: Icon, title, description, action, className, variant }: EmptyStateProps) {
   return (
     <div className={cn('flex flex-col items-center justify-center text-center py-16 px-4', className)}>
-      <div className="w-14 h-14 rounded-full bg-gray-100 flex items-center justify-center mb-4">
-        <Icon className="h-7 w-7 text-gray-400" />
-      </div>
+      {variant ? (
+        <EmptyStateIllustration variant={variant} />
+      ) : (
+        <div className="w-14 h-14 rounded-full bg-gray-100 flex items-center justify-center mb-4">
+          {Icon && <Icon className="h-7 w-7 text-gray-400" />}
+        </div>
+      )}
       <h3 className="text-base font-semibold text-gray-900 mb-1">{title}</h3>
       <p className="text-sm text-gray-500 max-w-xs leading-relaxed">{description}</p>
       {action && <div className="mt-6">{action}</div>}

--- a/invofi/apps/frontend/src/components/common/__tests__/EmptyState.test.tsx
+++ b/invofi/apps/frontend/src/components/common/__tests__/EmptyState.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FileText } from 'lucide-react';
+import { EmptyState, type EmptyStateVariant } from '@/components/common/EmptyState';
+
+const variants: EmptyStateVariant[] = ['no-invoices', 'no-offers', 'no-positions', 'no-results'];
+
+describe('EmptyState', () => {
+  it('renders title and description', () => {
+    render(<EmptyState icon={FileText} title="No invoices" description="Create your first one" />);
+    expect(screen.getByText('No invoices')).toBeInTheDocument();
+    expect(screen.getByText('Create your first one')).toBeInTheDocument();
+  });
+
+  it('falls back to the lucide icon when no variant is set', () => {
+    render(<EmptyState icon={FileText} title="Nothing here" description="desc" />);
+    // The circle container renders only in the icon fallback branch
+    const container = document.querySelector('.rounded-full');
+    expect(container).not.toBeNull();
+    // No illustration svg should be rendered
+    expect(document.querySelector('svg[role="img"]')).toBeNull();
+  });
+
+  it.each(variants)('renders an inline brand illustration for variant %s', (variant) => {
+    const { container } = render(
+      <EmptyState variant={variant} title="Empty" description="Nothing to show" />
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // aria-label comes from the variant label map
+    expect(svg).toHaveAttribute('aria-label');
+    // The hexagon polygon (brand mark) is present
+    expect(container.querySelector('polygon')).not.toBeNull();
+  });
+
+  it('renders the action node when provided', () => {
+    render(
+      <EmptyState
+        variant="no-invoices"
+        title="No invoices"
+        description="desc"
+        action={<button>Create invoice</button>}
+      />
+    );
+    expect(screen.getByRole('button', { name: /create invoice/i })).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <EmptyState variant="no-results" title="No results" description="desc" className="custom-class" />
+    );
+    expect(container.firstElementChild).toHaveClass('custom-class');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #132 — adds a `variant` prop to the shared `EmptyState` component that renders an inline **hexagon-invoice brand illustration** (no network requests) for each empty state context, and wires the component into the existing empty states on the dashboard, portfolio, and marketplace pages.

### What changed

- **`EmptyState.tsx`** — new `variant?: 'no-invoices' | 'no-offers' | 'no-positions' | 'no-results'` prop. When set, it renders a fully inline SVG built from the existing hexagon-invoice brand mark (hexagon + corner-cut invoice document) with a context-specific glyph:
  - `no-invoices` — document with a "+" create badge
  - `no-offers` — document with a coin/dollar badge
  - `no-positions` — document with an empty dashed ledger
  - `no-results` — document with a magnifier
  - The illustration uses `currentColor` with low-opacity accents, so it adapts to both light and dark themes with zero network requests.
  - The existing `icon` (lucide) fallback is preserved for backwards compatibility.
- **`dashboard/page.tsx`** — replaced inline empty states ("No invoices yet", "No active investments yet") with `<EmptyState variant=...>`.
- **`portfolio/page.tsx`** — replaced the "No financing offers yet" empty state with `<EmptyState variant="no-positions">`.
- **`marketplace/page.tsx`** — replaced the "No invoices match your filters" empty state with `<EmptyState variant="no-results">`.
- **`EmptyState.test.tsx`** — 8 unit tests covering each variant illustration, the icon fallback, the action node, and custom className.

### Verification

- `npx tsc --noEmit` — clean
- `npx vitest run src/components/common/__tests__/EmptyState.test.tsx` — 8/8 pass
- `npx eslint` on changed files — no new errors (2 pre-existing `react-hooks/exhaustive-deps` warnings in `marketplace/page.tsx`)

### Acceptance criteria

- [x] Every EmptyState variant shows a brand-consistent illustration
- [x] Illustrations are inline SVGs with no network requests
- [x] Render well in the existing light theme (and dark via `currentColor`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tailored empty-state illustrations for invoices, offers, positions, and search results.
  * Updated dashboard, marketplace, and portfolio empty screens with clearer messaging and relevant navigation actions.
  * Improved accessibility with descriptive illustration labels.

* **Tests**
  * Added coverage for empty-state content, illustrations, fallback icons, actions, and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->