### PR TITLE
feat(wallets): add Ledger hardware wallet to approved-wallet allowlist (Closes #99)

### DIFF
--- a/docs/adr/0001-approved-wallet-allowlist.md
+++ b/docs/adr/0001-approved-wallet-allowlist.md
@@ -16,10 +16,31 @@ All wallets connect through `@creit.tech/stellar-wallets-kit`. The approved
 subset lives in exactly one file — `src/lib/approved-wallets.ts` — which is
 the single extension point: approving a third wallet is one new entry in that
 list and nothing else. The wallet dialog, provider, and signer all read from
-that list. Currently approved: Freighter and LOBSTR.
+that list. Currently approved: Freighter, LOBSTR, Albedo, xBull, and Ledger.
 
 ## Consequences
 
 - New wallet = one config entry, no new code.
 - Consistent connect/sign behavior across approved wallets.
 - Unapproved kit modules stay excluded until explicitly added.
+
+## Hardware-wallet caveats
+
+Ledger (and any future hardware wallet) differs from browser/bridge wallets in
+ways that the app must account for:
+
+- **No auto-restore.** Connecting a hardware wallet opens the native WebUSB
+  device picker, so it must never be attempted during automatic session
+  restore on page load. Such wallets opt out via `autoConnectable: false` in
+  the allowlist entry and are connected only on explicit user action.
+- **Keys never leave the device.** All signing happens on the Ledger itself;
+  the app only ever sees the public address and a signed transaction.
+- **WebUSB is required.** Ledger works only in browsers that expose
+  `navigator.usb` (Chromium-based). Availability is gated on that capability,
+  and the kit re-validates with the transport at connect time.
+- **Buffer polyfill.** The Ledger module pulls in `@ledgerhq/hw-transport-webusb`,
+  which references the Node `Buffer` global. The frontend polyfills it (see
+  `next.config.mjs`) so the module can load and sign in the browser.
+- **Testnet signing needs a device.** End-to-end verification requires a
+  physical Ledger with the Stellar app installed; CI covers the allowlist
+  wiring, build, and lint instead of live signing.

--- a/invofi/apps/frontend/next.config.mjs
+++ b/invofi/apps/frontend/next.config.mjs
@@ -1,11 +1,14 @@
 import path from 'node:path';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import webpack from 'webpack';
 import createNextIntlPlugin from 'next-intl/plugin';
 import { buildSecurityHeaders } from './security-headers.mjs';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -27,6 +30,14 @@ const nextConfig = {
         dns: false,
         child_process: false,
       };
+      // The Ledger hardware-wallet module (issue #99) pulls in
+      // @ledgerhq/hw-transport-webusb, which references the Node `Buffer`
+      // global. Polyfill it in the browser bundle so the module loads and
+      // can sign from a device without a server-side Buffer.
+      config.resolve.fallback.buffer = require.resolve('buffer/');
+      config.plugins.push(
+        new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
+      );
     }
     // Task 15: @invofi/sdk is consumed from source via tsconfig paths, so its
     // dependencies must resolve to THIS app's copy (the SDK's own

--- a/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletProvider.tsx
@@ -207,13 +207,20 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
       // Prefer the last-connected wallet so returning users reconnect to the
       // wallet they chose last time; fall back to probing every approved
-      // wallet for a previously-granted session.
+      // wallet for a previously-granted session. Wallets that opt out of
+      // auto-connect (`autoConnectable: false`, e.g. hardware wallets that
+      // would open a WebUSB picker) are skipped — they connect on explicit
+      // user action only.
+      const isAutoConnectable = (walletId: string): boolean => {
+        const w = APPROVED_WALLETS.find(entry => entry.id === walletId);
+        return w ? w.autoConnectable !== false : true;
+      };
       const lastWallet = readLastWallet();
-      if (lastWallet && installed.has(lastWallet.walletId)) {
+      if (lastWallet && installed.has(lastWallet.walletId) && isAutoConnectable(lastWallet.walletId)) {
         if (await tryRestoreWallet(lastWallet.walletId)) return;
       }
       for (const w of APPROVED_WALLETS) {
-        if (!installed.has(w.id)) continue;
+        if (!installed.has(w.id) || !isAutoConnectable(w.id)) continue;
         if (await tryRestoreWallet(w.id)) return;
       }
 

--- a/invofi/apps/frontend/src/components/auth/WalletSelectDialog.tsx
+++ b/invofi/apps/frontend/src/components/auth/WalletSelectDialog.tsx
@@ -52,11 +52,18 @@ const XBullLogo = () => (
   </div>
 );
 
+const LedgerLogo = () => (
+  <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-zinc-800 to-black flex items-center justify-center text-white font-bold text-sm shrink-0">
+    L
+  </div>
+);
+
 const LOGOS: Record<string, React.ReactNode> = {
   [WALLET_IDS.freighter]: <FreighterLogo />,
   [WALLET_IDS.lobstr]: <LobstrLogo />,
   [WALLET_IDS.albedo]: <AlbedoLogo />,
   [WALLET_IDS.xbull]: <XBullLogo />,
+  [WALLET_IDS.ledger]: <LedgerLogo />,
 };
 
 export function WalletSelectDialog({

--- a/invofi/apps/frontend/src/lib/approved-wallets.ts
+++ b/invofi/apps/frontend/src/lib/approved-wallets.ts
@@ -7,6 +7,7 @@ import { FreighterModule, FREIGHTER_ID } from '@creit.tech/stellar-wallets-kit/m
 import { LobstrModule, LOBSTR_ID } from '@creit.tech/stellar-wallets-kit/modules/lobstr';
 import { AlbedoModule, ALBEDO_ID } from '@creit.tech/stellar-wallets-kit/modules/albedo';
 import { xBullModule, XBULL_ID } from '@creit.tech/stellar-wallets-kit/modules/xbull';
+import { LedgerModule, LEDGER_ID } from '@creit.tech/stellar-wallets-kit/modules/ledger';
 import { isConnected as isLobstrConnected } from '@lobstrco/signer-extension-api';
 import { isConnected as isFreighterConnected } from '@stellar/freighter-api';
 
@@ -48,6 +49,18 @@ function hasXBullAvailable(): Promise<boolean> {
   return Promise.resolve(hasWindow());
 }
 
+// Ledger is a hardware wallet accessed over WebUSB (the kit's Ledger module
+// uses @ledgerhq/hw-transport-webusb). There is no extension to detect — the
+// module opens the native WebUSB picker on connect — so availability is
+// gated on the browser exposing the WebUSB API (`navigator.usb`). The kit
+// module re-validates via transport.isSupported() at connect time, so this
+// check is only a cheap capability probe, mirroring the module's own
+// `isAvailable()`. Note: like all hardware wallets, a Ledger key never
+// leaves the device; see ADR-0001 for hardware-wallet caveats.
+function hasLedgerAvailable(): Promise<boolean> {
+  return Promise.resolve(hasWindow() && typeof navigator.usb !== 'undefined');
+}
+
 export const APPROVED_WALLETS = [
   {
     id: FREIGHTER_ID,
@@ -56,6 +69,7 @@ export const APPROVED_WALLETS = [
     installUrl: 'https://freighter.app',
     module: FreighterModule,
     isInstalled: hasFreighterExtension,
+    autoConnectable: true,
   },
   {
     id: LOBSTR_ID,
@@ -64,6 +78,7 @@ export const APPROVED_WALLETS = [
     installUrl: 'https://lobstr.co/extension',
     module: LobstrModule,
     isInstalled: hasLobstrExtension,
+    autoConnectable: true,
   },
   {
     id: ALBEDO_ID,
@@ -72,6 +87,7 @@ export const APPROVED_WALLETS = [
     installUrl: 'https://albedo.link/',
     module: AlbedoModule,
     isInstalled: hasAlbedoAvailable,
+    autoConnectable: true,
   },
   {
     id: XBULL_ID,
@@ -80,6 +96,18 @@ export const APPROVED_WALLETS = [
     installUrl: 'https://xbull.app',
     module: xBullModule,
     isInstalled: hasXBullAvailable,
+    autoConnectable: true,
+  },
+  {
+    id: LEDGER_ID,
+    name: 'Ledger',
+    description: 'Hardware wallet (Stellar app) — keys never leave the device',
+    installUrl: 'https://www.ledger.com/',
+    module: LedgerModule,
+    isInstalled: hasLedgerAvailable,
+    // Hardware wallets connect only on explicit user action — auto-restoring
+    // would open the native WebUSB device picker on every page load.
+    autoConnectable: false,
   },
 ] as const;
 
@@ -92,4 +120,5 @@ export const WALLET_IDS = {
   lobstr: LOBSTR_ID,
   albedo: ALBEDO_ID,
   xbull: XBULL_ID,
+  ledger: LEDGER_ID,
 } as const;


### PR DESCRIPTION
Integrates the **Ledger hardware wallet** into the approved-wallet allowlist (issue #99), behind the same ADR-0001 extension point used for Freighter / LOBSTR / Albedo / xBull.

## What changed

- `src/lib/approved-wallets.ts` — registers the kit's `LedgerModule` (`LEDGER_ID`) as a fifth approved wallet. Availability is gated on WebUSB support (`navigator.usb`), mirroring the module's own `isAvailable()`. The entry opts out of auto-restore via `autoConnectable: false` so the native WebUSB device picker is never opened on page load — a hardware wallet connects only on explicit user action.
- `src/components/auth/WalletProvider.tsx` — skips `autoConnectable: false` wallets during automatic session restore (both the last-wallet and fallback loops).
- `src/components/auth/WalletSelectDialog.tsx` — adds the Ledger logo to the wallet picker.
- `next.config.mjs` — polyfills the Node `Buffer` global (webpack `ProvidePlugin` + fallback) required by `@ledgerhq/hw-transport-webusb`, which the Ledger module pulls in.
- `docs/adr/0001-approved-wallet-allowlist.md` — updates the approved list and documents hardware-wallet caveats (no auto-restore, WebUSB requirement, keys never leave the device, Buffer polyfill, device needed for live testnet signing).

## Verification

- `tsc --noEmit` passes (the only reported error is a pre-existing missing `@testing-library/user-event` dev dependency in an unrelated test file).
- `next lint` passes on all touched files.
- `next build` succeeds in mock mode — the Ledger module and its `@ledgerhq` + Buffer polyfill bundle without errors.

Live signing on a physical device cannot be exercised in CI; the allowlist wiring, build, and lint are covered here (see the ADR note).

Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ledger hardware-wallet support for browser-based signing via WebUSB.
  * Added Ledger to the approved wallet list and wallet selection interface.
  * Added wallet logos for Ledger and support for Albedo and xBull.
* **Bug Fixes**
  * Prevented Ledger from triggering automatic connection or device prompts during wallet restoration.
  * Improved wallet connection behavior while keeping Ledger available for manual selection.
* **Documentation**
  * Documented Ledger setup requirements, device-bound signing, and testing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->