### PR TITLE
Add pagination to marketplace invoice listings

### DIFF
--- a/invofi/apps/frontend/src/app/marketplace/page.tsx
+++ b/invofi/apps/frontend/src/app/marketplace/page.tsx
@@ -70,7 +70,21 @@ function MarketplacePageInner() {
     search: search || undefined,
   });
 
-  const allInvoices = allInvoicesQuery.data ?? [];
+  // Flatten paginated pages and de-duplicate by id so that appended pages
+  // never repeat entries when rows shift the offset-based cursor between fetches.
+  const allInvoices = useMemo(() => {
+    const pages = allInvoicesQuery.data?.pages ?? [];
+    const seen = new Set<string>();
+    const merged: Invoice[] = [];
+    for (const page of pages) {
+      for (const inv of page.invoices) {
+        if (inv.id && seen.has(inv.id)) continue;
+        if (inv.id) seen.add(inv.id);
+        merged.push(inv);
+      }
+    }
+    return merged;
+  }, [allInvoicesQuery.data]);
 
   const sortedAll = useMemo(() => {
     let list = allInvoices.filter(inv => {
@@ -219,6 +233,27 @@ function MarketplacePageInner() {
                 {sortedAll.map(inv => (
                   <MarketplaceCard key={inv.id} invoice={inv} />
                 ))}
+              </div>
+            )}
+
+            {/* Load more (pagination) */}
+            {!allInvoicesQuery.isLoading && allInvoicesQuery.hasNextPage && (
+              <div className="flex justify-center mt-8">
+                <button
+                  type="button"
+                  onClick={() => allInvoicesQuery.fetchNextPage()}
+                  disabled={allInvoicesQuery.isFetchingNextPage}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {allInvoicesQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
+                </button>
+              </div>
+            )}
+
+            {/* Next-page loading skeleton */}
+            {allInvoicesQuery.isFetchingNextPage && (
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+                {[1, 2, 3].map(i => <CardSkeleton key={i} />)}
               </div>
             )}
           </>

--- a/invofi/apps/frontend/src/hooks/useMarketplace.ts
+++ b/invofi/apps/frontend/src/hooks/useMarketplace.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { createClient } from '@/utils/supabase/client';
 import type { Invoice } from '@/types';
 
@@ -11,26 +11,46 @@ interface MarketplaceFilters {
   search?: string;
 }
 
+const PAGE_SIZE = 12;
+
+export interface MarketplacePage {
+  invoices: Invoice[];
+  nextOffset: number | null;
+}
+
 export function useMarketplace(filters: MarketplaceFilters = {}) {
-  return useQuery({
+  return useInfiniteQuery<MarketplacePage>({
     queryKey: ['marketplace', filters],
-    queryFn: async () => {
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const offset = pageParam as number;
+
       let query = supabase
         .from('invoices')
-        .select('*')
+        .select('*', { count: 'exact' })
         .eq('status', 'Pending')
-        .order('created_at', { ascending: false });
+        .order('created_at', { ascending: false })
+        .range(offset, offset + PAGE_SIZE - 1);
 
       if (filters.currency) query = query.eq('currency', filters.currency);
       if (filters.search) query = query.ilike('id', `%${filters.search}%`);
 
-      const { data, error } = await query;
+      const { data, error, count } = await query;
       if (error) throw error;
 
       let results = data as Invoice[];
       if (filters.minAmount) results = results.filter(i => Number(i.amount) >= filters.minAmount!);
       if (filters.maxAmount) results = results.filter(i => Number(i.amount) <= filters.maxAmount!);
-      return results;
+
+      const hasMoreDbRows = data.length === PAGE_SIZE;
+      const reachedEnd =
+        !hasMoreDbRows || (count !== null && offset + PAGE_SIZE >= count);
+
+      return {
+        invoices: results,
+        nextOffset: reachedEnd ? null : offset + PAGE_SIZE,
+      };
     },
+    getNextPageParam: (lastPage) => lastPage.nextOffset,
   });
 }


### PR DESCRIPTION
## Summary
The marketplace "Browse all" view previously fetched every Pending invoice in a single request. This adds offset-based pagination using TanStack Query's `useInfiniteQuery` so the page stays responsive as the on-chain invoice count grows.

## Issue
- Closes #154

## Changes
- `src/hooks/useMarketplace.ts`: switched to `useInfiniteQuery` with a bounded `PAGE_SIZE` (12), fetching via Supabase `.range(offset, offset + PAGE_SIZE - 1)` and `count: 'exact'` to compute the next cursor. Returns `{ invoices, nextOffset }`.
- `src/app/marketplace/page.tsx`: flatten `data.pages` and de-duplicate by `id` (guards against repeats when rows shift the offset cursor between fetches); kept the existing client-side sort + status filter across loaded pages; added a **Load more** button (`fetchNextPage`/`hasNextPage`) and a `CardSkeleton` grid while `isFetchingNextPage` is true.

## Validation
- Not run in the agent environment: `npm ci` could not complete there (slow network + a transitive dependency's `yarn setup` postinstall fails on Windows). Please run `npm ci` then `npm run lint` and `npm run build` locally.

## Notes
- Sorting/filters (#81) still apply per loaded page as before. No server-side search index added (out of scope per issue).
- Suggested-matches view (`useMatchedInvoices`) is unchanged and already paginates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Load more” browsing for marketplace invoices.
  - Displays loading placeholders while additional invoices are retrieved.

- **Bug Fixes**
  - Prevented duplicate invoices from appearing.
  - Improved invoice pagination and handling when no additional results are available.
  - Preserved search and currency filtering while supporting larger result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->