### PR TITLE
ci(sdk): smoke-test ESM and CJS entry points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,32 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - run: npm test
 
+  sdk-entrypoint-smoke:
+    name: SDK / ESM & CJS Entry Point Smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: invofi/apps/sdk
+    env:
+      SDK_SMOKE_DIR: ${{ runner.temp }}/invofi-sdk-smoke
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: invofi/apps/sdk/package-lock.json
+      - run: npm ci
+      - name: Build ESM and CommonJS entry points
+        run: |
+          mkdir -p "$SDK_SMOKE_DIR"
+          npx --no-install esbuild src/index.ts --bundle --platform=node --format=esm --outfile="$SDK_SMOKE_DIR/index.mjs"
+          npx --no-install esbuild src/index.ts --bundle --platform=node --format=cjs --outfile="$SDK_SMOKE_DIR/index.cjs"
+      - name: Smoke-import ESM entry point
+        run: node --input-type=module -e "import(process.env.SDK_SMOKE_DIR + '/index.mjs')"
+      - name: Smoke-require CommonJS entry point
+        run: node -e "require(process.env.SDK_SMOKE_DIR + '/index.cjs')"
+
   frontend-build:
     name: Frontend / Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add an SDK CI job that builds temporary Node-targeted ESM and CommonJS artifacts, then smoke-loads both formats so module initialization failures fail CI.

Closes #142

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [x] Test addition
- [ ] Dependency update

## Changes made

- Add an SDK entry-point smoke job to the existing CI workflow.
- Install SDK dependencies reproducibly with `npm ci` and the SDK lockfile.
- Build temporary ESM and CommonJS Node bundles from `src/index.ts`.
- Load the ESM artifact with dynamic `import()` and the CommonJS artifact with `require()`.
- Leave SDK source, package metadata, lockfiles, permanent bundler configuration, and npm publishing untouched.

## Implementation note

The current SDK package has no `build` script or ESM/CJS export map. To avoid expanding into the package/publishing work tracked by #76, this check uses the lockfile-installed esbuild binary to create CI-only artifacts. It therefore validates Node loading for those generated artifacts without changing the SDK package configuration.

The existing CI workflow runs this job on every PR targeting `main`, including every PR that touches `invofi/apps/sdk`.

## Testing

- [x] `npm run type-check` passes in `invofi/apps/sdk`
- [x] `npm test` passes: 328 tests across 9 files
- [x] ESM bundle builds and loads successfully
- [x] CommonJS bundle builds and loads successfully
- [x] Negative ESM and CJS load tests both exit with status 1
- [x] `git diff --check` passes

## Checklist

- [x] I am assigned to issue #142
- [x] My branch is based on current upstream `main`
- [x] I followed the conventional commit format
- [x] I added a CI regression check for the requested behavior
- [x] I have not introduced any hardcoded secrets or keys

This workflow modification is explicitly requested by issue #142.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks confirming the SDK’s ESM and CommonJS entry points can be bundled and loaded successfully.
* **Chores**
  * Expanded continuous integration coverage for SDK entry-point compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->