### PR TITLE
docs(adr): record repo topology and SDK location

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ InvoFi lives across **two repositories**, split so the fast-moving app layer and
 
 | Repo | Contains | Why separate |
 |---|---|---|
-| **[invofi](https://github.com/Stellar-VaultLink/invofi)** (this repo) | Next.js frontend (`invofi/apps/frontend`), docs, scripts, roadmap | App-layer changes constantly; Node/npm CI; no audit dependency |
+| **[invofi](https://github.com/Stellar-VaultLink/invofi)** (this repo) | Next.js frontend (`invofi/apps/frontend`), `@invofi/sdk` (`apps/sdk`), docs, scripts, roadmap | App-layer changes constantly; Node/npm CI; no audit dependency |
 | **[invofi-contracts](https://github.com/Stellar-VaultLink/invofi-contracts)** | All Soroban Rust contracts — registry, financing, repayment, insurance, reputation, common | Stable, auditable, slow-moving history; Rust-only CI; the repo that goes through the SCF Audit Bank |
 
 **Smart contracts now live in a dedicated repo: [invofi-contracts](https://github.com/Stellar-VaultLink/invofi-contracts).**
+
+See [ADR-0007: Repository topology and SDK location](./docs/adr/0007-repo-topology-and-sdk.md) for the decision, rationale, and tradeoffs behind this project map.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Welcome to the official InvoFi documentation. InvoFi is a decentralized invoice 
 | [Environment Variables](./08-environment-variables.md) | Every variable explained |
 | [Contributing](./09-contributing.md) | How to set up a dev environment and submit PRs |
 | [Roadmap](./10-roadmap.md) | What's built, what's coming, what's planned for v2 |
+| [Architecture Decision Records](./adr/README.md) | Reviewable records of lasting application architecture decisions |
 
 ---
 

--- a/docs/adr/0007-repo-topology-and-sdk.md
+++ b/docs/adr/0007-repo-topology-and-sdk.md
@@ -1,0 +1,87 @@
+# ADR-0007: Repository topology and SDK location
+
+**Status:** Accepted (2026-08-29)
+
+## Context
+
+InvoFi has two active repositories with different ownership and change
+cadences. The application repository contains the user-facing application and
+its supporting TypeScript tooling. The contract repository contains the
+Soroban protocol implementation. The former standalone frontend repository is
+archived.
+
+[ADR-0003](./0003-sdk-extraction.md) established `apps/sdk` as the
+framework-agnostic `@invofi/sdk` package. This ADR records where that package
+belongs and formalises the repository boundary; it does not introduce a
+repository move.
+
+## Decision
+
+1. **The active project uses two repositories.**
+   [Stellar-VaultLink/invofi](https://github.com/Stellar-VaultLink/invofi) is
+   the application monorepo. It owns the frontend, `apps/sdk`, the indexer,
+   application scripts, and application documentation.
+   [Stellar-VaultLink/invofi-contracts](https://github.com/Stellar-VaultLink/invofi-contracts)
+   owns the Soroban contract source, contract tests, deployments, and
+   contract-facing architectural decisions.
+2. **Contracts remain separate.** Contract changes have a slower, more
+   controlled lifecycle because they require security review and may affect an
+   audited protocol surface. A dedicated repository gives reviewers a focused,
+   traceable contract history and prevents faster-moving application work from
+   obscuring contract changes or coupling the two release cadences.
+3. **The frontend and SDK remain together.** The frontend is the SDK's direct
+   application consumer. Keeping them in one repository allows contract-call
+   adapters, shared types, and application integration to change and be tested
+   together without routine cross-repository coordination.
+4. **`apps/sdk` belongs in the application repository.** The SDK is the typed,
+   framework-agnostic boundary between application consumers and deployed
+   contract interfaces. It can serve scripts, bots, the indexer, or future
+   applications without moving the contract implementation into this
+   repository. Its location does not transfer ownership of contract source or
+   contract-facing decisions from `invofi-contracts`.
+5. **The old standalone frontend repository stays archived.**
+   [Stellar-VaultLink/invofi-frontend](https://github.com/Stellar-VaultLink/invofi-frontend)
+   is a historical repository, not an active development target. Frontend
+   changes belong in `invofi`; the archived repository is not maintained as a
+   synchronized copy.
+
+## Rationale
+
+Contract code benefits from a narrow, audit-friendly review surface, explicit
+security ownership, and a history that changes only when the protocol changes.
+Application code benefits from shorter iteration cycles and coordinated
+changes across its UI and reusable client boundary. The two-repository split
+preserves those different workflows while `apps/sdk` makes the boundary
+between them explicit.
+
+A third active repository for the SDK would add version and pull-request
+coordination between the SDK and its primary consumer without improving
+contract isolation. Keeping it in `invofi` preserves reuse at the package
+boundary while avoiding that extra coordination.
+
+## Consequences
+
+- Contract development can follow a slower security-review and audit cadence
+  without being mixed into application history.
+- Frontend and SDK types, adapters, and tests can evolve together in one pull
+  request.
+- Repository ownership is explicit: application integration belongs in
+  `invofi`; contract implementation and contract decisions belong in
+  `invofi-contracts`.
+- Changes that alter both a contract interface and its application integration
+  may require coordinated pull requests and release sequencing across the two
+  repositories.
+- Contributors must identify the owning repository before starting work, and
+  cross-repository documentation links must be kept current.
+- The SDK shares the application repository's governance and release workflow;
+  if its external-consumer needs diverge materially, this decision should be
+  revisited rather than creating an untracked copy.
+- The archived frontend repository may contain stale instructions or links;
+  current frontend documentation and contributions belong in `invofi`.
+
+## Repository references
+
+- Application repository: [Stellar-VaultLink/invofi](https://github.com/Stellar-VaultLink/invofi)
+- Contracts repository: [Stellar-VaultLink/invofi-contracts](https://github.com/Stellar-VaultLink/invofi-contracts)
+- Contracts ADR index: [invofi-contracts/docs/adr/README.md](https://github.com/Stellar-VaultLink/invofi-contracts/blob/master/docs/adr/README.md)
+- Archived frontend repository: [Stellar-VaultLink/invofi-frontend](https://github.com/Stellar-VaultLink/invofi-frontend)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,8 +11,9 @@ append, never rewrite (status updates go in the file).
 | 0004 | [Secondary-market discovery for position tokens](./0004-position-token-listings.md) | Accepted |
 | 0005 | [Event-driven keeper](./0005-event-driven-keeper.md) | Accepted |
 | 0006 | [Multi-signature approval for high-value operations](./0006-multisig-transaction-approval.md) | Accepted |
+| 0007 | [Repository topology and SDK location](./0007-repo-topology-and-sdk.md) | Accepted |
 
-Contract-facing decisions live in the contracts repo: [invofi-contracts/docs/adr](https://github.com/Stellar-VaultLink/invofi-contracts/tree/main/docs/adr).
+Contract-facing decisions live in the contracts repo: [invofi-contracts/docs/adr](https://github.com/Stellar-VaultLink/invofi-contracts/blob/master/docs/adr/README.md).
 
 ## Why ADRs
 


### PR DESCRIPTION
## Summary

Formalises the two-repository topology and SDK placement in ADR-0007 so contributors can understand the ownership boundaries, rationale, and tradeoffs. Adds discoverability from the ADR index, documentation index, and README Project Map.

## Related issue

Closes #167

## Type of change

- [x] Documentation update

## Changes made

- Add ADR-0007 covering the application monorepo, separate audit-friendly contracts repository, and the role of `apps/sdk`.
- Record that the former standalone frontend repository remains archived.
- Link the ADR from the README Project Map and documentation indexes.
- Cross-link the live contracts repository and its verified ADR index on `master`.

## Testing

- [x] `git diff --check` passes
- [x] New relative Markdown link targets verified locally
- [x] Contracts repository URL and ADR index verified through GitHub metadata
- [x] Confirmed the patch changes documentation only

## Checklist

- [x] I am assigned to the related issue
- [x] My branch is up to date with `main`
- [x] I followed the commit message format
- [x] Tests are not applicable because this is documentation only
- [x] I updated the relevant documentation
- [x] I have not introduced any hardcoded secrets or keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record documenting repository structure, SDK location, ownership, and coordination.
  * Updated documentation navigation to include the architecture decision records.
  * Added the new repository topology decision to the ADR index.
  * Corrected the contract-related ADR link to point to the appropriate branch and file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->